### PR TITLE
 [quality] move lint targets to separate BUILD file and align target labels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run license-checker
-        run: bazel run //quality:licence-check
-      - name: Run gofmt
-        run: bazel run //quality:check_gofmt
-      - name: Run clang-format
-        run: bazel run //quality:check_clang_format
-      - name: Run buildifier
-        run: bazel run //quality:buildifier_check
+      - name: Run linter checks
+        run: bazel test //quality/...
 
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,13 +15,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run license-checker
-        run: bazel run //:licence-check
+        run: bazel run //quality:licence-check
       - name: Run gofmt
-        run: bazel run //:check_gofmt
+        run: bazel run //quality:check_gofmt
       - name: Run clang-format
-        run: bazel run //:check_clang_format
+        run: bazel run //quality:check_clang_format
       - name: Run buildifier
-        run: bazel run //:buildifier_check
+        run: bazel run //quality:buildifier_check
 
   test:
     runs-on: ubuntu-22.04

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,12 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_go//go:def.bzl", "nogo")
-load("@lowrisc_misc_linters//rules:rules.bzl", "licence_check")
-load("//rules:quality.bzl", "clang_format_check", "gofmt")
+
+exports_files([
+    "WORKSPACE",
+])
 
 config_setting(
     name = "windows",
@@ -20,89 +21,6 @@ nogo(
     name = "vet",
     vet = True,
     visibility = ["//visibility:public"],
-)
-
-licence_check(
-    name = "licence-check",
-    exclude_patterns = [
-        # Uncommented formats.
-        "*.md",
-        "*.json",
-        ".gitignore",
-        "**/.gitignore",
-        "src/registry_service/*.go",
-        "src/registry_upload/*.go",
-        "src/registry_buffer/*.go",
-        "src/manifest_reporting/*.go",
-        "src/registry_service/*.proto",
-        "src/registry_buffer/*.proto",
-        "src/manifest_reporting/*.proto",
-        "src/manifest_reporting/*.bazel",
-        "src/test_service/store/mysql.go",
-        "src/test_service/store/connector.go",
-        "src/test_service/ts_client.go",
-        "src/test_service/store/db.go",
-        "src/test_service/services/testservice.go",
-        "src/message_service/*.*",
-        "src/message_client/*.*",
-        ".github/CODEOWNERS",
-
-        # Copyright-related files that don"t need a header.
-        "CLA",
-        "LICENSE",
-    ],
-    licence = """
-    Copyright lowRISC contributors (OpenTitan project).
-    Licensed under the Apache License, Version 2.0, see LICENSE for details.
-    SPDX-License-Identifier: Apache-2.0
-    """,
-)
-
-gofmt(
-    name = "check_gofmt",
-    mode = "diff",
-)
-
-gofmt(
-    name = "gofmt",
-    mode = "fix",
-)
-
-clang_format_check(
-    name = "check_clang_format",
-    exclude_patterns = [
-        # Vendored source code dirs
-        "./**/third_party/**",
-    ],
-    mode = "diff",
-)
-
-clang_format_check(
-    name = "clang_format",
-    exclude_patterns = [
-        # Vendored source code dirs
-        "./**/third_party/**",
-    ],
-    mode = "fix",
-)
-
-buildifier_exclude = [
-    "./WORKSPACE",  # Prevent Buildifier from inserting unnecessary newlines.
-]
-
-buildifier(
-    name = "buildifier_fix",
-    exclude_patterns = buildifier_exclude,
-)
-
-buildifier_test(
-    name = "buildifier_check",
-    diff_command = "diff -u",
-    exclude_patterns = buildifier_exclude,
-    mode = "diff",
-    no_sandbox = True,
-    verbose = True,
-    workspace = "//:WORKSPACE",
 )
 
 # Use this rule to update Go dependencies.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,14 @@ To format the code before submitting changes:
 
 ```console
 $ bazelisk run //quality:buildifier_fix
-$ bazelisk run //quality:gofmt
-$ bazelisk run //quality:clang_format
+$ bazelisk run //quality:clang_format_fix
+$ bazelisk run //quality:gofmt_fix
+```
+
+To run all lint checks locally that are also run in CI:
+
+```console
+$ bazelisk test //quality/...
 ```
 
 ## GitHub Releases

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ $ ./run_integration_tests.sh
 To format the code before submitting changes:
 
 ```console
-$ bazelisk run //:buildifier_fix
-$ bazelisk run //:gofmt
-$ bazelisk run //:clang_format
+$ bazelisk run //quality:buildifier_fix
+$ bazelisk run //quality:gofmt
+$ bazelisk run //quality:clang_format
 ```
 
 ## GitHub Releases

--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@lowrisc_misc_linters//rules:rules.bzl", "licence_test")
 load("@bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
-load("@lowrisc_misc_linters//rules:rules.bzl", "licence_check")
-load("//rules:quality.bzl", "clang_format_check", "gofmt")
+load("//rules:quality.bzl", "clang_format_check", "clang_format_fix", "gofmt_check", "gofmt_fix")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,11 +14,6 @@ package(default_visibility = ["//visibility:public"])
 buildifier_exclude = [
     "./WORKSPACE",  # Prevent Buildifier from inserting unnecessary newlines.
 ]
-
-buildifier(
-    name = "buildifier_fix",
-    exclude_patterns = buildifier_exclude,
-)
 
 buildifier_test(
     name = "buildifier_check",
@@ -30,66 +25,56 @@ buildifier_test(
     workspace = "//:WORKSPACE",
 )
 
+buildifier(
+    name = "buildifier_fix",
+    exclude_patterns = buildifier_exclude,
+)
+
 ################################################################################
 # C/C++ lint/formatting.
 ################################################################################
-clang_format_check(
-    name = "check_clang_format",
-    exclude_patterns = [
-        # Vendored source code dirs
-        "./**/third_party/**",
-    ],
-    mode = "diff",
-)
+clang_format_exclude = [
+    # Vendored source code dirs
+    "./**/vendor/**",
+]
 
 clang_format_check(
-    name = "clang_format",
-    exclude_patterns = [
-        # Vendored source code dirs
-        "./**/third_party/**",
-    ],
+    name = "clang_format_check",
+    exclude_patterns = clang_format_exclude,
+    mode = "diff",
+    workspace = "//:WORKSPACE",
+)
+
+clang_format_fix(
+    name = "clang_format_fix",
+    exclude_patterns = clang_format_exclude,
     mode = "fix",
 )
 
 ################################################################################
 # Go lint/format.
 ################################################################################
-gofmt(
-    name = "check_gofmt",
+gofmt_check(
+    name = "gofmt_check",
     mode = "diff",
 )
 
-gofmt(
-    name = "gofmt",
+gofmt_fix(
+    name = "gofmt_fix",
     mode = "fix",
 )
 
 ################################################################################
 # License header check.
 ################################################################################
-licence_check(
-    name = "licence-check",
+licence_test(
+    name = "license_check",
     exclude_patterns = [
         # Uncommented formats.
         "*.md",
         "*.json",
         ".gitignore",
         "**/.gitignore",
-        "src/registry_service/*.go",
-        "src/registry_upload/*.go",
-        "src/registry_buffer/*.go",
-        "src/manifest_reporting/*.go",
-        "src/registry_service/*.proto",
-        "src/registry_buffer/*.proto",
-        "src/manifest_reporting/*.proto",
-        "src/manifest_reporting/*.bazel",
-        "src/test_service/store/mysql.go",
-        "src/test_service/store/connector.go",
-        "src/test_service/ts_client.go",
-        "src/test_service/store/db.go",
-        "src/test_service/services/testservice.go",
-        "src/message_service/*.*",
-        "src/message_client/*.*",
         ".github/CODEOWNERS",
 
         # Copyright-related files that don"t need a header.
@@ -101,4 +86,5 @@ licence_check(
     Licensed under the Apache License, Version 2.0, see LICENSE for details.
     SPDX-License-Identifier: Apache-2.0
     """,
+    workspace = "//:WORKSPACE",
 )

--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -1,0 +1,104 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
+load("@lowrisc_misc_linters//rules:rules.bzl", "licence_check")
+load("//rules:quality.bzl", "clang_format_check", "gofmt")
+
+package(default_visibility = ["//visibility:public"])
+
+################################################################################
+# Bazel BUILD file lint/formatting
+################################################################################
+buildifier_exclude = [
+    "./WORKSPACE",  # Prevent Buildifier from inserting unnecessary newlines.
+]
+
+buildifier(
+    name = "buildifier_fix",
+    exclude_patterns = buildifier_exclude,
+)
+
+buildifier_test(
+    name = "buildifier_check",
+    diff_command = "diff -u",
+    exclude_patterns = buildifier_exclude,
+    mode = "diff",
+    no_sandbox = True,
+    verbose = True,
+    workspace = "//:WORKSPACE",
+)
+
+################################################################################
+# C/C++ lint/formatting.
+################################################################################
+clang_format_check(
+    name = "check_clang_format",
+    exclude_patterns = [
+        # Vendored source code dirs
+        "./**/third_party/**",
+    ],
+    mode = "diff",
+)
+
+clang_format_check(
+    name = "clang_format",
+    exclude_patterns = [
+        # Vendored source code dirs
+        "./**/third_party/**",
+    ],
+    mode = "fix",
+)
+
+################################################################################
+# Go lint/format.
+################################################################################
+gofmt(
+    name = "check_gofmt",
+    mode = "diff",
+)
+
+gofmt(
+    name = "gofmt",
+    mode = "fix",
+)
+
+################################################################################
+# License header check.
+################################################################################
+licence_check(
+    name = "licence-check",
+    exclude_patterns = [
+        # Uncommented formats.
+        "*.md",
+        "*.json",
+        ".gitignore",
+        "**/.gitignore",
+        "src/registry_service/*.go",
+        "src/registry_upload/*.go",
+        "src/registry_buffer/*.go",
+        "src/manifest_reporting/*.go",
+        "src/registry_service/*.proto",
+        "src/registry_buffer/*.proto",
+        "src/manifest_reporting/*.proto",
+        "src/manifest_reporting/*.bazel",
+        "src/test_service/store/mysql.go",
+        "src/test_service/store/connector.go",
+        "src/test_service/ts_client.go",
+        "src/test_service/store/db.go",
+        "src/test_service/services/testservice.go",
+        "src/message_service/*.*",
+        "src/message_client/*.*",
+        ".github/CODEOWNERS",
+
+        # Copyright-related files that don"t need a header.
+        "CLA",
+        "LICENSE",
+    ],
+    licence = """
+    Copyright lowRISC contributors (OpenTitan project).
+    Licensed under the Apache License, Version 2.0, see LICENSE for details.
+    SPDX-License-Identifier: Apache-2.0
+    """,
+)

--- a/rules/quality.bzl
+++ b/rules/quality.bzl
@@ -6,6 +6,12 @@
 
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
+def _ensure_tag(tags, *tag):
+    for t in tag:
+        if t not in tags:
+            tags.append(t)
+    return tags
+
 def _gofmt_impl(ctx):
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     exclude_patterns = ["\\! -path {}".format(shell.quote(p)) for p in ctx.attr.exclude_patterns]
@@ -30,50 +36,67 @@ def _gofmt_impl(ctx):
         executable = out_file,
     )
 
-gofmt = rule(
+gofmt_attrs = {
+    "patterns": attr.string_list(
+        default = ["*.go"],
+        doc = "Filename patterns for format checking",
+    ),
+    "exclude_patterns": attr.string_list(
+        doc = "Filename patterns to exlucde from format checking",
+    ),
+    "mode": attr.string(
+        default = "diff",
+        values = ["diff", "fix"],
+        doc = "Execution mode: display diffs or fix formatting",
+    ),
+    "diff_command": attr.string(
+        default = "diff -u",
+        doc = "Command to execute to display diffs",
+    ),
+    "gofmt": attr.label(
+        default = "@go_sdk//:bin/gofmt",
+        allow_single_file = True,
+        cfg = "host",
+        executable = True,
+        doc = "The gofmt executable",
+    ),
+    "_runner": attr.label(
+        default = "//rules/scripts:gofmt.template.sh",
+        allow_single_file = True,
+    ),
+}
+
+gofmt_fix = rule(
     implementation = _gofmt_impl,
-    attrs = {
-        "patterns": attr.string_list(
-            default = ["*.go"],
-            doc = "Filename patterns for format checking",
-        ),
-        "exclude_patterns": attr.string_list(
-            doc = "Filename patterns to exlucde from format checking",
-        ),
-        "mode": attr.string(
-            default = "diff",
-            values = ["diff", "fix"],
-            doc = "Execution mode: display diffs or fix formatting",
-        ),
-        "diff_command": attr.string(
-            default = "diff -u",
-            doc = "Command to execute to display diffs",
-        ),
-        "gofmt": attr.label(
-            default = "@go_sdk//:bin/gofmt",
-            allow_single_file = True,
-            cfg = "host",
-            executable = True,
-            doc = "The gofmt executable",
-        ),
-        "_runner": attr.label(
-            default = "//rules/scripts:gofmt.template.sh",
-            allow_single_file = True,
-        ),
-    },
+    attrs = gofmt_attrs,
     executable = True,
 )
+
+_gofmt_test = rule(
+    implementation = _gofmt_impl,
+    attrs = gofmt_attrs,
+    test = True,
+)
+
+def gofmt_check(**kwargs):
+    tags = kwargs.get("tags", [])
+
+    # Note: the "external" tag is a workaround for bazelbuild#15516.
+    kwargs["tags"] = _ensure_tag(tags, "no-sandbox", "no-cache", "external")
+    _gofmt_test(**kwargs)
 
 def _clang_format_impl(ctx):
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     exclude_patterns = ["\\! -path {}".format(shell.quote(p)) for p in ctx.attr.exclude_patterns]
     include_patterns = ["-name {}".format(shell.quote(p)) for p in ctx.attr.patterns]
+    workspace = ctx.file.workspace.path if ctx.file.workspace else ""
     substitutions = {
         "@@EXCLUDE_PATTERNS@@": " ".join(exclude_patterns),
         "@@INCLUDE_PATTERNS@@": " -o ".join(include_patterns),
         "@@CLANG_FORMAT@@": shell.quote(ctx.attr.clang_format_command),
         "@@DIFF_COMMAND@@": shell.quote(ctx.attr.diff_command),
         "@@MODE@@": shell.quote(ctx.attr.mode),
+        "@@WORKSPACE@@": workspace,
     }
     ctx.actions.expand_template(
         template = ctx.file._runner,
@@ -87,33 +110,52 @@ def _clang_format_impl(ctx):
         executable = out_file,
     )
 
-clang_format_check = rule(
+clang_format_attrs = {
+    "patterns": attr.string_list(
+        default = ["*.c", "*.h", "*.cc", "*.cpp"],
+        doc = "Filename patterns for format checking",
+    ),
+    "exclude_patterns": attr.string_list(
+        doc = "Filename patterns to exclude from format checking",
+    ),
+    "mode": attr.string(
+        default = "diff",
+        values = ["diff", "fix"],
+        doc = "Execution mode: display diffs or fix formatting",
+    ),
+    "diff_command": attr.string(
+        default = "diff -u",
+        doc = "Command to execute to display diffs",
+    ),
+    "clang_format_command": attr.string(
+        default = "clang-format",
+        doc = "The clang-format executable",
+    ),
+    "workspace": attr.label(
+        allow_single_file = True,
+        doc = "Label of the WORKSPACE file",
+    ),
+    "_runner": attr.label(
+        default = "//rules/scripts:clang_format.template.sh",
+        allow_single_file = True,
+    ),
+}
+
+clang_format_fix = rule(
     implementation = _clang_format_impl,
-    attrs = {
-        "patterns": attr.string_list(
-            default = ["*.c", "*.h", "*.cc", "*.cpp"],
-            doc = "Filename patterns for format checking",
-        ),
-        "exclude_patterns": attr.string_list(
-            doc = "Filename patterns to exlucde from format checking",
-        ),
-        "mode": attr.string(
-            default = "diff",
-            values = ["diff", "fix"],
-            doc = "Execution mode: display diffs or fix formatting",
-        ),
-        "diff_command": attr.string(
-            default = "diff -u",
-            doc = "Command to execute to display diffs",
-        ),
-        "clang_format_command": attr.string(
-            default = "clang-format",
-            doc = "The clang-format executable",
-        ),
-        "_runner": attr.label(
-            default = "//rules/scripts:clang_format.template.sh",
-            allow_single_file = True,
-        ),
-    },
+    attrs = clang_format_attrs,
     executable = True,
 )
+
+_clang_format_test = rule(
+    implementation = _clang_format_impl,
+    attrs = clang_format_attrs,
+    test = True,
+)
+
+def clang_format_check(**kwargs):
+    tags = kwargs.get("tags", [])
+
+    # Note: the "external" tag is a workaround for bazelbuild#15516.
+    kwargs["tags"] = _ensure_tag(tags, "no-sandbox", "no-cache", "external")
+    _clang_format_test(**kwargs)


### PR DESCRIPTION
This PR:
 - Reorganizes the lint rules and puts them in a separate BUILD file to consolidate similar targets and not pollute the top-level BUILD file.
 - Sligns the linter/formatter Bazel target labels to match the convention <tool>_{check,fix} as is used in the main opentitan repository.

This partially addresses #9.