### PR TITLE
[pa] add RPC stubs for endorsing certs and generating LC/WAS tokens

### DIFF
--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -20,9 +20,28 @@ service ProvisioningApplianceService {
   rpc CloseSession(CloseSessionRequest)
     returns (CloseSessionResponse) {}
   rpc CreateKeyAndCert(CreateKeyAndCertRequest)
-      returns (CreateKeyAndCertResponse) {}
+    returns (CreateKeyAndCertResponse) {}
+  rpc EndorseCerts(EndorseCertsRequest)
+    returns (EndorseCertsResponse) {}
   rpc SendDeviceRegistrationPayload(RegistrationRequest)
-      returns (RegistrationResponse) {}
+    returns (RegistrationResponse) {}
+}
+
+// Endorse certs request.
+message EndorseCertsRequest {
+  // SKU identifier. Required.
+  string sku = 1;
+  // (Per SKU) Serial number of CA that should endorse these certificates.
+  // Required. Size enforced by SKU implementation.
+  bytes ca_serial_number = 2;
+  // Array of TBS certificates to be endorsed.
+  repeated crypto.cert.Certificate certs = 3;
+}
+
+// Endorse certs response.
+message EndorseCertsResponse {
+  // Array of complete (endorsed) certificates to be installed in a device.
+  repeated crypto.cert.Certificate certs = 1;
 }
 
 // Create key and endorsement certificates request.

--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -23,6 +23,8 @@ service ProvisioningApplianceService {
     returns (CreateKeyAndCertResponse) {}
   rpc EndorseCerts(EndorseCertsRequest)
     returns (EndorseCertsResponse) {}
+  rpc DeriveSymmetricKey(DeriveSymmetricKeyRequest)
+    returns (DeriveSymmetricKeyResponse) {}
   rpc SendDeviceRegistrationPayload(RegistrationRequest)
     returns (RegistrationResponse) {}
 }
@@ -42,6 +44,65 @@ message EndorseCertsRequest {
 message EndorseCertsResponse {
   // Array of complete (endorsed) certificates to be installed in a device.
   repeated crypto.cert.Certificate certs = 1;
+}
+
+// Symmetric key seed type (seed is provisioned into HSM).
+enum SymmetricKeySeed {
+  // Unspecified.
+  SYMMETRIC_KEY_SEED_UNSPECIFIED = 0;
+  // Low Security: seed is rotated infrequently.
+  SYMMETRIC_KEY_SEED_LOW_SECURITY = 1;
+  // High Security: seed is rotated frequently.
+  SYMMETRIC_KEY_SEED_HIGH_SECURITY = 2;
+}
+
+// Symmetric key type.
+enum SymmetricKeyType {
+  // Unspecified.
+  SYMMETRIC_KEY_TYPE_UNSPECIFIED = 0;
+  // Raw.
+  //
+  // This format is used when the raw plaintext key must be generated.
+  SYMMETRIC_KEY_TYPE_RAW = 1;
+  // Hashed.
+  //
+  // This format is used when the cSHAKE128 hashed (with "LC_CTRL" customization
+  // string) form of the key needs to be generated. This type supports
+  // provisioning of OpenTitan lifecycle tokens, which are programmed into a
+  // device's OTP memory in this form.
+  //
+  // protolint:disable:next MAX_LINE_LENGTH
+  // See https://opentitan.org/book/hw/ip/lc_ctrl/doc/theory_of_operation.html#token-hashing-mechanism
+  // for more details.
+  SYMMETRIC_KEY_TYPE_HASHED_OT_LC_TOKEN = 2;
+}
+
+// Symmetric key size.
+enum SymmetricKeySize {
+  // Unspecified.
+  SYMMETRIC_KEY_SIZE_UNSPECIFIED = 0;
+  // 128 bits.
+  SYMMETRIC_KEY_SIZE_128_BITS = 1;
+  // 256 bits.
+  SYMMETRIC_KEY_SIZE_256_BITS = 2;
+}
+
+// Derive symmetric key request.
+message DeriveSymmetricKeyRequest{
+  // Symmetric key seed to use. Required.
+  SymmetricKeySeed seed = 1;
+  // Symmetric key type to generate. Required.
+  SymmetricKeyType type = 2;
+  // Symmetric key size. Required.
+  SymmetricKeySize size = 3;
+  // Diversifier string to use in KDF operation. Required.
+  string diversifier = 4;
+}
+
+// Derive symmetric key response.
+message DeriveSymmetricKeyResponse{
+  // Key bytes. Size is provided in the request.
+  bytes key = 1;
 }
 
 // Create key and endorsement certificates request.

--- a/src/pa/services/pa.go
+++ b/src/pa/services/pa.go
@@ -108,6 +108,15 @@ func (s *server) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequ
 	return nil, nil
 }
 
+// DeriveSymmetricKey generates a symmetric key from a seed (pre-provisioned in
+// the SPM/HSM) and diversifier string.
+func (s *server) DeriveSymmetricKey(ctx context.Context, request *pbp.DeriveSymmetricKeyRequest) (*pbp.DeriveSymmetricKeyResponse, error) {
+	log.Printf("In PA - Recieved DeriveSymmetricKey request with diversifier string: %s", request.Diversifier)
+
+	// TODO(#4) implement backend operations.
+	return nil, nil
+}
+
 // SendDeviceRegistrationPayload registers a new device record to the local MySql DB.
 func (s *server) SendDeviceRegistrationPayload(ctx context.Context, request *pbp.RegistrationRequest) (*pbp.RegistrationResponse, error) {
 	log.Printf("In PA - Received SendDeviceRegistrationPayload request with DeviceID: %v", request.DeviceRecord.Id)

--- a/src/pa/services/pa.go
+++ b/src/pa/services/pa.go
@@ -100,6 +100,14 @@ func (s *server) CreateKeyAndCert(ctx context.Context, request *pbp.CreateKeyAnd
 	return r, nil
 }
 
+// EndorseCerts endorses a set of TBS certificates and returns them.
+func (s *server) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequest) (*pbp.EndorseCertsResponse, error) {
+	log.Printf("In PA - Recieved EndorseCerts request with Sku=%s", request.Sku)
+
+	// TODO(#4) implement backend operations.
+	return nil, nil
+}
+
 // SendDeviceRegistrationPayload registers a new device record to the local MySql DB.
 func (s *server) SendDeviceRegistrationPayload(ctx context.Context, request *pbp.RegistrationRequest) (*pbp.RegistrationResponse, error) {
 	log.Printf("In PA - Received SendDeviceRegistrationPayload request with DeviceID: %v", request.DeviceRecord.Id)

--- a/src/proto/crypto/cert.proto
+++ b/src/proto/crypto/cert.proto
@@ -27,7 +27,8 @@ message CertParams {
 
 // A Certificate.
 message Certificate {
-  // Opaque bytes.
+  // Opaque bytes that may be used to represent a complete certificate, or only
+  // the TBS (To Be Signed) portion.
   //
   // Protobuf knows nothing about internal structure of this blob;
   // that's handled at a higher level, not by protobuf.


### PR DESCRIPTION
This partially addresses #4 by adding RPC function stubs for:
1. endorsing cert payloads from OT devices (during personalization),
2. generating LC tokens (in raw and hashed forms), and
3. generating wafer authentication secrets.
