### PR TITLE
[spmutil] add KDF seed loading subcommands

### DIFF
--- a/docs/spm.md
+++ b/docs/spm.md
@@ -101,7 +101,13 @@ $ bazelisk run //src/spm:spmutil -- \
     --hsm_so=${OPENTITAN_VAR_DIR}/softhsm2/libsofthsm2.so \
     --hsm_type=0 \
     --hsm_slot=0 \
-    --force_keygen --gen_kg --gen_kca \
+    --force_keygen \
+    --gen_kg \
+    --gen_kca \
+    --load_low_sec_ks \
+    --low_sec_ks="0x23df79a8052010ef6e3d49255b606f871cff06170247c1145ebb71ad23834061" \
+    --load_high_sec_ks \
+    --high_sec_ks="0xaba9d5616e5a7c18b9a41d8a22f42d4dc3bafa9ca1fad01e404e708b1eab21fd" \
     --ca_outfile=${OPENTITAN_VAR_DIR}/spm/config/certs/NuvotonTPMRootCA0200.cer
 ```
 
@@ -114,7 +120,13 @@ $ bazelisk run //src/spm:spmutil -- \
     --hsm_so=/usr/safenet/lunaclient/lib/libCryptoki2_64.so \
     --hsm_type=1 \
     --hsm_slot=0 \
-    --force_keygen --gen_kg --gen_kca \
+    --force_keygen \
+    --gen_kg \
+    --gen_kca \
+    --load_low_sec_ks \
+    --low_sec_ks="0x23df79a8052010ef6e3d49255b606f871cff06170247c1145ebb71ad23834061" \
+    --load_high_sec_ks \
+    --high_sec_ks="0xaba9d5616e5a7c18b9a41d8a22f42d4dc3bafa9ca1fad01e404e708b1eab21fd" \
     --ca_outfile=${OPENTITAN_VAR_DIR}/spm/config/certs/NuvotonTPMRootCA0200.cer
 ```
 

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -32,7 +32,13 @@ bazelisk run //src/spm:spmutil -- \
     --hsm_so=${OPENTITAN_VAR_DIR}/softhsm2/libsofthsm2.so \
     --hsm_type=0 \
     --hsm_slot=0 \
-    --force_keygen --gen_kg --gen_kca \
+    --force_keygen \
+    --gen_kg \
+    --gen_kca \
+    --load_low_sec_ks \
+    --low_sec_ks="0x23df79a8052010ef6e3d49255b606f871cff06170247c1145ebb71ad23834061" \
+    --load_high_sec_ks \
+    --high_sec_ks="0xaba9d5616e5a7c18b9a41d8a22f42d4dc3bafa9ca1fad01e404e708b1eab21fd" \
     --ca_outfile=${OPENTITAN_VAR_DIR}/spm/config/certs/NuvotonTPMRootCA0200.cer
 
 bazelisk run //src/pa:loadtest -- \

--- a/src/pk11/kdf.go
+++ b/src/pk11/kdf.go
@@ -222,6 +222,7 @@ func (s *Session) ImportKeyMaterial(key []byte, opts *KeyOptions) (SecretKey, er
 		pkcs11.NewAttribute(pkcs11.CKA_DERIVE, true),
 		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, !opts.Extractable),
 		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, opts.Extractable),
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, opts.Token),
 	}
 	s.tok.m.appendAttrKeyID(&tpl)
 


### PR DESCRIPTION
This adds KDF seed loading subcommands to support the KDF operations that will be used to generate OpenTitan Earlgrey LC tokens and Wafer Auth Secrets during provisioning.

This partially addresses #4.
This fixes #20.