### PR TITLE
[tests,pa,spm] add/fix configurations to enable running integration tests

### DIFF
--- a/config/dev/spm/sku_auth.yml
+++ b/config/dev/spm/sku_auth.yml
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+skuAuthCfgList:
+  "tpm_1":
+    # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
+    skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
+    methods: ["password"]

--- a/config/dev/spm/sku_tpm_1.yml
+++ b/config/dev/spm/sku_tpm_1.yml
@@ -28,4 +28,3 @@ keyWrapConfig:
       name: 1
       hash: 2
 rootCAPath: certs/NuvotonTPMRootCA0200.cer
-

--- a/src/pa/loadtest.go
+++ b/src/pa/loadtest.go
@@ -29,7 +29,7 @@ const (
 	testSKUName = "tpm_1"
 
 	// testSKUAuth contains the test SKU authentication string.
-	testSKUAuth = "TODO: SET_SKU_AUTH"
+	testSKUAuth = "test_password"
 )
 
 var (

--- a/src/pa/pa_server.go
+++ b/src/pa/pa_server.go
@@ -25,7 +25,7 @@ import (
 var (
 	port          = flag.Int("port", 0, "the port to bind the server on; required")
 	spmAddress    = flag.String("spm_address", "", "the SPM server address to connect to; required")
-	enableRegBuff = flag.Bool("enable_rb", true, "Enable connectivity to the RegistryBuffer server; optional")
+	enableRegBuff = flag.Bool("enable_rb", false, "Enable connectivity to the RegistryBuffer server; optional")
 	rbAddress     = flag.String("rb_address", "", "the RegistryBuffer server address to connect to; required")
 	enableTLS     = flag.Bool("enable_tls", false, "Enable mTLS secure channel; optional")
 	serviceKey    = flag.String("service_key", "", "File path to the PEM encoding of the server's private key")

--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -151,7 +151,7 @@ message InitSessionResponse {
   // PA endpoint. The client should select connections to this client to issue
   // any provisioning calls (e.g. CreateKeyAndCertRequest).
   string pa_endpoint = 2;
-  // list of authenticate methods
+  // List of authenticate methods. Required.
   repeated string auth_methods = 3;
 }
 

--- a/src/spm/BUILD.bazel
+++ b/src/spm/BUILD.bazel
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/spm/services/se.go
+++ b/src/spm/services/se.go
@@ -38,6 +38,7 @@ type SE interface {
 	// Derives the transport secret for a device with the given ID, and wraps
 	// it with the device class's global secret.
 	DeriveAndWrapTransportSecret(deviceId []byte) ([]byte, error)
+
 	// Generates and signs certificates with the given parent corresponding to the
 	// arguments in certs.
 	//

--- a/src/spm/services/spm.go
+++ b/src/spm/services/spm.go
@@ -145,6 +145,7 @@ func NewSpmServer(opts Options) (pbs.SpmServiceServer, error) {
 		return nil, fmt.Errorf("config directory does not exist: %q, error: %v", opts.SPMConfigDir, err)
 	}
 
+	// TODO: make this runtime configurable
 	filename := "sku_auth.yml"
 	var config AuthConfig
 	err := utils.LoadConfig(opts.SPMConfigDir, filename, &config)
@@ -171,7 +172,6 @@ func NewSpmServer(opts Options) (pbs.SpmServiceServer, error) {
 func (s *server) initSku(sku string) (string, error) {
 	token, err := generateSessionToken(TokenSize)
 	if err != nil {
-
 		log.Printf("failed to generate session token: %v", err)
 		return "", status.Errorf(codes.NotFound, "failed to generate session token: %v", err)
 	}
@@ -188,7 +188,7 @@ func (s *server) initSku(sku string) (string, error) {
 }
 
 // findSkuAuth returns an empty sku auth config, if nor sku or a family sku can be found
-// in the map config, otherwize the relavent sku auth config will be return.
+// in the map config, otherwise the relavent sku auth config will be return.
 func (s *server) findSkuAuth(sku string) (SkuAuthConfig, bool) {
 	skuAuthConfig := SkuAuthConfig{}
 	if skuAuthConfig, found := s.authCfg.SkuAuthCfgList[sku]; found {


### PR DESCRIPTION
The `./run_integration_tests.sh` script was failing for many reasons, and this fixes two issues:
1. adding a reference SKU authorization YAML config file with a test authorization password to revive the `pa/loadtest.go` program, and
2. default to disabling the registry buffer until #24 can be addressed.

This partially addresses #17.