### PR TITLE
[pa,auth,loadtest] fix PA token authentication mechanism and loadtest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,15 @@ jobs:
         # Skip running lint tests as those are run in a previous stage.
         run: bazel test --test_tag_filters=-lint //...
 
+  # Run integration tests.
+  integration_tests:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run PA loadtest (in containers)
+        run: ./run_integration_tests.sh -c
+
   # Test airgapped build.
   airgapped_build_test:
     runs-on: ubuntu-22.04

--- a/config/dev/spm/sku_auth.yml
+++ b/config/dev/spm/sku_auth.yml
@@ -6,4 +6,4 @@ skuAuthCfgList:
   "tpm_1":
     # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
     skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
-    methods: ["password"]
+    methods: ["CreateKeyAndCert"]

--- a/src/pa/BUILD.bazel
+++ b/src/pa/BUILD.bazel
@@ -44,6 +44,7 @@ go_binary(
         "//src/spm/proto:spm_go_pb",
         "//src/transport:grpconn",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//metadata",
         "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )

--- a/src/pa/services/BUILD.bazel
+++ b/src/pa/services/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//src/utils",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//encoding/protojson",
     ],

--- a/src/transport/auth_service/auth_service.go
+++ b/src/transport/auth_service/auth_service.go
@@ -46,11 +46,8 @@ func (ctrl *AuthController) RemoveUser(userID string) (*User, error) {
 }
 
 func (ctrl *AuthController) AddUser(userID, token, sku string, authMethods []string) (*User, error) {
-	log.Printf("In auth_service AddUser: recieved user ID =%s", userID)
-
 	user, err := ctrl.FindUser(userID)
 	if err == nil {
-		//User already exist
 		fmt.Println("Debug: AddUser: user already exist: ", user)
 		user, err = ctrl.RemoveUser(userID)
 	}


### PR DESCRIPTION
This updates the PA and auth_controller to accept a userID from the client instead of always defaulting to using the client IP address as the user ID. This way we can test several sessions eminating from the same host.

Additionally, this updates the loadtest to:
1. send a userID to the PA upon session initialization and closing, and
2. save session auth tokens received from the PA during InitiSession calls, and forward them back to the server on calls to CreateKeyAndCert, to authorize invoking these RPCs.

With these changes, we can now execute the PA loadtest successfully. Therefore, the last commit in this PR also adds the integration tests (i.e., PA loadtest) to the presubmit CI configuration. 