### PR TITLE
[util] add script to deploy containers for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run PA loadtest (in containers)
-        run: ./run_integration_tests.sh -c
+        run: ./run_integration_tests.sh
 
   # Test airgapped build.
   airgapped_build_test:

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -5,17 +5,9 @@
 
 set -e
 
-readonly REPO_TOP=$(git rev-parse --show-toplevel)
-
 # Parse command line options.
 for i in "$@"; do
   case $i in
-  # -c option: Only build/deploy container images, not raw binaries.
-  # Saves time when running this script if not permanently deploying infra.
-  -c | --containers-only)
-    export CONTAINERS_ONLY="yes"
-    shift
-    ;;
   # -d option: Activate debug mode, which will not tear down containers if
   # there is a failure so the failure can be inspected.
   -d | --debug)
@@ -29,17 +21,6 @@ for i in "$@"; do
   esac
 done
 
-# Build release binaries.
-# TODO: Build inside util/containers/build container to be able to consistently
-# reproduce the runtime environment for targets that leak outside the Bazel
-# sandbox (e.g. "@softhsm2//:softhsm2").
-if [ -z "${CONTAINERS_ONLY}" ]; then
-  bazelisk build --stamp //release:provisioning_appliance_binaries
-else
-  bazelisk build --stamp //release:provisioning_appliance_containers_tar
-fi
-bazelisk build --stamp //release:softhsm_dev
-
 # Register trap to shutdown containers before exit.
 # Teardown containers. This currently does not remove the container volumes.
 shutdown_containers() {
@@ -50,24 +31,8 @@ if [ -z "${DEBUG}" ]; then
   trap shutdown_containers EXIT
 fi
 
-# Deploy the provisioning appliance binaries and services.
-. ${REPO_TOP}/config/dev/env/spm.env
-${REPO_TOP}/config/dev/deploy.sh ${REPO_TOP}/bazel-bin/release
-
-# Initialize and configure the HSM.
-bazelisk run //src/spm:spmutil -- \
-  --hsm_pw="${SPM_HSM_PIN_USER}" \
-  --hsm_so="${OPENTITAN_VAR_DIR}/softhsm2/libsofthsm2.so" \
-  --hsm_type=0 \
-  --hsm_slot=0 \
-  --force_keygen \
-  --gen_kg \
-  --gen_kca \
-  --load_low_sec_ks \
-  --low_sec_ks="0x23df79a8052010ef6e3d49255b606f871cff06170247c1145ebb71ad23834061" \
-  --load_high_sec_ks \
-  --high_sec_ks="0xaba9d5616e5a7c18b9a41d8a22f42d4dc3bafa9ca1fad01e404e708b1eab21fd" \
-  --ca_outfile="${OPENTITAN_VAR_DIR}/spm/config/certs/NuvotonTPMRootCA0200.cer"
+# Build and deploy containers.
+./util/containers/deploy_test_k8_pod.sh
 
 # Run the loadtest on each SKU.
 SKUS=("tpm_1" "sival")

--- a/util/containers/deploy_test_k8_pod.sh
+++ b/util/containers/deploy_test_k8_pod.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+readonly REPO_TOP=$(git rev-parse --show-toplevel)
+
+# Build release containers.
+bazelisk build --stamp //release:provisioning_appliance_containers_tar
+bazelisk build --stamp //release:softhsm_dev
+
+# Deploy the provisioning appliance services.
+export CONTAINERS_ONLY="yes"
+. ${REPO_TOP}/config/dev/env/spm.env
+${REPO_TOP}/config/dev/deploy.sh ${REPO_TOP}/bazel-bin/release
+
+# Initialize and configure the HSM.
+bazelisk run //src/spm:spmutil -- \
+  --hsm_pw="${SPM_HSM_PIN_USER}" \
+  --hsm_so="${OPENTITAN_VAR_DIR}/softhsm2/libsofthsm2.so" \
+  --hsm_type=0 \
+  --hsm_slot=0 \
+  --force_keygen \
+  --gen_kg \
+  --gen_kca \
+  --load_low_sec_ks \
+  --low_sec_ks="0x23df79a8052010ef6e3d49255b606f871cff06170247c1145ebb71ad23834061" \
+  --load_high_sec_ks \
+  --high_sec_ks="0xaba9d5616e5a7c18b9a41d8a22f42d4dc3bafa9ca1fad01e404e708b1eab21fd" \
+  --ca_outfile="${OPENTITAN_VAR_DIR}/spm/config/certs/NuvotonTPMRootCA0200.cer"
+
+echo "Provisioning services launched."
+echo "Run the following to teardown:"
+echo "  podman pod stop provapp && podman pod rm provapp"


### PR DESCRIPTION
This adds a script that builds, deploys, and initializes the PA / SPM containers locally for testing. Additionally, we update the `run_integration_tests.sh` script to reuse the same code as the new deployment script.