### PR TITLE
[bazel] define `http_archive_or_local` macro and use it

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,8 +68,8 @@ load("//third_party/bazel:deps.bzl", "bazel_deps")
 bazel_deps()
 
 # SoftHSM2.
-load("//third_party/softhsm2:deps.bzl", "softhsm2_deps")
-softhsm2_deps()
+load("//third_party/softhsm2:repos.bzl", "softhsm2_repos")
+softhsm2_repos()
 
 # Docker rules.
 load("//third_party/docker:repos.bzl", "docker_repos")

--- a/rules/repo.bzl
+++ b/rules/repo.bzl
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def http_archive_or_local(local = None, **kwargs):
+    if not local:
+        http_archive(**kwargs)
+    elif ("build_file" in kwargs or
+          "build_file_content" in kwargs or
+          "workspace_file" in kwargs or
+          "workspace_file_content" in kwargs):
+        native.new_local_repository(
+            name = kwargs.get("name"),
+            path = local,
+            build_file = kwargs.get("build_file"),
+            build_file_content = kwargs.get("build_file_content"),
+            workspace_file = kwargs.get("workspace_file"),
+            workspace_file_content = kwargs.get("workspace_file_content"),
+        )
+    else:
+        native.local_repository(
+            name = kwargs.get("name"),
+            path = local,
+        )

--- a/third_party/bazel/repos.bzl
+++ b/third_party/bazel/repos.bzl
@@ -3,20 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@//rules:repo.bzl", "http_archive_or_local")
 
-def bazel_repos():
+def bazel_repos(rules_foreign_cc = None, rules_pkg = None):
     maybe(
-        http_archive,
+        http_archive_or_local,
         name = "rules_foreign_cc",
+        local = rules_foreign_cc,
         sha256 = "6041f1374ff32ba711564374ad8e007aef77f71561a7ce784123b9b4b88614fc",
         strip_prefix = "rules_foreign_cc-0.8.0",
         url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.8.0.tar.gz",
     )
 
     maybe(
-        http_archive,
+        http_archive_or_local,
         name = "rules_pkg",
+        local = rules_pkg,
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
             "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",

--- a/third_party/crt/repos.bzl
+++ b/third_party/crt/repos.bzl
@@ -3,19 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@//rules:repo.bzl", "http_archive_or_local")
 
 def crt_repos(local = None):
-    if local:
-        native.local_repository(
-            name = "crt",
-            path = local,
-        )
-    else:
-        maybe(
-            http_archive,
-            name = "crt",
-            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.3.9.tar.gz",
-            sha256 = "3f6e8e103595d2a6affbac5e2d9c14d1876f82fc6c8aca2a7528c97098a2f7ff",
-            strip_prefix = "crt-0.3.9",
-        )
+    maybe(
+        http_archive_or_local,
+        local = local,
+        name = "crt",
+        url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.3.9.tar.gz",
+        sha256 = "3f6e8e103595d2a6affbac5e2d9c14d1876f82fc6c8aca2a7528c97098a2f7ff",
+        strip_prefix = "crt-0.3.9",
+    )

--- a/third_party/docker/repos.bzl
+++ b/third_party/docker/repos.bzl
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@//rules:repo.bzl", "http_archive_or_local")
 
-def docker_repos():
-    http_archive(
+def docker_repos(local = None):
+    http_archive_or_local(
         name = "io_bazel_rules_docker",
+        local = local,
         sha256 = "59536e6ae64359b716ba9c46c39183403b01eabfbd57578e84398b4829ca499a",
         strip_prefix = "rules_docker-0.22.0",
         urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.22.0/rules_docker-v0.22.0.tar.gz"],

--- a/third_party/go/repos.bzl
+++ b/third_party/go/repos.bzl
@@ -2,15 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@//rules:repo.bzl", "http_archive_or_local")
 
 _RULES_GO_VERSION = "0.34.0"
 _GAZELLE_VERSION = "0.24.0"
 
-def go_repos():
+def go_repos(rules_go = None, gazelle = None):
     # Go toolchain
-    http_archive(
+    http_archive_or_local(
         name = "io_bazel_rules_go",
+        local = rules_go,
         sha256 = "16e9fca53ed6bd4ff4ad76facc9b7b651a89db1689a2877d6fd7b82aa824e366",
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v{}/rules_go-v{}.zip".format(_RULES_GO_VERSION, _RULES_GO_VERSION),
@@ -19,8 +20,9 @@ def go_repos():
     )
 
     # Gazelle go version management
-    http_archive(
+    http_archive_or_local(
         name = "bazel_gazelle",
+        local = gazelle,
         sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
         url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/v{}/bazel-gazelle-v{}.tar.gz".format(_GAZELLE_VERSION, _GAZELLE_VERSION),
     )

--- a/third_party/google/repos.bzl
+++ b/third_party/google/repos.bzl
@@ -2,11 +2,17 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@//rules:repo.bzl", "http_archive_or_local")
 
-def google_repos():
-    http_archive(
+def google_repos(
+        boringssl = None,
+        re2 = None,
+        googletest = None,
+        pbuf_matchers = None,
+        absl = None):
+    http_archive_or_local(
         name = "boringssl",
+        local = boringssl,
         # Use github mirror instead of https://boringssl.googlesource.com/boringssl
         # to obtain a boringssl archive with consistent sha256
         sha256 = "534fa658bd845fd974b50b10f444d392dfd0d93768c4a51b61263fd37d851c40",
@@ -18,24 +24,27 @@ def google_repos():
         patches = [Label("//third_party/google:boringssl-windows-constraints.patch")],
         patch_args = ["-p1"],
     )
-    http_archive(
+    http_archive_or_local(
         name = "com_googlesource_code_re2",
+        local = re2,
         urls = ["https://github.com/google/re2/archive/refs/tags/2022-12-01.tar.gz"],
         strip_prefix = "re2-2022-12-01",
         sha256 = "665b65b6668156db2b46dddd33405cd422bd611352c5052ab3dae6a5fbac5506",
     )
 
     # Googletest https://google.github.io/googletest/
-    http_archive(
+    http_archive_or_local(
         name = "com_google_googletest",
+        local = googletest,
         urls = ["https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz"],
         strip_prefix = "googletest-1.13.0",
         sha256 = "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363",
     )
 
     # Protobuf matchers for googletest.
-    http_archive(
+    http_archive_or_local(
         name = "com_github_protobuf_matchers",
+        local = pbuf_matchers,
         urls = ["https://github.com/inazarenko/protobuf-matchers/archive/7c8e15741bcea83db7819cc472c3e96301a95158.zip"],
         strip_prefix = "protobuf-matchers-7c8e15741bcea83db7819cc472c3e96301a95158",
         build_file_content = "package(default_visibility = [\"//visibility:public\"])",
@@ -43,8 +52,9 @@ def google_repos():
     )
 
     # Abseil https://abseil.io/
-    http_archive(
+    http_archive_or_local(
         name = "com_google_absl",
+        local = absl,
         urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.0.tar.gz"],
         strip_prefix = "abseil-cpp-20230125.0",
         sha256 = "3ea49a7d97421b88a8c48a0de16c16048e17725c7ec0f1d3ea2683a2a75adc21",

--- a/third_party/lint/repos.bzl
+++ b/third_party/lint/repos.bzl
@@ -2,18 +2,20 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@//rules:util.bzl", "deb_package")
+load("@//rules:repo.bzl", "http_archive_or_local")
 
-def lint_repos(lowrisc_lint = None):
-    http_archive(
+def lint_repos(buildtools = None, protolint = None):
+    http_archive_or_local(
         name = "bazelbuild_buildtools",
+        local = buildtools,
         sha256 = "05c3c3602d25aeda1e9dbc91d3b66e624c1f9fdadf273e5480b489e744ca7269",
         strip_prefix = "buildtools-6.4.0",
         url = "https://github.com/bazelbuild/buildtools/archive/refs/tags/v6.4.0.tar.gz",
     )
-    http_archive(
+    http_archive_or_local(
         name = "protolint",
+        local = protolint,
         sha256 = "f6073ee43c8f87d4a9a8479f5f806f3d3d06741534ae0facbe135a632c4e5988",
         build_file = Label("//third_party/lint:BUILD.protolint.bazel"),
         url = "https://github.com/yoheimuta/protolint/releases/download/v0.50.5/protolint_0.50.5_linux_amd64.tar.gz",

--- a/third_party/lowrisc/repos.bzl
+++ b/third_party/lowrisc/repos.bzl
@@ -2,19 +2,21 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@//rules:repo.bzl", "http_archive_or_local")
 
-def lowrisc_repos():
+def lowrisc_repos(misc_linters = None, bazel_release = None):
     maybe(
-        http_archive,
+        http_archive_or_local,
         name = "lowrisc_misc_linters",
+        local = misc_linters,
         sha256 = "ff4e14b2a8ace83a7f6a1536c7489c29f8c2b97d345ae9bb8b2d0f68059ec265",
         strip_prefix = "misc-linters-20240423_01",
         url = "https://github.com/lowRISC/misc-linters/archive/refs/tags/20240423_01.tar.gz",
     )
     maybe(
-        http_archive,
+        http_archive_or_local,
+        local = bazel_release,
         name = "lowrisc_bazel_release",
         sha256 = "c7b0cbdec0a1081a0b0a52eb1ebd942e7eaa218408008661fdb6e8ec3b441a4a",
         strip_prefix = "bazel-release-0.0.3",

--- a/third_party/protobuf/repos.bzl
+++ b/third_party/protobuf/repos.bzl
@@ -2,23 +2,25 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@//rules:repo.bzl", "http_archive_or_local")
 
 _PROTOBUF_VERSION = "3.20.1"
 _GRPC_VERSION = "1.52.0"
 
-def protobuf_repos():
+def protobuf_repos(protobuf = None, grpc = None):
     # Protobuf toolchain
-    http_archive(
+    http_archive_or_local(
         name = "com_google_protobuf",
+        local = protobuf,
         url = "https://github.com/protocolbuffers/protobuf/releases/download/v{}/protobuf-all-{}.tar.gz".format(_PROTOBUF_VERSION, _PROTOBUF_VERSION),
         sha256 = "3a400163728db996e8e8d21c7dfb3c239df54d0813270f086c4030addeae2fad",
         strip_prefix = "protobuf-{}".format(_PROTOBUF_VERSION),
     )
 
     #gRPC
-    http_archive(
+    http_archive_or_local(
         name = "com_github_grpc_grpc",
+        local = grpc,
         sha256 = "df9608a5bd4eb6d6b78df75908bb3390efdbbb9e07eddbee325e98cdfad6acd5",
         strip_prefix = "grpc-{}".format(_GRPC_VERSION),
         url = "https://github.com/grpc/grpc/archive/refs/tags/v{}.tar.gz".format(_GRPC_VERSION),

--- a/third_party/softhsm2/repos.bzl
+++ b/third_party/softhsm2/repos.bzl
@@ -2,13 +2,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@//rules:repo.bzl", "http_archive_or_local")
 
 SOFTHSM2_COMMIT_HASH = "4975c0df4c7090e97a3860ae21079a9597cfedc6"
 
-def softhsm2_deps():
-    http_archive(
+def softhsm2_repos(local = None):
+    http_archive_or_local(
         name = "softhsm2",
+        local = local,
         build_file = Label("//third_party/softhsm2:BUILD.softhsm2.bazel"),
         url = "https://github.com/opendnssec/SoftHSMv2/archive/{}.tar.gz".format(SOFTHSM2_COMMIT_HASH),
         strip_prefix = "SoftHSMv2-{}".format(SOFTHSM2_COMMIT_HASH),


### PR DESCRIPTION
This updates all `http_archive` rules to use a new macro, `http_archive_or_local`, which enables using a local version of the dependency instead of a remote HTTP archive. This is useful when debugging issues with dependencies.