### PR TITLE
[quality] add C/C++ header file nclude guard check

### DIFF
--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -4,7 +4,17 @@
 
 load("@lowrisc_misc_linters//rules:rules.bzl", "licence_test")
 load("@bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
-load("//rules:quality.bzl", "clang_format_check", "clang_format_fix", "gofmt_check", "gofmt_fix", "protolint_check", "protolint_fix")
+load(
+    "//rules:quality.bzl",
+    "clang_format_check",
+    "clang_format_fix",
+    "gofmt_check",
+    "gofmt_fix",
+    "include_guard_check",
+    "include_guard_fix",
+    "protolint_check",
+    "protolint_fix",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -65,6 +75,21 @@ gofmt_check(
 
 gofmt_fix(
     name = "gofmt_fix",
+    mode = "fix",
+)
+
+################################################################################
+# Include guard lint/formatting.
+################################################################################
+include_guard_check(
+    name = "include_guard_check",
+    mode = "diff",
+    tags = ["lint"],
+    workspace = "//:WORKSPACE",
+)
+
+include_guard_fix(
+    name = "include_guard_fix",
     mode = "fix",
 )
 

--- a/rules/quality.bzl
+++ b/rules/quality.bzl
@@ -209,3 +209,59 @@ def protolint_check(**kwargs):
     # Note: the "external" tag is a workaround for bazelbuild#15516.
     kwargs["tags"] = _ensure_tag(tags, "no-sandbox", "no-cache", "external")
     _protolint_test(**kwargs)
+
+################################################################################
+# include guard
+################################################################################
+include_guard_attrs = {
+    "patterns": attr.string_list(
+        default = ["*.h"],
+        doc = "Filename patterns for format checking.",
+    ),
+    "exclude_patterns": attr.string_list(
+        doc = "Filename patterns to exlucde from format checking.",
+    ),
+    "mode": attr.string(
+        default = "diff",
+        values = ["diff", "fix"],
+        doc = "Execution mode: display diffs or fix formatting.",
+    ),
+    "lint_tool": attr.label(
+        default = "//util:fix_include_guard.py",
+        allow_single_file = True,
+        cfg = "host",
+        executable = True,
+        doc = "The include_guard.py tool.",
+    ),
+    "workspace": attr.label(
+        allow_single_file = True,
+        doc = "Label of the WORKSPACE file",
+    ),
+    "_runner": attr.label(
+        default = "//rules/scripts:include_guard.sh",
+        allow_single_file = True,
+    ),
+    "_runner_general": attr.label(
+        default = "//rules/scripts:general_lint.template.sh",
+        allow_single_file = True,
+    ),
+}
+
+include_guard_fix = rule(
+    implementation = _general_lint_impl,
+    attrs = include_guard_attrs,
+    executable = True,
+)
+
+_include_guard_test = rule(
+    implementation = _general_lint_impl,
+    attrs = include_guard_attrs,
+    test = True,
+)
+
+def include_guard_check(**kwargs):
+    tags = kwargs.get("tags", [])
+
+    # Note: the "external" tag is a workaround for bazelbuild#15516.
+    kwargs["tags"] = _ensure_tag(tags, "no-sandbox", "no-cache", "external")
+    _include_guard_test(**kwargs)

--- a/rules/scripts/include_guard.sh
+++ b/rules/scripts/include_guard.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+case "$MODE" in
+    diff)
+        echo "$FILES" | xargs ${lint_tool} --dry-run
+        exit $?
+        ;;
+    fix)
+        echo "$FILES" | xargs ${lint_tool}
+        ;;
+    *)
+        echo "Unknown mode: $MODE"
+        exit 2
+esac

--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-#ifndef OT_PROVISIONING_SRC_ATE_ATE_API_H
-#define OT_PROVISIONING_SRC_ATE_ATE_API_H
+#ifndef OPENTITAN_PROVISIONING_SRC_ATE_ATE_API_H_
+#define OPENTITAN_PROVISIONING_SRC_ATE_ATE_API_H_
 #include <stddef.h>
 #include <stdint.h>
 
@@ -192,4 +192,4 @@ DLLEXPORT int CreateKeyAndCertificate(ate_client_ptr client, const char* sku,
 #ifdef __cplusplus
 }
 #endif
-#endif  // OT_PROVISIONING_SRC_ATE_ATE_API_H
+#endif  // OPENTITAN_PROVISIONING_SRC_ATE_ATE_API_H_

--- a/src/ate/ate_client.h
+++ b/src/ate/ate_client.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-#ifndef OT_PROVISIONING_SRC_ATE_ATE_CLIENT_H
-#define OT_PROVISIONING_SRC_ATE_ATE_CLIENT_H
+#ifndef OPENTITAN_PROVISIONING_SRC_ATE_ATE_CLIENT_H_
+#define OPENTITAN_PROVISIONING_SRC_ATE_ATE_CLIENT_H_
 
 #include <grpcpp/grpcpp.h>
 
@@ -88,4 +88,4 @@ std::ostream& operator<<(std::ostream& os, const AteClient::Options& options);
 
 }  // namespace ate
 }  // namespace provisioning
-#endif  // OT_PROVISIONING_SRC_ATE_ATE_CLIENT_H
+#endif  // OPENTITAN_PROVISIONING_SRC_ATE_ATE_CLIENT_H_

--- a/src/testing/test_helpers.h
+++ b/src/testing/test_helpers.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-#ifndef OT_PROVISIONING_SRC_TESTING_TEST_HELPERS_H
-#define OT_PROVISIONING_SRC_TESTING_TEST_HELPERS_H
+#ifndef OPENTITAN_PROVISIONING_SRC_TESTING_TEST_HELPERS_H_
+#define OPENTITAN_PROVISIONING_SRC_TESTING_TEST_HELPERS_H_
 
 #include <cstdlib>
 
@@ -31,4 +31,4 @@ using ::protobuf_matchers::proto::Partially;
 using ::protobuf_matchers::proto::WhenDeserialized;
 
 }  // namespace testing
-#endif  // OT_PROVISIONING_SRC_TESTING_TEST_HELPERS_H
+#endif  // OPENTITAN_PROVISIONING_SRC_TESTING_TEST_HELPERS_H_

--- a/src/transport/service_credentials.h
+++ b/src/transport/service_credentials.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-#ifndef OT_PROVISIONING_SRC_UTILS_SERVICE_CREDENTIALS_H
-#define OT_PROVISIONING_SRC_UTILS_SERVICE_CREDENTIALS_H
+#ifndef OPENTITAN_PROVISIONING_SRC_TRANSPORT_SERVICE_CREDENTIALS_H_
+#define OPENTITAN_PROVISIONING_SRC_TRANSPORT_SERVICE_CREDENTIALS_H_
 
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/security/credentials.h>
@@ -42,4 +42,4 @@ class ServiceCredentials : public grpc::MetadataCredentialsPlugin {
 }  // namespace transport
 }  // namespace provisioning
 
-#endif  // OT_PROVISIONING_SRC_UTILS_SERVICE_CREDENTIALS_H
+#endif  // OPENTITAN_PROVISIONING_SRC_TRANSPORT_SERVICE_CREDENTIALS_H_

--- a/src/version/version.h
+++ b/src/version/version.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-#ifndef OT_PROVISIONING_SRC_VERSION_VERSION_H
-#define OT_PROVISIONING_SRC_VERSION_VERSION_H
+#ifndef OPENTITAN_PROVISIONING_SRC_VERSION_VERSION_H_
+#define OPENTITAN_PROVISIONING_SRC_VERSION_VERSION_H_
 
 #include <string>
 
@@ -41,4 +41,4 @@ std::string VersionFormatted();
 
 }  // namespace provisioning
 
-#endif  // OT_PROVISIONING_SRC_VERSION_VERSION_H
+#endif  // OPENTITAN_PROVISIONING_SRC_VERSION_VERSION_H_

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# TODO(#41): make this a proper py_binary target
+exports_files([
+    "fix_include_guard.py",
+])

--- a/util/fix_include_guard.py
+++ b/util/fix_include_guard.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# fix_include_guard.py script takes any number of C or C++ header files as
+# input, and formats their include guards to conform to the style mandated
+# by Google C++. See
+# https://google.github.io/styleguide/cppguide.html#The__define_Guard
+#
+# clang-format does not, unfortunately, have support for automatically
+# generating the correct include guards; hence the existence of this script.
+#
+# This script will write the names of all affected files to stdout; if no such
+# output is present, all files have the correct guards. This script is
+# idempotent. If it cannot fix a file, the script will write the file name to
+# stderr and will exit at the end with a nonzero status code.
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# TODO(#41): make this a command line arg.
+PROJECT_NAME = "OPENTITAN_PROVISIONING"
+
+# This file is $REPO_TOP/util/fix_include_guard.py, so it takes two parent()
+# calls to get back to the top.
+REPO_TOP = Path(__file__).resolve().parent.parent
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run',
+                        action='store_true',
+                        help='report writes which would have happened')
+    parser.add_argument('headers',
+                        type=str,
+                        nargs='+',
+                        help='headers to fix guards for')
+    args = parser.parse_args()
+
+    total_unfixable = 0
+    total_fixable = 0
+
+    for header_path in args.headers:
+        header = Path(header_path).resolve().relative_to(REPO_TOP)
+        if header.suffix != '.h' or 'vendor' in header.parts:
+            continue
+
+        uppercase_dir = re.sub(r'[^\w]', '_', str(header.parent)).upper()
+        uppercase_stem = re.sub(r'[^\w]', '_', str(header.stem)).upper()
+        guard = '%s_%s_%s_H_' % (PROJECT_NAME, uppercase_dir, uppercase_stem)
+
+        header_text = header.read_text()
+        header_original = header_text
+
+        # Find the first non-comment, non-whitespace line in the file
+        first_line_match = re.search(r'^\s*([^/].*)', header_text,
+                                     re.MULTILINE)
+        if first_line_match is None:
+            total_unfixable += 1
+            print('No non-comment line found in `{}\'.'.format(header),
+                  file=sys.stderr)
+            continue
+
+        first_line = first_line_match.group(1).rstrip()
+
+        # Find the old guard name, which will be the first #ifndef in the file.
+        # This should be an #ifndef line. If it isn't, we can't fix things
+        ifndef_match = re.match(r'#ifndef\s+(\w+)$', first_line)
+        if ifndef_match is None:
+            total_unfixable += 1
+            print('Unsupported first non-comment line in `{}\': {!r}.'.format(
+                header, first_line),
+                  file=sys.stderr)
+            continue
+
+        old_guard = ifndef_match.group(1)
+
+        # Fix the guards at the top, which are guaranteed to be there.
+        header_text = re.sub('#(ifndef|define) +%s' % (old_guard, ),
+                             r'#\1 %s' % (guard, ), header_text)
+
+        # Fix up the endif. Since this is the last thing in the file, and it
+        # might be missing the comment, we just truncate the file, and add on
+        # the required guard end.
+        header_text = header_text[:header_text.rindex('#endif')]
+        header_text += "#endif  // %s\n" % (guard, )
+
+        if header_text != header_original:
+            print('Fixing header: "%s"' % (header, ), file=sys.stdout)
+            total_fixable += 1
+            if not args.dry_run:
+                header.write_text(header_text)
+
+    if total_fixable:
+        verb = 'Would have fixed' if args.dry_run else 'Fixed'
+        print('{} {} files.'.format(verb, total_fixable), file=sys.stderr)
+    if total_unfixable:
+        print('Failed to fix {} files.'.format(total_unfixable),
+              file=sys.stderr)
+
+    # Pass if we fixed everything or there was nothing to fix.
+    unfixed = total_unfixable + (total_fixable if args.dry_run else 0)
+    return 1 if unfixed else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This adds a CI check for include guards in C/C++ header files. Additionally this fixes existing include guards in the code base to be style guide compliant. 