### PR TITLE
[bazel] add lowrisc_opentitan as a dependency

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,8 +9,17 @@ build --action_env=BAZEL_CXXOPTS="-std=c++14"
 #build --cxxopt="-std=c++14"
 build --conlyopt="-std=c11"
 
+# Override default enablement of CRT flags.
+build --features=-all_warnings_as_errors
+
 # Enable toolchain resolution with cc
 build --incompatible_enable_cc_toolchain_resolution
 
 # Versioning
 build --workspace_status_command=util/get_workspace_status.sh
+
+# Enable the rust nightly toolchain
+build --@rules_rust//rust/toolchain/channel=nightly
+
+# Import site-specific configuration.
+try-import .bazelrc-site

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,14 +2,26 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# lowRISC linters and release process.
+# lowRISC opentitan, linters, and release process.
 load("//third_party/lowrisc:repos.bzl", "lowrisc_repos")
 lowrisc_repos()
+
+# Python Toolchain + PIP Dependencies from the lowrisc_opentitan repo.
+load("@lowrisc_opentitan//third_party/python:repos.bzl", "python_repos")
+python_repos()
+load("@lowrisc_opentitan//third_party/python:deps.bzl", "python_deps")
+python_deps()
+load("@lowrisc_opentitan//third_party/python:pip.bzl", "pip_deps")
+pip_deps()
+load("@ot_python_deps//:requirements.bzl", install_ot_python_deps="install_deps")
+install_ot_python_deps()
+
 # Release process.
 load("@lowrisc_bazel_release//:repos.bzl", "lowrisc_bazel_release_repos")
 lowrisc_bazel_release_repos()
 load("@lowrisc_bazel_release//:deps.bzl", "lowrisc_bazel_release_deps")
 lowrisc_bazel_release_deps()
+
 # Linters.
 # The linter deps need to be loaded like this to get the python and PIP
 # dependencies established in the proper order.
@@ -19,6 +31,30 @@ load("@lowrisc_misc_linters//rules:deps.bzl", "lowrisc_misc_linters_dependencies
 lowrisc_misc_linters_dependencies()
 load("@lowrisc_misc_linters//rules:pip.bzl", "lowrisc_misc_linters_pip_dependencies")
 lowrisc_misc_linters_pip_dependencies()
+load("@lowrisc_misc_linters_pip//:requirements.bzl", install_lowrisc_lint_python_deps="install_deps")
+install_lowrisc_lint_python_deps()
+
+# Rust Toolchain + crates.io dependencies from the lowrisc_opentitan repo.
+load("@lowrisc_opentitan//third_party/rust:repos.bzl", "rust_repos")
+rust_repos()
+load("@lowrisc_opentitan//third_party/rust:deps.bzl", "rust_deps")
+rust_deps()
+load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
+crate_universe_dependencies(bootstrap = True)
+load("@lowrisc_opentitan//third_party/rust/crates:crates.bzl", "crate_repositories")
+crate_repositories()
+
+# HyperDebug firmware (required for opentitanlib) from the lowrisc_opentitan repo.
+load("@lowrisc_opentitan//third_party/hyperdebug:repos.bzl", "hyperdebug_repos")
+hyperdebug_repos()
+
+# OpenOCD (required for opentitanlib) from the lowrisc_opentitan repo.
+load("@lowrisc_opentitan//third_party/openocd:repos.bzl", "openocd_repos")
+openocd_repos()
+
+# SPHINCS+ Test Vectors (required for opentitanlib).
+load("@lowrisc_opentitan//third_party/sphincsplus:repos.bzl", "sphincsplus_repos")
+sphincsplus_repos()
 
 # CRT is the Compiler Repository Toolkit.  It contains the configuration for
 # the windows compiler.
@@ -30,6 +66,7 @@ load("@crt//:deps.bzl", "crt_deps")
 crt_deps()
 load("@crt//config:registration.bzl", "crt_register_toolchains")
 crt_register_toolchains(
+    riscv32 = True,
     win32 = True,
     win64 = True,
 )

--- a/third_party/bazel/deps.bzl
+++ b/third_party/bazel/deps.bzl
@@ -4,7 +4,9 @@
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 def bazel_deps():
     rules_foreign_cc_dependencies()
     rules_pkg_dependencies()
+    bazel_skylib_workspace()

--- a/third_party/crt/repos.bzl
+++ b/third_party/crt/repos.bzl
@@ -5,12 +5,14 @@
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@//rules:repo.bzl", "http_archive_or_local")
 
+_CRT_VERSION = "0.4.14"
+
 def crt_repos(local = None):
     maybe(
         http_archive_or_local,
         local = local,
         name = "crt",
-        url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.3.9.tar.gz",
-        sha256 = "3f6e8e103595d2a6affbac5e2d9c14d1876f82fc6c8aca2a7528c97098a2f7ff",
-        strip_prefix = "crt-0.3.9",
+        url = "https://github.com/lowRISC/crt/archive/refs/tags/v{}.tar.gz".format(_CRT_VERSION),
+        sha256 = "aad71e39d0361d3eede8cb889d5ffb3a560108671598b01a4b6deadcfe75d6a6",
+        strip_prefix = "crt-{}".format(_CRT_VERSION),
     )

--- a/third_party/google/repos.bzl
+++ b/third_party/google/repos.bzl
@@ -41,7 +41,7 @@ def google_repos(
 
     # Googletest https://google.github.io/googletest/
     http_archive_or_local(
-        name = "com_google_googletest",
+        name = "googletest",
         local = googletest,
         url = "https://github.com/google/googletest/archive/refs/tags/v{}.tar.gz".format(_GOOGLETEST_VERSION),
         strip_prefix = "googletest-{}".format(_GOOGLETEST_VERSION),

--- a/third_party/lowrisc/repos.bzl
+++ b/third_party/lowrisc/repos.bzl
@@ -5,20 +5,45 @@
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@//rules:repo.bzl", "http_archive_or_local")
 
-def lowrisc_repos(misc_linters = None, bazel_release = None):
+_MISC_LINTERS_VERSION = "20240820_01"
+_BAZEL_RELEASE_VERSION = "0.0.3"
+_BAZEL_SKYLIB_VERSION = "1.5.0"
+
+# TODO(timothytrippel): pin a tagged release once one is created on the earlgrey_1.0.0 branch.
+_OPENTITAN_VERSION = "a48293cd4e4865fea6c74bf036db5905736f6687"
+
+def lowrisc_repos(misc_linters = None, bazel_release = None, bazel_skylib = None, opentitan = None):
     maybe(
         http_archive_or_local,
         name = "lowrisc_misc_linters",
         local = misc_linters,
-        sha256 = "ff4e14b2a8ace83a7f6a1536c7489c29f8c2b97d345ae9bb8b2d0f68059ec265",
-        strip_prefix = "misc-linters-20240423_01",
-        url = "https://github.com/lowRISC/misc-linters/archive/refs/tags/20240423_01.tar.gz",
+        sha256 = "1303d2790b7d1a0a216558c01f8bc6255dfb840e9e60b523d988b3655a0ddab3",
+        strip_prefix = "misc-linters-{}".format(_MISC_LINTERS_VERSION),
+        url = "https://github.com/lowRISC/misc-linters/archive/refs/tags/{}.tar.gz".format(_MISC_LINTERS_VERSION),
     )
     maybe(
         http_archive_or_local,
         local = bazel_release,
         name = "lowrisc_bazel_release",
         sha256 = "c7b0cbdec0a1081a0b0a52eb1ebd942e7eaa218408008661fdb6e8ec3b441a4a",
-        strip_prefix = "bazel-release-0.0.3",
-        url = "https://github.com/lowRISC/bazel-release/archive/refs/tags/v0.0.3.tar.gz",
+        strip_prefix = "bazel-release-{}".format(_BAZEL_RELEASE_VERSION),
+        url = "https://github.com/lowRISC/bazel-release/archive/refs/tags/v{}.tar.gz".format(_BAZEL_RELEASE_VERSION),
+    )
+    maybe(
+        http_archive_or_local,
+        name = "bazel_skylib",
+        lcoal = bazel_skylib,
+        sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+        url = "https://github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(
+            _BAZEL_SKYLIB_VERSION,
+            _BAZEL_SKYLIB_VERSION,
+        ),
+    )
+    maybe(
+        http_archive_or_local,
+        local = opentitan,
+        name = "lowrisc_opentitan",
+        sha256 = "3e53aa13816e370b92f88a8e7ce319a627e442663ada53cbba4a4ac515d0dc07",
+        strip_prefix = "opentitan-{}".format(_OPENTITAN_VERSION),
+        url = "https://github.com/lowRISC/opentitan/archive/{}.tar.gz".format(_OPENTITAN_VERSION),
     )


### PR DESCRIPTION
This adds the lowrisc_opentitan repository as a Bazel dependency in order to build opentitanlib as a dependency for an FPGA DUT shim layer that will be used for running provisioning flow tests in the lab.

Additionally, this adds skylib, rules_python, and rules_rust as external dependencies, as these are also required for building opentitanlib.

Lastly, this updates the CRT and misc_linters dependencies, as this is required to build opentitanlib as well.