### PR TITLE
[dut_lib] add initial dut_lib boilerplate and otlib_wrapper

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Prepare environment
+description: Install dependencies and prepare environment needed for OpenTitan
+
+runs:
+  using: composite
+  steps:
+    - name: Install system dependencies
+      run: |
+        sudo apt update
+        grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
+      shell: bash

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 80
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run linter checks
         run: bazel test //quality/...
 
@@ -21,7 +21,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 80
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
       - name: Build everything
         run: |
           bazel build //...
@@ -43,7 +45,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
       - name: Run PA loadtest (in containers)
         run: ./run_integration_tests.sh
 
@@ -52,7 +56,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 80
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
       - name: Build everything in an airgapped network namespace.
         run: |
           ./util/airgapped_builds/test-airgapped-build.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,7 +11,7 @@ lowrisc_repos()
 load("@lowrisc_opentitan//rules:hooks_setup.bzl", "provisioning_exts_setup")
 provisioning_exts_setup(
     name = "provisioning_exts_setup",
-    dummy = "sw/device/silicon_creator/manuf/extensions",
+    dummy = "third_party/lowrisc/provisioning_exts",
 )
 
 # Declare the external repository for provisioning source code extensions.

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -17,7 +17,12 @@ g++
 git
 gnupg
 golang
+libftdi1-2
+libftdi1-dev
+libncursesw5
 libssl-dev
+libudev-dev
+libusb-1.0-0
 lsb-release
 make
 podman

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -45,13 +45,3 @@ for sku in "${SKUS[@]}"; do
     --parallel_clients=10 \
     --total_calls_per_client=10
 done
-
-# Run the reference CP flow.
-CP_SKUS=("sival")
-for sku in "${CP_SKUS[@]}"; do
-  echo "Running reference CP flow with sku: ${sku} ..."
-  bazelisk run //src/ate/test_programs:cp -- \
-    --pa_socket="localhost:5001" \
-    --sku="${sku}" \
-    --sku_auth_pw="test_password"
-done

--- a/src/ate/test_programs/BUILD.bazel
+++ b/src/ate/test_programs/BUILD.bazel
@@ -7,8 +7,13 @@ package(default_visibility = ["//visibility:public"])
 cc_binary(
     name = "cp",
     srcs = ["cp.cc"],
+    data = [
+        "//third_party/lowrisc/ot_bitstreams:cp_cw340.bit",
+        "//third_party/lowrisc/ot_bitstreams:cp_hyper310.bit",
+    ],
     deps = [
         "//src/ate:ate_client",
+        "//src/ate/test_programs/dut_lib",
         "//src/version",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",

--- a/src/ate/test_programs/cp.cc
+++ b/src/ate/test_programs/cp.cc
@@ -17,8 +17,14 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "src/ate/ate_client.h"
+#include "src/ate/test_programs/dut_lib/dut_lib.h"
 #include "src/pa/proto/pa.grpc.pb.h"
 #include "src/version/version.h"
+
+/**
+ * DUT configuration flags.
+ */
+ABSL_FLAG(std::string, fpga, "", "FPGA platform to use.");
 
 /**
  * PA configuration flags.
@@ -42,6 +48,7 @@ ABSL_FLAG(std::string, ca_root_certs, "",
 namespace {
 using provisioning::VersionFormatted;
 using provisioning::ate::AteClient;
+using provisioning::test_programs::DutLib;
 
 // Returns `filename` content in a std::string format
 absl::StatusOr<std::string> ReadFile(const std::string &filename) {
@@ -104,6 +111,12 @@ int main(int argc, char **argv) {
     LOG(ERROR) << "InitSession failed with " << status.error_code() << ": "
                << status.error_message() << std::endl;
   }
+
+  // Init session with DUT.
+  auto dut = DutLib::Create();
+  dut->DutInit(absl::GetFlag(FLAGS_fpga),
+               absl::StrCat("third_party/lowrisc/ot_bitstreams/cp_",
+                            absl::GetFlag(FLAGS_fpga), ".bit"));
 
   // TODO(#6): add CP test code here.
 

--- a/src/ate/test_programs/dut_lib/BUILD.bazel
+++ b/src/ate/test_programs/dut_lib/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "dut_lib",
+    srcs = ["dut_lib.cc"],
+    hdrs = ["dut_lib.h"],
+    data = [
+        "@lowrisc_opentitan//sw/host/opentitanlib",
+    ],
+    # TODO(timothytrippel): make these bazel managed dependencies.
+    linkopts = [
+        "-lusb-1.0",
+        "-ludev",
+        "-lftdi1",
+    ],
+    deps = [
+        "//src/ate:ate_client",
+        "//src/ate/test_programs/otlib_wrapper",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@lowrisc_opentitan//sw/host/opentitanlib",
+    ],
+)

--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "src/ate/test_programs/dut_lib/dut_lib.h"
+
+#include <string>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+
+namespace provisioning {
+namespace test_programs {
+
+extern "C" {
+void OtLibFpgaInit(const char* fpga, const char* fpga_bitstream);
+}
+
+std::unique_ptr<DutLib> DutLib::Create(void) {
+  return absl::make_unique<DutLib>();
+}
+
+absl::Status DutLib::DutInit(const std::string& fpga,
+                             const std::string& fpga_bitstream) {
+  LOG(INFO) << "in DutLib::DutInit";
+  OtLibFpgaInit(fpga.c_str(), fpga_bitstream.c_str());
+  return absl::OkStatus();
+}
+
+}  // namespace test_programs
+}  // namespace provisioning

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_PROVISIONING_SRC_ATE_TEST_PROGRAMS_DUT_LIB_DUT_LIB_H_
+#define OPENTITAN_PROVISIONING_SRC_ATE_TEST_PROGRAMS_DUT_LIB_DUT_LIB_H_
+
+#include <string>
+
+#include "absl/status/status.h"
+
+namespace provisioning {
+namespace test_programs {
+
+class DutLib {
+ public:
+  DutLib(){};
+
+  // Forbids copies or assignments of DutLib.
+  DutLib(const DutLib&) = delete;
+  DutLib& operator=(const DutLib&) = delete;
+
+  static std::unique_ptr<DutLib> Create(void);
+
+  // Calls opentitanlib backend transport init for FPGA.
+  absl::Status DutInit(const std::string& fpga,
+                       const std::string& fpga_bitstream);
+};
+
+}  // namespace test_programs
+}  // namespace provisioning
+
+#endif  // OPENTITAN_PROVISIONING_SRC_ATE_TEST_PROGRAMS_DUT_LIB_DUT_LIB_H_

--- a/src/ate/test_programs/otlib_wrapper/BUILD.bazel
+++ b/src/ate/test_programs/otlib_wrapper/BUILD.bazel
@@ -1,0 +1,17 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "otlib_wrapper",
+    srcs = [
+        "src/lib.rs",
+    ],
+    deps = [
+        "@lowrisc_opentitan//sw/host/opentitanlib",
+    ],
+)

--- a/src/ate/test_programs/otlib_wrapper/src/lib.rs
+++ b/src/ate/test_programs/otlib_wrapper/src/lib.rs
@@ -1,0 +1,74 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::Duration;
+
+use opentitanlib::backend;
+use opentitanlib::backend::chip_whisperer::ChipWhispererOpts;
+use opentitanlib::backend::proxy::ProxyOpts;
+use opentitanlib::backend::ti50emulator::Ti50EmulatorOpts;
+use opentitanlib::backend::verilator::VerilatorOpts;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::load_bitstream::LoadBitstream;
+
+#[no_mangle]
+pub extern "C" fn OtLibFpgaInit(fpga: *mut c_char, fpga_bitstream: *mut c_char) {
+    // Unsupported backends.
+    let empty_proxy_opts = ProxyOpts {
+        proxy: None,
+        port: 0,
+    };
+    let empty_ti50emul_opts = Ti50EmulatorOpts {
+        instance_prefix: String::from(""),
+        executable_directory: PathBuf::from_str("").unwrap(),
+        executable: String::from(""),
+    };
+    let empty_verilator_opts = VerilatorOpts {
+        verilator_bin: String::from(""),
+        verilator_rom: String::from(""),
+        verilator_flash: vec![],
+        verilator_otp: String::from(""),
+        verilator_timeout: Duration::from_millis(0),
+        verilator_args: vec![],
+    };
+
+    // Only the hyper310 backend is currently supported.
+    let backend_opts = backend::BackendOpts {
+        interface: String::from(fpga_in),
+        disable_dft_on_reset: false,
+        conf: vec![],
+        usb_vid: None,
+        usb_pid: None,
+        usb_serial: None,
+        opts: ChipWhispererOpts { uarts: None },
+        openocd_adapter_config: None,
+        // Unsupported backends.
+        verilator_opts: empty_verilator_opts,
+        proxy_opts: empty_proxy_opts,
+        ti50emulator_opts: empty_ti50emul_opts,
+    };
+
+    // Create transport.
+    let transport = backend::create(&backend_opts).unwrap();
+    transport.apply_default_configuration(None).unwrap();
+
+    // Load bitstream.
+    // SAFETY: The FPGA string must be defined by the caller and be valid.
+    let fpga_cstr = unsafe { CStr::from_ptr(fpga) };
+    let fpga_in = fpga_cstr.to_str().unwrap();
+    // SAFETY: The FPGA bitstream path string must be defined by the caller and be a valid path.
+    let fpga_bitstream_cstr = unsafe { CStr::from_ptr(fpga_bitstream) };
+    let fpga_bitstream_in = fpga_bitstream_cstr.to_str().unwrap();
+    let load_bitstream = LoadBitstream {
+        clear_bitstream: true,
+        bitstream: Some(PathBuf::from_str(fpga_bitstream_in).unwrap()),
+        rom_reset_pulse: Duration::from_millis(50),
+        rom_timeout: Duration::from_secs(2),
+    };
+    InitializeTest::print_result("load_bitstream", load_bitstream.init(&transport)).unwrap();
+}

--- a/src/ate/test_programs/otlib_wrapper/src/lib.rs
+++ b/src/ate/test_programs/otlib_wrapper/src/lib.rs
@@ -37,6 +37,13 @@ pub extern "C" fn OtLibFpgaInit(fpga: *mut c_char, fpga_bitstream: *mut c_char) 
         verilator_args: vec![],
     };
 
+    // SAFETY: The FPGA string must be defined by the caller and be valid.
+    let fpga_cstr = unsafe { CStr::from_ptr(fpga) };
+    let fpga_in = fpga_cstr.to_str().unwrap();
+    // SAFETY: The FPGA bitstream path string must be defined by the caller and be a valid path.
+    let fpga_bitstream_cstr = unsafe { CStr::from_ptr(fpga_bitstream) };
+    let fpga_bitstream_in = fpga_bitstream_cstr.to_str().unwrap();
+
     // Only the hyper310 backend is currently supported.
     let backend_opts = backend::BackendOpts {
         interface: String::from(fpga_in),
@@ -58,12 +65,6 @@ pub extern "C" fn OtLibFpgaInit(fpga: *mut c_char, fpga_bitstream: *mut c_char) 
     transport.apply_default_configuration(None).unwrap();
 
     // Load bitstream.
-    // SAFETY: The FPGA string must be defined by the caller and be valid.
-    let fpga_cstr = unsafe { CStr::from_ptr(fpga) };
-    let fpga_in = fpga_cstr.to_str().unwrap();
-    // SAFETY: The FPGA bitstream path string must be defined by the caller and be a valid path.
-    let fpga_bitstream_cstr = unsafe { CStr::from_ptr(fpga_bitstream) };
-    let fpga_bitstream_in = fpga_bitstream_cstr.to_str().unwrap();
     let load_bitstream = LoadBitstream {
         clear_bitstream: true,
         bitstream: Some(PathBuf::from_str(fpga_bitstream_in).unwrap()),

--- a/third_party/lowrisc/provisioning_exts/BUILD.bazel
+++ b/third_party/lowrisc/provisioning_exts/BUILD.bazel
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This is just a dummy config file to enable the third party @lowrisc_opentitan
+# Bazel repo dependencies to build cleanly without having to close the repo.
+workspace(name = "provisioning_exts")

--- a/third_party/lowrisc/provisioning_exts/cfg.bzl
+++ b/third_party/lowrisc/provisioning_exts/cfg.bzl
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This is just a dummy config file to enable the third party @lowrisc_opentitan
+# Bazel repo dependencies to build cleanly without having to close the repo.
+EXT_EARLGREY_OTP_CFGS = {}
+EXT_EARLGREY_SKUS = {}
+EXT_SIGNED_PERSO_BINS = []
+EXT_EXEC_ENV_SILICON_ROM_EXT = {}

--- a/util/airgapped_builds/prep-bazel-airgapped-build.sh
+++ b/util/airgapped_builds/prep-bazel-airgapped-build.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 : "${BAZEL_AIRGAPPED_DIR:=bazel-airgapped}"
 : "${BAZEL_DISTDIR:=bazel-distdir}"
 : "${BAZEL_CACHEDIR:=bazel-cache}"
+: "${BAZEL_PYTHON_WHEEL_REPO:=ot_python_wheels}"
 
 LINE_SEP="====================================================================="
 
@@ -134,12 +135,27 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   bazelisk fetch \
     --repository_cache=${BAZEL_AIRGAPPED_DIR}/${BAZEL_CACHEDIR} \
     //... \
-    @remotejdk11_linux//... \
+    @remote_java_tools//... \
+    @remote_java_tools_linux//... \
+    @bindgen_clang_linux//... \
+    @rules_rust_bindgen__bindgen-0.65.1//... \
+    @rules_rust_bindgen__bindgen-cli-0.65.1//... \
+    @go_sdk//... \
     @cmake-3.22.2-linux-x86_64//... \
-    @ninja_1.10.2_linux//... \
     @gnumake_src//... \
+    @go_sdk//... \
     @gcc_mxe_mingw32_files//... \
-    @gcc_mxe_mingw64_files//...
+    @gcc_mxe_mingw64_files//... \
+    @ninja_1.10.2_linux//... \
+    @ot_python_wheels//... \
+    @python3_toolchains//... \
+    @remotejdk11_linux//... \
+    @rustfmt_nightly-2023-10-05__x86_64-unknown-linux-gnu_tools//... \
+    @rust_analyzer_1.71.1_tools//... \
+    @rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//... \
+    @rust_linux_x86_64__riscv32imc-unknown-none-elf__nightly_tools//...
+  cp -R "$(bazelisk info output_base)"/external/${BAZEL_PYTHON_WHEEL_REPO} \
+    ${BAZEL_AIRGAPPED_DIR}/
   echo "Done."
 fi
 

--- a/util/airgapped_builds/test-airgapped-build.sh
+++ b/util/airgapped_builds/test-airgapped-build.sh
@@ -22,23 +22,11 @@ sudo ip netns exec airgapped ip addr add 127.0.0.1/8 dev lo
 sudo ip netns exec airgapped ip link set dev lo up
 
 # Enter the network namespace and perform several builds.
-sudo ip netns exec airgapped sudo -u "$USER" bash -c \
-  "TARGET_PATTERN_FILE=\$(mktemp)
-  echo //... > \"\${TARGET_PATTERN_FILE}\"
-  bazel-airgapped/bazel cquery \
-    --distdir=$(pwd)/bazel-airgapped/bazel-distdir \
-    --repository_cache=$(pwd)/bazel-airgapped/bazel-cache \
-    --noinclude_aspects \
-    --output=starlark \
-    --starlark:expr='\"-{}\".format(target.label)' \
-    --define DISABLE_VERILATOR_BUILD=true \
-    -- \"rdeps(//..., kind(bitstream_splice, //...))\" \
-    >> \"\${TARGET_PATTERN_FILE}\"
-  echo Building target pattern:
-  cat \"\${TARGET_PATTERN_FILE}\"
-  bazel-airgapped/bazel build \
-    --distdir=$(pwd)/bazel-airgapped/bazel-distdir \
-    --repository_cache=$(pwd)/bazel-airgapped/bazel-cache \
-    --define DISABLE_VERILATOR_BUILD=true \
-    --target_pattern_file=\"\${TARGET_PATTERN_FILE}\""
+sudo ip netns exec airgapped sudo -u "$USER" \
+  env \
+    BAZEL_PYTHON_WHEELS_REPO="${PWD}/bazel-airgapped/ot_python_wheels" \
+  "${PWD}/bazel-airgapped/bazel" build                               \
+    --distdir="${PWD}/bazel-airgapped/bazel-distdir"                 \
+    --repository_cache="${PWD}/bazel-airgapped/bazel-cache"          \
+    //...
 exit 0


### PR DESCRIPTION
The dut_lib will be used to interface a test program with a DUT backend.
This will enable E2E testing with FPGAs or real silicon.

This initial version loads a bitstream onto an FPGA using opentitanlib.

This depends on #51, only review the last two commits.