### PR TITLE
[proto] update DeviceId protos namespace

### DIFF
--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -125,7 +125,7 @@ message CreateKeyAndCertRequest {
   // SKU identifier. Required.
   string sku = 1;
   // Device identifier. Optional.
-  device_id.DeviceId device_id = 2;
+  ot_device_id.DeviceId device_id = 2;
   // Serial Number per sku. Required.
   bytes serial_number = 3;
 }
@@ -179,7 +179,7 @@ message CloseSessionResponse {
 // Device Registration request.
 message RegistrationRequest {
   // Device record. Required.
-  device_id.DeviceRecord device_record = 1;
+  ot_device_id.DeviceRecord device_record = 1;
 }
 
 // Device Registration reponse.

--- a/src/proto/device_id.proto
+++ b/src/proto/device_id.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto3";
 
-package device_id;
+package ot_device_id;
 
 option go_package = "device_id_go_pb";
 

--- a/src/proto/device_id.proto
+++ b/src/proto/device_id.proto
@@ -73,11 +73,6 @@ message DeviceId {
   //
   // 128 bits (size is enforced at a higher level, not by protobuf).
   bytes sku_specific = 2;
-  // IEEE802.3 CRC32.
-  //
-  // This CRC covers the entire (deserialized) region above, and is calculated
-  // at a higher level, not by protobuf.
-  fixed32 crc32 = 3;
 }
 
 // OpenTitan Device Registration State.

--- a/src/proxy_buffer/proto/proxy_buffer.proto
+++ b/src/proxy_buffer/proto/proxy_buffer.proto
@@ -28,9 +28,9 @@ enum DeviceRegistrationStatus {
   DEVICE_REGISTRATION_STATUS_BUFFER_FULL = 3;
 }
 message DeviceRegistrationRequest {
-  device_id.DeviceRecord device_record = 1;
+  ot_device_id.DeviceRecord device_record = 1;
 }
 message DeviceRegistrationResponse {
   DeviceRegistrationStatus status = 1;
-  device_id.DeviceId device_id = 2;
+  ot_device_id.DeviceId device_id = 2;
 }


### PR DESCRIPTION
This udpates the device ID namespace to be more specific to the OT project. Additionally, remove CRC from device ID field.