### PR TITLE
[proto] adjust RegistryRecord proto based on feedback

### DIFF
--- a/src/proto/registry_record.proto
+++ b/src/proto/registry_record.proto
@@ -14,8 +14,10 @@ option go_package = "registry_record_go_pb";
 message RegistryRecord {
   // Device ID encoded as a hex string.
   string device_id = 1;
+  // SKU identifier encoded as a string.
+  string sku = 2;
   // Verion number indicating version of device data field below.
-  sfixed32 version = 2;
+  uint32 version = 3;
   // Device data encoded as a variable length bytes payload.
-  bytes data = 3;
+  bytes data = 4;
 }


### PR DESCRIPTION
This contains two fixes to the RegistryRecord message:
1. we add a "sku" string field to make it easier to route different records to various backend customer registries, and
2. encode the version field as a variable length uint32.