### PR TITLE
[bazel,utils] add missing build target and DeviceID to string conversion utility

### DIFF
--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -31,6 +31,15 @@ go_library(
 )
 
 go_library(
+    name = "device_id_utils",
+    srcs = ["device_id_utils.go"],
+    importpath = "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_utils",
+    deps = [
+        ":device_id_go_pb",
+    ],
+)
+
+go_library(
     name = "device_testdata",
     testonly = True,
     srcs = ["device_testdata.go"],

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -51,3 +51,9 @@ proto_library(
     name = "registry_record_proto",
     srcs = ["registry_record.proto"],
 )
+
+go_proto_library(
+    name = "registry_record_go_pb",
+    importpath = "github.com/lowRISC/opentitan-provisioning/src/proto/registry_record_go_pb",
+    proto = ":registry_record_proto",
+)

--- a/src/proto/device_id_utils.go
+++ b/src/proto/device_id_utils.go
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package device_id_utils
+
+import (
+	"fmt"
+	dpb "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_go_pb"
+)
+
+const (
+	ReservedDeviceIdField = 0
+)
+
+// Converts a DeviceId into a hex string.
+func DeviceIdToHexString(di *dpb.DeviceId) string {
+	return fmt.Sprintf("0x%x%08x%016x%08x%08x",
+		di.SkuSpecific,
+		ReservedDeviceIdField,
+		uint64(di.HardwareOrigin.DeviceIdentificationNumber),
+		uint16(di.HardwareOrigin.ProductId),
+		uint16(di.HardwareOrigin.SiliconCreatorId),
+	)
+}

--- a/src/proto/validators.go
+++ b/src/proto/validators.go
@@ -85,15 +85,6 @@ func ValidateDeviceId(di *dpb.DeviceId) error {
 	return nil
 }
 
-// DeviceIdToString injectively converts a (valid!) DeviceId into a deterministic string.
-func DeviceIdToString(di *dpb.DeviceId) string {
-	return fmt.Sprintf("DeviceId:%x:%x:%x:%x",
-		di.HardwareOrigin.SiliconCreatorId,
-		di.HardwareOrigin.ProductId,
-		di.HardwareOrigin.DeviceIdentificationNumber,
-		di.SkuSpecific)
-}
-
 // Checks the length of the payload object ([]byte).  Since a payload is optional,
 // 0-length is considered valid.
 func validatePayload(payload []byte) error {


### PR DESCRIPTION
This contains two commits that:

1. adds a utility for converting a DeviceID proto object to a hexstring, and
2. adds a Bazel proto build target for the RegistryRecord proto message.