### PR TITLE
[proxy_buffer] refactor registration proto

### DIFF
--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -179,7 +179,7 @@ message CloseSessionResponse {
 // Device Registration request.
 message RegistrationRequest {
   // Device record. Required.
-  ot_device_id.DeviceRecord device_record = 1;
+  ot_device_id.DeviceData device_data = 1;
 }
 
 // Device Registration reponse.

--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -125,7 +125,7 @@ message CreateKeyAndCertRequest {
   // SKU identifier. Required.
   string sku = 1;
   // Device identifier. Optional.
-  ot_device_id.DeviceId device_id = 2;
+  ot.DeviceId device_id = 2;
   // Serial Number per sku. Required.
   bytes serial_number = 3;
 }
@@ -179,7 +179,7 @@ message CloseSessionResponse {
 // Device Registration request.
 message RegistrationRequest {
   // Device record. Required.
-  ot_device_id.DeviceData device_data = 1;
+  ot.DeviceData device_data = 1;
 }
 
 // Device Registration reponse.

--- a/src/pa/services/BUILD.bazel
+++ b/src/pa/services/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//src/pa/proto:pa_go_pb",
         "//src/proto:device_id_go_pb",
+        "//src/proto:device_id_utils",
         "//src/registry_buffer/proto:registry_buffer_go_pb",
         "//src/spm/proto:spm_go_pb",
         "//src/transport/auth_service",

--- a/src/pa/services/pa.go
+++ b/src/pa/services/pa.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pbp "github.com/lowRISC/opentitan-provisioning/src/pa/proto/pa_go_pb"
+	diu "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_utils"
 	pbr "github.com/lowRISC/opentitan-provisioning/src/registry_buffer/proto/registry_buffer_go_pb"
 	pbs "github.com/lowRISC/opentitan-provisioning/src/spm/proto/spm_go_pb"
 	"github.com/lowRISC/opentitan-provisioning/src/transport/auth_service"
@@ -149,7 +150,7 @@ func (s *server) DeriveSymmetricKeys(ctx context.Context, request *pbp.DeriveSym
 
 // SendDeviceRegistrationPayload registers a new device record to the local MySql DB.
 func (s *server) SendDeviceRegistrationPayload(ctx context.Context, request *pbp.RegistrationRequest) (*pbp.RegistrationResponse, error) {
-	log.Printf("In PA - Received SendDeviceRegistrationPayload request with DeviceID: %v", request.DeviceRecord.Id)
+	log.Printf("In PA - Received SendDeviceRegistrationPayload request with DeviceID: %v", diu.DeviceIdToHexString(request.DeviceData.DeviceId))
 
 	if !s.enableRegBuff {
 		return nil, status.Errorf(codes.Internal, "RegisterDevice ended with error, PA started without registry buffer")

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -46,6 +46,8 @@ go_library(
     importpath = "github.com/lowRISC/opentitan-provisioning/src/proto/device_testdata",
     deps = [
         ":device_id_go_pb",
+        ":device_id_utils",
+        ":registry_record_go_pb",
     ],
 )
 

--- a/src/proto/device_id.proto
+++ b/src/proto/device_id.proto
@@ -147,39 +147,19 @@ enum DeviceLifeCycle {
 }
 
 // OpenTitan Device Provisioning Data.
-//
-// This contains information pertaining to the provisioning of a device,
-// including:
-// - device life cycle state,
-// - a generic blob of certificates or assets provisioned into the device,
-// - metadata with information on device creation time and registration state.
 message DeviceData {
+  // SKU string.
+  string sku = 1;
+  // DeviceId.
+  DeviceId device_id = 2;
   // Device life cycle of this device.
-  DeviceLifeCycle device_life_cycle = 1;
-  // Up to 8192 (8k) bytes of SKU specific device provisioning data.
+  DeviceLifeCycle device_life_cycle = 3;
+  // Additional metadata contain device creation time and registration state.
+  Metadata metadata = 4;
+  // Encrypted RMA unlock token.
+  bytes wrapped_rma_unlock_token = 5;
+  // Up to (8k) bytes of SKU specific personalization TLV data.
   //
   // (Size is enforced at a higher level, not by protobuf).
-  //
-  // While the format of this is to be determined by SKU owners, this may
-  // contain a LTV data structure of DICE, TPM, and other certificates, as well
-  // as any additional metadata relevant for a SKU. For example, this may be
-  // structured in the same format as `perso_blob_t` LTV struct defined here:
-  // protolint:disable:next MAX_LINE_LENGTH
-  // https://github.com/lowRISC/opentitan/blob/25b1acbf687e5535e8742c2aacb5b224ee77c80d/sw/device/lib/testing/json/provisioning_data.h#L94
-  bytes payload = 2;
-  // Additional metadata contain device creation time and registration state.
-  Metadata metadata = 3;
-}
-
-
-// OpenTitan Device Record.
-//
-// This will get sent to one (or many) registry service(s).
-message DeviceRecord {
-  // SKU name.
-  string sku = 1;
-  // Device ID.
-  DeviceId id = 2;
-  // Device data.
-  DeviceData data = 3;
+  bytes perso_tlv_data = 6;
 }

--- a/src/proto/device_id.proto
+++ b/src/proto/device_id.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto3";
 
-package ot_device_id;
+package ot;
 
 option go_package = "device_id_go_pb";
 

--- a/src/proto/device_id_utils.go
+++ b/src/proto/device_id_utils.go
@@ -13,7 +13,7 @@ const (
 	ReservedDeviceIdField = 0
 )
 
-// Converts a DeviceId into a hex string.
+// Converts a DeviceId proto object into a hex string.
 func DeviceIdToHexString(di *dpb.DeviceId) string {
 	return fmt.Sprintf("0x%x%08x%016x%08x%08x",
 		di.SkuSpecific,

--- a/src/proto/validators_test.go
+++ b/src/proto/validators_test.go
@@ -175,7 +175,7 @@ func TestValidateDeviceId(t *testing.T) {
 			name: "sku too long",
 			di:   &dtd.DeviceIdSkuTooLong,
 		},
-		// TODO: test a device ID which has a bad DeviceIdentificationNumber field.
+		// TODO(timothytrippel): test a device ID which has a bad DeviceIdentificationNumber field.
 	}
 
 	for _, tt := range tests {
@@ -233,25 +233,21 @@ func TestValidateDeviceData(t *testing.T) {
 		ok   bool
 	}{
 		{
-			name: "empty payload",
-			dd: &dpb.DeviceData{
-				Payload:         make([]byte, 0),
-				DeviceLifeCycle: dpb.DeviceLifeCycle_DEVICE_LIFE_CYCLE_DEV,
-			},
-			ok: true,
-		},
-		{
-			name: "valid payload with one cert",
+			name: "valid payload with no data",
 			dd:   &dtd.DeviceDataOk,
 			ok:   true,
 		},
 		{
-			name: "payload too large",
-			dd:   &dtd.DeviceDataBadPayloadTooLarge,
-		},
-		{
 			name: "bad device life cycle",
 			dd:   &dtd.DeviceDataBadLifeCycle,
+		},
+		{
+			name: "wrapped rma unlock token too large",
+			dd:   &dtd.DeviceDataWrappedRmaUnlockTokenTooLarge,
+		},
+		{
+			name: "perso tlv data too large",
+			dd:   &dtd.DeviceDataPersoTlvDataTooLarge,
 		},
 	}
 

--- a/src/proxy_buffer/pb_server_integration_test.go
+++ b/src/proxy_buffer/pb_server_integration_test.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	dpb "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_go_pb"
 	dtd "github.com/lowRISC/opentitan-provisioning/src/proto/device_testdata"
 	pbp "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/proxy_buffer_go_pb"
 )
@@ -40,28 +39,22 @@ func TestRegisterDevice(t *testing.T) {
 		{
 			name: "ok",
 			drr: &pbp.DeviceRegistrationRequest{
-				DeviceRecord: &dpb.DeviceRecord{
-					Id: dtd.NewDeviceID(),
-					Data: &dpb.DeviceData{
-						DeviceLifeCycle: dpb.DeviceLifeCycle_DEVICE_LIFE_CYCLE_PROD,
-					},
-				},
+				Record: &dtd.RegistryRecordOk,
 			},
 			expCode: codes.OK,
-			expDR:   &pbp.DeviceRegistrationResponse{DeviceId: dtd.NewDeviceID()},
+			expDR: &pbp.DeviceRegistrationResponse{
+				Status:   pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_SUCCESS,
+				DeviceId: dtd.RegistryRecordOk.DeviceId},
 		},
 		{
-			name: "invalid arg",
+			name: "empty device id",
 			drr: &pbp.DeviceRegistrationRequest{
-				DeviceRecord: &dpb.DeviceRecord{
-					Id: dtd.NewDeviceIdBadOrigin(),
-					Data: &dpb.DeviceData{
-						DeviceLifeCycle: dpb.DeviceLifeCycle_DEVICE_LIFE_CYCLE_PROD,
-					},
-				},
+				Record: &dtd.RegistryRecordOk,
 			},
 			expCode: codes.InvalidArgument,
-			expDR:   nil,
+			expDR: &pbp.DeviceRegistrationResponse{
+				Status:   pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_BAD_REQUEST,
+				DeviceId: dtd.RegistryRecordOk.DeviceId},
 		},
 	}
 

--- a/src/proxy_buffer/proto/BUILD.bazel
+++ b/src/proxy_buffer/proto/BUILD.bazel
@@ -14,7 +14,7 @@ package(default_visibility = ["//visibility:public"])
 proto_library(
     name = "proxy_buffer_proto",
     srcs = ["proxy_buffer.proto"],
-    deps = ["//src/proto:device_id_proto"],
+    deps = ["//src/proto:registry_record_proto"],
 )
 
 go_proto_library(
@@ -23,7 +23,7 @@ go_proto_library(
     importpath = "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/proxy_buffer_go_pb",
     proto = ":proxy_buffer_proto",
     deps = [
-        "//src/proto:device_id_go_pb",
+        "//src/proto:registry_record_go_pb",
     ],
 )
 
@@ -31,10 +31,7 @@ go_library(
     name = "validators",
     srcs = ["validators.go"],
     importpath = "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/validators",
-    deps = [
-        ":proxy_buffer_go_pb",
-        "//src/proto:validators",
-    ],
+    deps = [":proxy_buffer_go_pb"],
 )
 
 go_test(
@@ -42,7 +39,7 @@ go_test(
     srcs = ["validators_test.go"],
     embed = [":validators"],
     deps = [
-        "//src/proto:device_id_go_pb",
+        "//src/proto:device_id_utils",
         "//src/proto:device_testdata",
         "//src/proto:validators",
     ],

--- a/src/proxy_buffer/proto/proxy_buffer.proto
+++ b/src/proxy_buffer/proto/proxy_buffer.proto
@@ -8,7 +8,7 @@ syntax = "proto3";
 
 package proxy_buffer;
 
-import "src/proto/device_id.proto";
+import "src/proto/registry_record.proto";
 
 option go_package = "proxy_buffer_go_bp";
 
@@ -27,10 +27,12 @@ enum DeviceRegistrationStatus {
   DEVICE_REGISTRATION_STATUS_BAD_REQUEST = 2;
   DEVICE_REGISTRATION_STATUS_BUFFER_FULL = 3;
 }
+
 message DeviceRegistrationRequest {
-  ot_device_id.DeviceRecord device_record = 1;
+  ot_registry_record.RegistryRecord record = 1;
 }
+
 message DeviceRegistrationResponse {
   DeviceRegistrationStatus status = 1;
-  ot_device_id.DeviceId device_id = 2;
+  string device_id = 2;
 }

--- a/src/proxy_buffer/proto/validators.go
+++ b/src/proxy_buffer/proto/validators.go
@@ -9,18 +9,25 @@ package validators
 import (
 	"fmt"
 
-	common_validators "github.com/lowRISC/opentitan-provisioning/src/proto/validators"
 	pb "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/proxy_buffer_go_pb"
 )
 
 // ValidateDeviceRegistrationRequest performs invariant checks for a
 // DeviceRegistrationRequest that protobuf syntax cannot capture.
 func ValidateDeviceRegistrationRequest(request *pb.DeviceRegistrationRequest) error {
-	if err := common_validators.ValidateDeviceId(request.DeviceRecord.Id); err != nil {
-		return err
+	// Device IDs will be validated by the PA, only check if device ID string is empty.
+	if request.Record.DeviceId == "" {
+		return fmt.Errorf("Invalid DeviceRegistrationRequest; DeviceId empty")
 	}
-
-	return common_validators.ValidateDeviceData(request.DeviceRecord.Data)
+	// SKU strings will be validated by the PA, only check if SKU string is empty.
+	if request.Record.Sku == "" {
+		return fmt.Errorf("Invalid DeviceRegistrationRequest; SKU empty")
+	}
+	// Data fields will be validated by the PA, only check if field is empty.
+	if len(request.Record.Data) == 0 {
+		return fmt.Errorf("Invalid DeviceRegistrationRequest; Data empty")
+	}
+	return nil
 }
 
 func validateDeviceRegistrationStatus(status pb.DeviceRegistrationStatus) error {
@@ -41,6 +48,9 @@ func ValidateDeviceRegistrationResponse(response *pb.DeviceRegistrationResponse)
 	if err := validateDeviceRegistrationStatus(response.Status); err != nil {
 		return err
 	}
+	if response.DeviceId == "" {
+		return fmt.Errorf("Invalid DeviceRegistrationResponse; DeviceId empty")
+	}
 
-	return common_validators.ValidateDeviceId(response.DeviceId)
+	return nil
 }

--- a/src/proxy_buffer/proto/validators_test.go
+++ b/src/proxy_buffer/proto/validators_test.go
@@ -6,7 +6,7 @@ package validators
 import (
 	"testing"
 
-	dpb "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_go_pb"
+	diu "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_utils"
 	dtd "github.com/lowRISC/opentitan-provisioning/src/proto/device_testdata"
 	pb "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/proxy_buffer_go_pb"
 )
@@ -20,38 +20,20 @@ func TestValidateDeviceRegistrationRequest(t *testing.T) {
 		{
 			name: "ok",
 			drr: &pb.DeviceRegistrationRequest{
-				DeviceRecord: &dpb.DeviceRecord{
-					Id:   &dtd.DeviceIdOk,
-					Data: &dtd.DeviceDataOk,
-				},
+				Record: &dtd.RegistryRecordOk,
 			},
 			ok: true,
 		},
 		{
-			name: "bad silicon creator id",
+			name: "empty device id",
 			drr: &pb.DeviceRegistrationRequest{
-				DeviceRecord: &dpb.DeviceRecord{
-					Id:   &dtd.DeviceIdBadSiliconCreatorId,
-					Data: &dtd.DeviceDataOk,
-				},
+				Record: &dtd.RegistryRecordEmptyDeviceId,
 			},
 		},
 		{
-			name: "bad product id",
+			name: "empty sku",
 			drr: &pb.DeviceRegistrationRequest{
-				DeviceRecord: &dpb.DeviceRecord{
-					Id:   &dtd.DeviceIdBadProductId,
-					Data: &dtd.DeviceDataOk,
-				},
-			},
-		},
-		{
-			name: "bad device data",
-			drr: &pb.DeviceRegistrationRequest{
-				DeviceRecord: &dpb.DeviceRecord{
-					Id:   &dtd.DeviceIdOk,
-					Data: &dtd.DeviceDataBadPayloadTooLarge,
-				},
+				Record: &dtd.RegistryRecordEmptySku,
 			},
 		},
 	}
@@ -75,23 +57,21 @@ func TestValidateDeviceRegistrationResponse(t *testing.T) {
 			name: "ok",
 			drr: &pb.DeviceRegistrationResponse{
 				Status:   pb.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_SUCCESS,
-				DeviceId: &dtd.DeviceIdOk,
+				DeviceId: diu.DeviceIdToHexString(&dtd.DeviceIdOk),
 			},
 			ok: true,
 		},
 		{
 			name: "bad request",
 			drr: &pb.DeviceRegistrationResponse{
-				Status:   pb.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_BAD_REQUEST,
-				DeviceId: &dtd.DeviceIdOk,
+				DeviceId: diu.DeviceIdToHexString(&dtd.DeviceIdOk),
 			},
-			ok: true,
 		},
 		{
 			name: "buffer full",
 			drr: &pb.DeviceRegistrationResponse{
 				Status:   pb.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_BUFFER_FULL,
-				DeviceId: &dtd.DeviceIdOk,
+				DeviceId: diu.DeviceIdToHexString(&dtd.DeviceIdOk),
 			},
 			ok: true,
 		},
@@ -99,14 +79,14 @@ func TestValidateDeviceRegistrationResponse(t *testing.T) {
 			name: "invalid status",
 			drr: &pb.DeviceRegistrationResponse{
 				Status:   pb.DeviceRegistrationStatus(-1),
-				DeviceId: &dtd.DeviceIdOk,
+				DeviceId: diu.DeviceIdToHexString(&dtd.DeviceIdOk),
 			},
 		},
 		{
 			name: "bad device id",
 			drr: &pb.DeviceRegistrationResponse{
 				Status:   pb.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_SUCCESS,
-				DeviceId: &dtd.DeviceIdBadSiliconCreatorId,
+				DeviceId: "",
 			},
 		},
 	}

--- a/src/proxy_buffer/services/BUILD.bazel
+++ b/src/proxy_buffer/services/BUILD.bazel
@@ -25,7 +25,6 @@ go_test(
     srcs = ["proxybuffer_test.go"],
     deps = [
         ":proxybuffer",
-        "//src/proto:device_id_go_pb",
         "//src/proto:device_testdata",
         "//src/proxy_buffer/proto:proxy_buffer_go_pb",
         "//src/proxy_buffer/store:db",

--- a/src/proxy_buffer/services/proxybuffer_test.go
+++ b/src/proxy_buffer/services/proxybuffer_test.go
@@ -17,7 +17,6 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	dpb "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_go_pb"
 	dtd "github.com/lowRISC/opentitan-provisioning/src/proto/device_testdata"
 	pbp "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/proxy_buffer_go_pb"
 	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/services/proxybuffer"
@@ -65,27 +64,33 @@ func TestRegisterDevice(t *testing.T) {
 		{
 			name: "ok",
 			drr: &pbp.DeviceRegistrationRequest{
-				DeviceRecord: &dpb.DeviceRecord{
-					Id: dtd.NewDeviceID(),
-					Data: &dpb.DeviceData{
-						DeviceLifeCycle: dpb.DeviceLifeCycle_DEVICE_LIFE_CYCLE_PROD,
-					},
-				},
+				Record: &dtd.RegistryRecordOk,
 			},
 			expCode: codes.OK,
 			expDR: &pbp.DeviceRegistrationResponse{
 				Status:   pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_SUCCESS,
-				DeviceId: dtd.NewDeviceID()},
+				DeviceId: dtd.RegistryRecordOk.DeviceId},
 		},
 		{
-			name: "invalid arg",
+			name: "empty device id",
 			drr: &pbp.DeviceRegistrationRequest{
-				DeviceRecord: &dpb.DeviceRecord{
-					Id: dtd.NewDeviceIdBadOrigin(),
-					Data: &dpb.DeviceData{
-						DeviceLifeCycle: dpb.DeviceLifeCycle_DEVICE_LIFE_CYCLE_PROD,
-					},
-				},
+				Record: &dtd.RegistryRecordEmptyDeviceId,
+			},
+			expCode: codes.InvalidArgument,
+			expDR:   nil,
+		},
+		{
+			name: "empty sku",
+			drr: &pbp.DeviceRegistrationRequest{
+				Record: &dtd.RegistryRecordEmptySku,
+			},
+			expCode: codes.InvalidArgument,
+			expDR:   nil,
+		},
+		{
+			name: "empty data",
+			drr: &pbp.DeviceRegistrationRequest{
+				Record: &dtd.RegistryRecordEmptyData,
 			},
 			expCode: codes.InvalidArgument,
 			expDR:   nil,

--- a/src/proxy_buffer/store/BUILD.bazel
+++ b/src/proxy_buffer/store/BUILD.bazel
@@ -20,7 +20,7 @@ go_library(
     importpath = "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/db",
     deps = [
         ":connector",
-        "//src/proto:device_id_go_pb",
+        "//src/proto:registry_record_go_pb",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )
@@ -40,7 +40,7 @@ go_test(
     deps = [
         ":db",
         ":db_fake",
-        "//src/proto:device_id_go_pb",
+        "//src/proto:device_testdata",
         "@com_github_google_go_cmp//cmp",
         "@org_golang_google_protobuf//testing/protocmp",
     ],

--- a/src/proxy_buffer/store/db.go
+++ b/src/proxy_buffer/store/db.go
@@ -11,17 +11,11 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	dpb "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_go_pb"
+	rpb "github.com/lowRISC/opentitan-provisioning/src/proto/registry_record_go_pb"
 	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/connector"
 )
 
-const (
-	// Database key template.
-	// /pb/<record_type>/<device_type>/<device_identifier>
-	recordKey = "/pb/dr/%08X/%016X"
-)
-
-// DB implements the Proxy Buffer database abstration layer.
+// DB implements the Proxy Buffer database abstraction layer.
 type DB struct {
 	// conn is the database connector interface.
 	conn connector.Connector
@@ -32,34 +26,27 @@ func New(c connector.Connector) *DB {
 	return &DB{conn: c}
 }
 
-// genKey generates a device key in string format from a `di` protobuf message.
-func genKey(di *dpb.DeviceId) string {
-	dt := uint32(dpb.SiliconCreatorId_value[di.HardwareOrigin.SiliconCreatorId.String()])
-	dt = dt<<16 | uint32(di.HardwareOrigin.ProductId)
-	return fmt.Sprintf(recordKey, dt, di.HardwareOrigin.DeviceIdentificationNumber)
-}
-
-// InsertDevice adds a `dr` device record into the database in serialized bytes
-// format.
-func (d *DB) InsertDevice(ctx context.Context, dr *dpb.DeviceRecord) error {
-	key := genKey(dr.Id)
-	data, err := proto.Marshal(dr)
+// InsertDevice adds a `rr` registry record into the database in serialized
+// bytes format.
+func (d *DB) InsertDevice(ctx context.Context, rr *rpb.RegistryRecord) error {
+	key := rr.DeviceId
+	data, err := proto.Marshal(rr)
 	if err != nil {
-		return fmt.Errorf("failed to marshal device record: %v", err)
+		return fmt.Errorf("failed to marshal registry record: %v", err)
 	}
 	return d.conn.Insert(ctx, key, data)
 }
 
 // GetDevice returns a device record associated with a `di` device id. The
 // result is returned in protobuf format.
-func (d *DB) GetDevice(ctx context.Context, di *dpb.DeviceId) (*dpb.DeviceRecord, error) {
-	res, err := d.conn.Get(ctx, genKey(di))
+func (d *DB) GetDevice(ctx context.Context, di string) (*rpb.RegistryRecord, error) {
+	rr_bytes, err := d.conn.Get(ctx, di)
 	if err != nil {
 		return nil, err
 	}
-	record := &dpb.DeviceRecord{}
-	if err := proto.Unmarshal(res, record); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal device record: %v", err)
+	record := &rpb.RegistryRecord{}
+	if err := proto.Unmarshal(rr_bytes, record); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal registry record: %v", err)
 	}
 	return record, nil
 }

--- a/src/proxy_buffer/store/db_test.go
+++ b/src/proxy_buffer/store/db_test.go
@@ -12,32 +12,20 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	dpb "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_go_pb"
+	dtd "github.com/lowRISC/opentitan-provisioning/src/proto/device_testdata"
 	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/db"
 	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/db_fake"
 )
 
 func TestInsert(t *testing.T) {
 	database := db.New(db_fake.New())
-
-	record := &dpb.DeviceRecord{
-		Id: &dpb.DeviceId{
-			HardwareOrigin: &dpb.HardwareOrigin{
-				SiliconCreatorId:           dpb.SiliconCreatorId_SILICON_CREATOR_ID_OPENSOURCE,
-				ProductId:                  dpb.ProductId_PRODUCT_ID_EARLGREY_Z1,
-				DeviceIdentificationNumber: 0x0123456701234567,
-			},
-		},
-		Data: &dpb.DeviceData{
-			DeviceLifeCycle: dpb.DeviceLifeCycle_DEVICE_LIFE_CYCLE_PROD,
-		},
-	}
+	record := &dtd.RegistryRecordOk
 
 	if err := database.InsertDevice(context.Background(), record); err != nil {
 		t.Fatalf("failed to insert record: %v", err)
 	}
 
-	got, err := database.GetDevice(context.Background(), record.Id)
+	got, err := database.GetDevice(context.Background(), record.DeviceId)
 	if err != nil {
 		t.Fatalf("failed to get record: %v", err)
 	}


### PR DESCRIPTION
This refactors the proto that is sent to the ProxyBuffer to register an OT device. The RegistryRecord proto was added in a previous commit to simplify the interface to downstream registry services. This is the first step towards enabling a PA shim layer for translating device records for sending to various downstream registry services. 

Note: this relies on #58, only review the last commit.