### PR TITLE
[proxybuffer] launch proxybuffer and etcd containers

### DIFF
--- a/config/dev/containers/provapp.yml
+++ b/config/dev/containers/provapp.yml
@@ -64,6 +64,48 @@ spec:
         - CAP_MKNOD
         - CAP_NET_RAW
         - CAP_AUDIT_WRITE
+  # Configuration for the `pbserver` container.
+  - name: pbserver
+    args:
+    - --port=5002
+    - --etcd_endpoints="http://localhost:5003"
+    # TODO: Update label to point to specific release version.
+    image: localhost/pb_server:latest
+    resources: {}
+    ports:
+      - containerPort: 5002
+        hostPort: 5002
+    securityContext:
+      capabilities:
+        drop:
+        - CAP_MKNOD
+        - CAP_NET_RAW
+        - CAP_AUDIT_WRITE
+  # Configuration for the `etcd` container.
+  - name: etcd
+    command:
+    - etcd
+    args:
+    - --name
+    - 'pb'
+    - --data-dir
+    - '/pb-data'
+    - --listen-client-urls
+    - 'http://localhost:5003'
+    - --advertise-client-urls
+    - 'http://localhost:5003'
+    # TODO: Update label to point to specific release version.
+    image: localhost/pb_etcd:latest
+    resources: {}
+    ports:
+      - containerPort: 5003
+        hostPort: 5003
+    securityContext:
+      capabilities:
+        drop:
+        - CAP_MKNOD
+        - CAP_NET_RAW
+        - CAP_AUDIT_WRITE
   restartPolicy: Always
   volumes:
   - hostPath:

--- a/config/dev/deploy.sh
+++ b/config/dev/deploy.sh
@@ -2,6 +2,7 @@
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 ################################################################################
@@ -69,15 +70,19 @@ fi
 tar -xvf "${RELEASE_DIR}/hsmtool.tar.xz" --directory "${OPENTITAN_VAR_DIR}/bin"
 
 ################################################################################
-# Unpack the infrastructure release binaries (PA, SPM, etc.).
+# Unpack the infrastructure release binaries (PA, SPM, ProxyBuffer, etc.).
 ################################################################################
 echo "Unpacking release binaries and container images ..."
 mkdir -p "${OPENTITAN_VAR_DIR}/release"
 if [ -z "${CONTAINERS_ONLY}" ]; then
     tar -xvf "${RELEASE_DIR}/provisioning_appliance_binaries.tar.xz" \
         --directory "${OPENTITAN_VAR_DIR}/release"
+    tar -xvf "${RELEASE_DIR}/proxybuffer_binaries.tar.xz" \
+        --directory "${OPENTITAN_VAR_DIR}/release"
 else
     sudo cp "${RELEASE_DIR}/provisioning_appliance_containers.tar" \
+        "${OPENTITAN_VAR_DIR}/release/"
+    sudo cp "${RELEASE_DIR}/proxybuffer_containers.tar" \
         "${OPENTITAN_VAR_DIR}/release/"
     echo "Skipping unpacking raw binaries; deploying containers only ..."
 fi
@@ -98,6 +103,8 @@ infra_image = "podman_pause:latest"
 EOF
 podman load \
     -i "${OPENTITAN_VAR_DIR}/release/provisioning_appliance_containers.tar"
+podman load \
+    -i "${OPENTITAN_VAR_DIR}/release/proxybuffer_containers.tar"
 echo "Done."
 
 ################################################################################

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -30,6 +30,12 @@ container_bundle(
     },
 )
 
+filegroup(
+    name = "proxybuffer_containers_tar",
+    srcs = [":proxybuffer_containers"],
+    output_group = "tar",
+)
+
 pkg_tar(
     name = "provisioning_appliance_binaries",
     srcs = [
@@ -38,6 +44,12 @@ pkg_tar(
         "//src/spm:spm_server",
         "//src/spm:spmutil",
     ],
+    extension = "tar.xz",
+)
+
+pkg_tar(
+    name = "proxybuffer_binaries",
+    srcs = ["//src/proxy_buffer:pb_server"],
     extension = "tar.xz",
 )
 
@@ -71,6 +83,7 @@ release(
     artifacts = {
         ":deploy_dev": "Development deployment scripts",
         ":provisioning_appliance_binaries": "Provisioning Appliance binaries",
+        ":proxybuffer_binaries": "ProxyBuffer binaries",
         ":softhsm_dev": "SoftHSM2 development binaries",
         "//src/ate:windows": "ATE Win32 binaries",
         ":hsmtool": "hsmtool binaries",

--- a/util/containers/deploy_test_k8_pod.sh
+++ b/util/containers/deploy_test_k8_pod.sh
@@ -9,6 +9,7 @@ readonly REPO_TOP=$(git rev-parse --show-toplevel)
 
 # Build release containers.
 bazelisk build --stamp //release:provisioning_appliance_containers_tar
+bazelisk build --stamp //release:proxybuffer_containers_tar
 bazelisk build --stamp //release:softhsm_dev
 bazelisk build --stamp //release:hsmtool
 


### PR DESCRIPTION
During deployment of the provisioning infrastructure, also launch the proxybuffer and etcd containers. This is the first step before connecting the PA to the ProxyBuffer and testing E2E.