### PR TITLE
[proxy_buffer] Add support for sqlite backend.

### DIFF
--- a/config/dev/containers/provapp.yml
+++ b/config/dev/containers/provapp.yml
@@ -70,38 +70,13 @@ spec:
   - name: pbserver
     args:
     - --port=5002
-    - --etcd_endpoints=localhost:5003
+    - --db_path=file::memory:?cache=shared
     # TODO: Update label to point to specific release version.
     image: localhost/pb_server:latest
     resources: {}
     ports:
       - containerPort: 5002
         hostPort: 5002
-    securityContext:
-      capabilities:
-        drop:
-        - CAP_MKNOD
-        - CAP_NET_RAW
-        - CAP_AUDIT_WRITE
-  # Configuration for the `etcd` container.
-  - name: etcd
-    command:
-    - etcd
-    args:
-    - --name
-    - 'pb'
-    - --data-dir
-    - '/pb-data'
-    - --listen-client-urls
-    - 'http://localhost:5003'
-    - --advertise-client-urls
-    - 'http://localhost:5003'
-    # TODO: Update label to point to specific release version.
-    image: localhost/pb_etcd:latest
-    resources: {}
-    ports:
-      - containerPort: 5003
-        hostPort: 5003
     securityContext:
       capabilities:
         drop:

--- a/go.mod
+++ b/go.mod
@@ -1,23 +1,40 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
 module github.com/lowRISC/opentitan-provisioning
 
 go 1.19
 
 replace github.com/lowRISC/opentitan-provisioning => ./
 
+
+// This file is used to manage dependencies for the OpenTitan Provisioning
+// project. It is used by the Go toolchain to fetch dependencies and their
+// transitive dependencies.
+//
+// To update the dependencies, run `bazel run //:update-go-repos`.
+//
+// This project does not support the `go mod tidy` command.
 require (
+	// Required by Bazel golang infrastructure.
+	golang.org/x/tools v0.10.0
+
+	// OpenTitan Provisioning core dependencies.
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/tink/go v1.6.1
 	github.com/miekg/pkcs11 v1.0.3
-	go.etcd.io/etcd v3.3.27+incompatible
-	go.etcd.io/etcd/api/v3 v3.5.1
-	go.etcd.io/etcd/client/v3 v3.5.1
 	golang.org/x/crypto v0.23.0
 	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
-	golang.org/x/tools v0.10.0
 	google.golang.org/api v0.32.0
 	google.golang.org/grpc v1.41.0
+
+	// Proxy buffer backends.
+	go.etcd.io/etcd v3.3.27+incompatible
+	go.etcd.io/etcd/api/v3 v3.5.1
+	go.etcd.io/etcd/client/v3 v3.5.1
+	gorm.io/gorm v1.25.12
 
 	// Required by etcd.
 	github.com/coreos/go-semver v0.3.0
@@ -26,6 +43,12 @@ require (
 	go.uber.org/atomic v1.7.0
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.17.0
+
+	// Required by gorm.
+	github.com/mattn/go-sqlite3 v1.14.22
+	gorm.io/driver/sqlite v1.5.7
+	github.com/jinzhu/now v1.1.5
+	github.com/jinzhu/inflection v1.0.0
 
 	// Required by google.golang.org/grpc
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c

--- a/src/proxy_buffer/BUILD.bazel
+++ b/src/proxy_buffer/BUILD.bazel
@@ -28,8 +28,7 @@ PB_SERVER_DEPS = [
     "//src/proxy_buffer/proto:proxy_buffer_go_pb",
     "//src/proxy_buffer/services:proxybuffer",
     "//src/proxy_buffer/store:db",
-    "//src/proxy_buffer/store:etcd",
-    "@io_etcd_go_etcd_client_v3//:go_default_library",
+    "//src/proxy_buffer/store:filedb",
     "@org_golang_google_grpc//:go_default_library",
 ]
 

--- a/src/proxy_buffer/store/BUILD.bazel
+++ b/src/proxy_buffer/store/BUILD.bazel
@@ -68,3 +68,23 @@ go_test(
         "@org_golang_google_protobuf//testing/protocmp",
     ],
 )
+
+go_library(
+    name = "filedb",
+    srcs = ["filedb.go"],
+    importpath = "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/filedb",
+    deps = [
+        ":connector",
+        "@io_gorm_driver_sqlite//:go_default_library",
+        "@io_gorm_gorm//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "filedb_test",
+    srcs = ["filedb_test.go"],
+    deps = [
+        ":connector",
+        ":filedb",
+    ],
+)

--- a/src/proxy_buffer/store/filedb.go
+++ b/src/proxy_buffer/store/filedb.go
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package filedb implements a connector to a sqlite database.
+package filedb
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/connector"
+)
+
+type sqliteDB struct {
+	db *gorm.DB
+}
+
+// deviceSchema represents the schema of the device table.
+type deviceSchema struct {
+	gorm.Model
+	DeviceID string
+	SKU      string
+	Device   []byte
+}
+
+var writeMutex sync.Mutex
+
+// New creates a sqlite connector with an initialized gorm.DB instance.
+func New(db_path string) (connector.Connector, error) {
+	db, err := gorm.Open(sqlite.Open(db_path), &gorm.Config{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %v", err)
+	}
+
+	db.Exec("PRAGMA journal_mode=WAL;")
+	db.Exec("PRAGMA busy_timeout = 5000;")
+	db.Exec("PRAGMA synchronous=NORMAL;")
+
+	db.AutoMigrate(&deviceSchema{})
+	return &sqliteDB{db: db}, nil
+}
+
+// Insert adds a `key` `value` pair to the database. Multiple calls with the
+// same key will fail. Multiple calss with the same key will succeed.
+func (s *sqliteDB) Insert(ctx context.Context, key string, value []byte) error {
+	writeMutex.Lock()
+	defer writeMutex.Unlock()
+
+	r := s.db.Create(&deviceSchema{DeviceID: key, Device: value})
+	if r.Error != nil {
+		return fmt.Errorf("failed to insert data with key: %q, error: %v", key, r.Error)
+	}
+	return nil
+}
+
+// Get gets the latest insterted value associated with a given `key`.
+func (s *sqliteDB) Get(ctx context.Context, key string) ([]byte, error) {
+	var device deviceSchema
+	r := s.db.Last(&device, "device_id = ?", key)
+	if r.Error != nil {
+		return nil, fmt.Errorf("failed to get data associated with key: %q, error: %v", key, r.Error)
+	}
+	return device.Device, nil
+}

--- a/src/proxy_buffer/store/filedb_test.go
+++ b/src/proxy_buffer/store/filedb_test.go
@@ -1,0 +1,44 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package filedb_test implements unit tests for the filedb package.
+package filedb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/connector"
+	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/filedb"
+)
+
+func newDB(t *testing.T) connector.Connector {
+	c, err := filedb.New("file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	return c
+}
+
+func TestInsert(t *testing.T) {
+	db := newDB(t)
+	if err := db.Insert(context.Background(), "key", []byte("value")); err != nil {
+		t.Errorf("Insert failed: %v", err)
+	}
+}
+
+func TestGet(t *testing.T) {
+	db := newDB(t)
+	if err := db.Insert(context.Background(), "key", []byte("value")); err != nil {
+		t.Errorf("Insert failed: %v", err)
+	}
+
+	value, err := db.Get(context.Background(), "key")
+	if err != nil {
+		t.Errorf("Get failed: %v", err)
+	}
+	if string(value) != "value" {
+		t.Errorf("Get returned wrong value: got %q, want %q", value, "value")
+	}
+}

--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -56,6 +56,27 @@ def go_packages_():
         version = "v1.6.1",
     )
     go_repository(
+        name = "com_github_jinzhu_inflection",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/jinzhu/inflection",
+        sum = "h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=",
+        version = "v1.0.0",
+    )
+    go_repository(
+        name = "com_github_jinzhu_now",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/jinzhu/now",
+        sum = "h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=",
+        version = "v1.1.5",
+    )
+    go_repository(
+        name = "com_github_mattn_go_sqlite3",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/mattn/go-sqlite3",
+        sum = "h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=",
+        version = "v1.14.22",
+    )
+    go_repository(
         name = "com_github_miekg_pkcs11",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/miekg/pkcs11",
@@ -89,6 +110,20 @@ def go_packages_():
         importpath = "go.etcd.io/etcd/client/v3",
         sum = "h1:oImGuV5LGKjCqXdjkMHCyWa5OO1gYKCnC/1sgdfj1Uk=",
         version = "v3.5.1",
+    )
+    go_repository(
+        name = "io_gorm_driver_sqlite",
+        build_file_proto_mode = "disable_global",
+        importpath = "gorm.io/driver/sqlite",
+        sum = "h1:8NvsrhP0ifM7LX9G4zPB97NwovUakUxc+2V2uuf3Z1I=",
+        version = "v1.5.7",
+    )
+    go_repository(
+        name = "io_gorm_gorm",
+        build_file_proto_mode = "disable_global",
+        importpath = "gorm.io/gorm",
+        sum = "h1:I0u8i2hWQItBq1WfE0o2+WuL9+8L21K9e2HHSTE/0f8=",
+        version = "v1.25.12",
     )
     go_repository(
         name = "org_golang_google_api",


### PR DESCRIPTION
This change introduces the `filedb` module which implements a sqlite database backend with the gorm ORM library.

The `pb_server` was updated to use `filedb` as the backend. The `etcd` backend will be removed in a follow-up change.