### PR TITLE
[ate] Add `DeriveSymmetricKeys` call.

### DIFF
--- a/src/ate/ate_client.cc
+++ b/src/ate/ate_client.cc
@@ -13,6 +13,7 @@
 
 #include "absl/log/log.h"
 #include "absl/memory/memory.h"
+#include "absl/status/statusor.h"
 #include "src/pa/proto/pa.grpc.pb.h"
 #include "src/transport/service_credentials.h"
 
@@ -26,6 +27,10 @@ using pa::CloseSessionRequest;
 using pa::CloseSessionResponse;
 using pa::CreateKeyAndCertRequest;
 using pa::CreateKeyAndCertResponse;
+using pa::DeriveSymmetricKeysRequest;
+using pa::DeriveSymmetricKeysResponse;
+using pa::EndorseCertsRequest;
+using pa::EndorseCertsResponse;
 using pa::InitSessionRequest;
 using pa::InitSessionResponse;
 using pa::ProvisioningApplianceService;
@@ -128,6 +133,32 @@ Status AteClient::CreateKeyAndCert(const std::string& sku,
 
   // The actual RPC - call the server's CreateKeyAndCert method.
   return stub_->CreateKeyAndCert(&context, request, reply);
+}
+
+Status AteClient::EndorseCerts(EndorseCertsRequest& request,
+                               EndorseCertsResponse* reply) {
+  LOG(INFO) << "AteClient::EndorseCerts";
+
+  // Context for the client (It could be used to convey extra information to
+  // the server and/or tweak certain RPC behaviors).
+  ClientContext context;
+  context.AddMetadata("authorization", sku_session_token_);
+
+  // The actual RPC - call the server's EndorseCerts method.
+  return stub_->EndorseCerts(&context, request, reply);
+}
+
+Status AteClient::DeriveSymmetricKeys(DeriveSymmetricKeysRequest& request,
+                                      DeriveSymmetricKeysResponse* reply) {
+  LOG(INFO) << "AteClient::DeriveSymmetricKeys";
+
+  // Context for the client (It could be used to convey extra information to
+  // the server and/or tweak certain RPC behaviors).
+  ClientContext context;
+  context.AddMetadata("authorization", sku_session_token_);
+
+  // The actual RPC - call the server's DeriveSymmetricKeys method.
+  return stub_->DeriveSymmetricKeys(&context, request, reply);
 }
 
 Status AteClient::RegisterDevice(RegistrationRequest& request,

--- a/src/ate/ate_client.h
+++ b/src/ate/ate_client.h
@@ -68,6 +68,14 @@ class AteClient {
                                 const size_t serial_number_size,
                                 pa::CreateKeyAndCertResponse* reply);
 
+  // Calls the server's EndorseCerts method and returns its reply.
+  grpc::Status EndorseCerts(pa::EndorseCertsRequest& request,
+                            pa::EndorseCertsResponse* reply);
+
+  // Calls the server's DeriveSymmetricKeys method and returns its reply.
+  grpc::Status DeriveSymmetricKeys(pa::DeriveSymmetricKeysRequest& request,
+                                   pa::DeriveSymmetricKeysResponse* reply);
+
   // Calls the server's RegisterDevice method and returns its reply.
   grpc::Status RegisterDevice(pa::RegistrationRequest& request,
                               pa::RegistrationResponse* reply);

--- a/src/ate/ate_client_test.cc
+++ b/src/ate/ate_client_test.cc
@@ -22,6 +22,10 @@ namespace {
 
 using pa::CreateKeyAndCertRequest;
 using pa::CreateKeyAndCertResponse;
+using pa::DeriveSymmetricKeysRequest;
+using pa::DeriveSymmetricKeysResponse;
+using pa::EndorseCertsRequest;
+using pa::EndorseCertsResponse;
 using pa::MockProvisioningApplianceServiceStub;
 using testing::_;
 using testing::DoAll;
@@ -66,6 +70,52 @@ TEST_F(AteTest, CreateKeyAndCertCallsServer) {
   EXPECT_THAT(
       ate_->CreateKeyAndCert("abc123", serial, sizeof(serial), &result).ok(),
       IsTrue());
+  EXPECT_THAT(result, EqualsProto(response));
+}
+
+TEST_F(AteTest, EndorseCerts) {
+  // Response that will be sent back for EndorseCerts.
+  auto response = ParseTextProto<EndorseCertsResponse>(R"pb(
+    certs: { blob: "fake-cert-blob" })pb");
+
+  // Expect EndorseCerts to be called.
+  // The 2nd arg is expected to be a protobuf with the `sku` field.
+  // We'll return the `response` struct and a status of `OK`.
+  EXPECT_CALL(*pa_service_, EndorseCerts(_, EqualsProto(R"pb(
+                                           sku: "abc123"
+                                         )pb"),
+                                         _))
+      .WillOnce(DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
+
+  EndorseCertsRequest request;
+  request.set_sku("abc123");
+
+  // Call the AteClient and verify it returns OK with the expected response.
+  EndorseCertsResponse result;
+  EXPECT_THAT(ate_->EndorseCerts(request, &result).ok(), IsTrue());
+  EXPECT_THAT(result, EqualsProto(response));
+}
+
+TEST_F(AteTest, DeriveSymmetricKeys) {
+  // Response that will be sent back for DeriveSymmetricKeys.
+  auto response = ParseTextProto<DeriveSymmetricKeysResponse>(R"pb(
+    keys: "fake-key-blob")pb");
+
+  // Expect DeriveSymmetricKeys to be called.
+  // The 2nd arg is expected to be a protobuf with the `sku` field.
+  // We'll return the `response` struct and a status of `OK`.
+  EXPECT_CALL(*pa_service_, DeriveSymmetricKeys(_, EqualsProto(R"pb(
+                                                  sku: "abc123"
+                                                )pb"),
+                                                _))
+      .WillOnce(DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
+
+  DeriveSymmetricKeysRequest request;
+  request.set_sku("abc123");
+
+  // Call the AteClient and verify it returns OK with the expected response.
+  pa::DeriveSymmetricKeysResponse result;
+  EXPECT_THAT(ate_->DeriveSymmetricKeys(request, &result).ok(), IsTrue());
   EXPECT_THAT(result, EqualsProto(response));
 }
 


### PR DESCRIPTION
This change adds the following functions to the ate_api.h library:

1. `AllocateDeriveSymmetricKeyResponse`: Allocates memory for a `DeriveSymmetricKeyResponse` call.
2. `FreeDeriveSymmetricKeyResponse`: Releases the memory allocated by `AllocateDeriveSymmetricKeyResponse`. This function must be called after the caller is done processing the data.
3. `DeriveSymmetricKeys`: Calls the provisioning appliance backend to request symmetric keys. The function performs the conversion from C++ C data structures.

The `ate_dll` implementation uses C data structures to be able to be integrated with older compilers with limited C++ support.