### PR TITLE
[ate] Add `EndorseCerts()` to ate_api.h.

### DIFF
--- a/src/ate/BUILD.bazel
+++ b/src/ate/BUILD.bazel
@@ -58,6 +58,8 @@ cc_binary(
     deps = [
         ":ate_client",
         "//src/pa/proto:pa_cc_grpc",
+        "//src/proto/crypto:common_cc_proto",
+        "//src/proto/crypto:ecdsa_cc_proto",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -75,6 +75,68 @@ typedef struct DeviceId {
 #pragma pack(pop)
 
 /**
+ * Hash types supported by the provisioning service.
+ */
+typedef enum hash_type {
+  /** Hash type SHA256. */
+  kHashTypeSha256 = 1,
+} hash_type_t;
+
+/**
+ * Curve types supported by the provisioning service.
+ */
+typedef enum curve_type {
+  /** Curve type P256. */
+  kCurveTypeP256 = 1,
+} curve_type_t;
+
+/**
+ * Signature encoding types supported by the provisioning service.
+ */
+typedef enum signature_encoding {
+  /** Signature encoding DER. */
+  kSignatureEncodingDer = 1,
+} signature_encoding_t;
+
+/**
+ * Request parameters for endorsing certificates.
+ */
+typedef struct endorse_cert_request {
+  /** Hash mechanism. */
+  hash_type_t hash_type;
+  /** ECC Curve type. */
+  curve_type_t curve_type;
+  /** Signature encoding type. */
+  signature_encoding_t signature_encoding;
+  /** Signing key label. */
+  const char* key_label;
+  /** Size of the TBS data. */
+  size_t tbs_size;
+  /**
+   * TBS data to sign.
+   *
+   * This field should be allocated by the caller to store the TBS data.
+   */
+  const char* tbs;
+} endorse_cert_request_t;
+
+/**
+ * Response parameters for endorsing certificates.
+ */
+typedef struct endorse_cert_response {
+  /**
+   * The size of the buffer pointed by `cert`. The user should set the size
+   * allocated before calling the `EndorseCerts()` function. The funtion will
+   * update the value with the actual certificate size.
+   */
+  size_t size;
+  /**
+   * The endorsed certificate.
+   */
+  char* cert;
+} endorse_cert_response_t;
+
+/**
  * Symmetric key seed type. The seed is provisioned by the manufacturer.
  */
 typedef enum symmetric_key_seed {
@@ -256,6 +318,27 @@ DLLEXPORT int CreateKeyAndCertificate(ate_client_ptr client, const char* sku,
 DLLEXPORT int DeriveSymmetricKeys(
     ate_client_ptr client, const char* sku, size_t keys_count,
     const derive_symmetric_key_params_t* key_params, symmetric_key_t* keys);
+
+/**
+ * Endorse certificates.
+ *
+ * The function endorses certificates based on the request parameters.
+ *
+ * The `certs` parameter should be allocated by the caller to store the
+ * endorsed certificates, and each `cert.size` field should represent the
+ * allocated size of the `cert.cert` buffer.
+ *
+ * @param client A client instance.
+ * @param sku The SKU of the product to endorse the certificates for.
+ * @param cert_count The number of certificates to endorse.
+ * @param request The request parameters for the certificate endorsement.
+ * @param[out] certs The endorsed certificates.
+ * @return The result of the operation.
+ */
+DLLEXPORT int EndorseCerts(ate_client_ptr client, const char* sku,
+                           size_t cert_count,
+                           const endorse_cert_request_t* request,
+                           endorse_cert_response_t* certs);
 
 #ifdef __cplusplus
 }

--- a/src/pa/loadtest.go
+++ b/src/pa/loadtest.go
@@ -204,11 +204,7 @@ func testOTEndorseCerts(ctx context.Context, numCalls int, skuName string, c *cl
 						},
 					},
 				},
-				Certs: []*pbc.Certificate{
-					{
-						Blob: tbs,
-					},
-				},
+				Tbs: tbs,
 			},
 		},
 	}

--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -33,8 +33,8 @@ service ProvisioningApplianceService {
 message EndorseCertBundle {
   // Certificate signing key parameters. Required.
   crypto.cert.SigningKeyParams key_params = 1;
-  // Array of TBS certificates to be endorsed. Required.
-  repeated crypto.cert.Certificate certs = 2;
+  // TBS certificate to be endorsed. Required.
+  bytes tbs = 2;
 }
 
 // Endorse certs request.

--- a/src/proto/crypto/BUILD.bazel
+++ b/src/proto/crypto/BUILD.bazel
@@ -5,6 +5,7 @@
 # OT Provisioning Protobuf Definitions for Cryptographic Primitives
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -31,6 +32,11 @@ proto_library(
     srcs = ["common.proto"],
 )
 
+cc_proto_library(
+    name = "common_cc_proto",
+    deps = [":common_proto"],
+)
+
 go_proto_library(
     name = "common_go_pb",
     importpath = "github.com/lowRISC/opentitan-provisioning/src/proto/crypto/common_go_pb",
@@ -43,6 +49,11 @@ proto_library(
     deps = [
         ":common_proto",
     ],
+)
+
+cc_proto_library(
+    name = "ecdsa_cc_proto",
+    deps = [":ecdsa_proto"],
 )
 
 go_proto_library(

--- a/src/spm/services/spm.go
+++ b/src/spm/services/spm.go
@@ -368,13 +368,11 @@ func (s *server) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequ
 				KeyLabel:           bundle.KeyParams.KeyLabel,
 				SignatureAlgorithm: ecdsaSignatureAlgorithmFromHashType(key.EcdsaParams.HashType),
 			}
-			for _, tbs := range bundle.Certs {
-				cert, err := sku.seHandle.EndorseCert(tbs.Blob, params)
-				if err != nil {
-					return nil, status.Errorf(codes.Internal, "could not endorse cert: %v", err)
-				}
-				certs = append(certs, &pbc.Certificate{Blob: cert})
+			cert, err := sku.seHandle.EndorseCert(bundle.Tbs, params)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "could not endorse cert: %v", err)
 			}
+			certs = append(certs, &pbc.Certificate{Blob: cert})
 		default:
 			return nil, status.Errorf(codes.Unimplemented, "unsupported key format")
 		}


### PR DESCRIPTION
1. Simplify `EndorseCerts()` API in the provisioning appliance service to avoid having to support multiple certs per key associations in the ATE C interface.
2. Implement `EndorseCerts()` in the ATE C library.