### PR TITLE
[skucfg] Move SKU settings to their own package.

### DIFF
--- a/src/cert/templates/BUILD.bazel
+++ b/src/cert/templates/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         ":tpm",
         "//src/cert:signer",
         "//src/spm/services:certloader",
+        "//src/spm/services:skucfg",
         "//src/utils",
         "@io_bazel_rules_go//go/tools/bazel",
     ],

--- a/src/cert/templates/tpm_test.go
+++ b/src/cert/templates/tpm_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lowRISC/opentitan-provisioning/src/cert/signer"
 	"github.com/lowRISC/opentitan-provisioning/src/cert/templates/tpm"
 	"github.com/lowRISC/opentitan-provisioning/src/spm/services/certloader"
+	"github.com/lowRISC/opentitan-provisioning/src/spm/services/skucfg"
 	"github.com/lowRISC/opentitan-provisioning/src/utils"
 )
 
@@ -88,7 +89,7 @@ func TestCertFormat(t *testing.T) {
 	}
 
 	subjectAltName, err := certloader.BuildSubjectAltName(
-		certloader.CertificateSubjectAltName{
+		skucfg.CertificateSubjectAltName{
 			Manufacturer: "id:4E544300",
 			Model:        "NPCT75x",
 			Version:      "id:00070002",

--- a/src/spm/services/BUILD.bazel
+++ b/src/spm/services/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     deps = [
         ":certloader",
         ":se",
+        ":skucfg",
         "//src/cert:signer",
         "//src/cert/templates:tpm",
         "//src/pa/proto:pa_go_pb",
@@ -45,9 +46,9 @@ go_library(
     srcs = ["certloader.go"],
     importpath = "github.com/lowRISC/opentitan-provisioning/src/spm/services/certloader",
     deps = [
+        ":skucfg",
         "//src/cert:signer",
         "//src/cert/templates:tpm",
-        "//src/proto/crypto:common_go_pb",
         "//src/utils",
         "@io_bazel_rules_go//go/tools/bazel",
         "@org_golang_google_grpc//codes",
@@ -78,6 +79,7 @@ go_test(
     embed = [":se"],
     deps = [
         ":certloader",
+        ":skucfg",
         "//src/cert:signer",
         "//src/cert/templates:tpm",
         "//src/pk11",
@@ -87,5 +89,14 @@ go_test(
         "@io_bazel_rules_go//go/tools/bazel",
         "@org_golang_x_crypto//hkdf",
         "@org_golang_x_crypto//sha3",
+    ],
+)
+
+go_library(
+    name = "skucfg",
+    srcs = ["skucfg.go"],
+    importpath = "github.com/lowRISC/opentitan-provisioning/src/spm/services/skucfg",
+    deps = [
+        "//src/proto/crypto:common_go_pb",
     ],
 )

--- a/src/spm/services/se_pk11_test.go
+++ b/src/spm/services/se_pk11_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/lowRISC/opentitan-provisioning/src/pk11"
 	ts "github.com/lowRISC/opentitan-provisioning/src/pk11/test_support"
 	certloader "github.com/lowRISC/opentitan-provisioning/src/spm/services/certloader"
+	"github.com/lowRISC/opentitan-provisioning/src/spm/services/skucfg"
 )
 
 const (
@@ -321,7 +322,7 @@ func TestGenerateCert(t *testing.T) {
 	b := tpm.New()
 
 	subjectAltName, err := certloader.BuildSubjectAltName(
-		certloader.CertificateSubjectAltName{
+		skucfg.CertificateSubjectAltName{
 			Manufacturer: "id:4E544300",
 			Model:        "NPCT75x",
 			Version:      "id:00070002",

--- a/src/spm/services/skucfg.go
+++ b/src/spm/services/skucfg.go
@@ -1,0 +1,106 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package skucfg provides the configuration for a SKU.
+package skucfg
+
+import (
+	"fmt"
+
+	pbcommon "github.com/lowRISC/opentitan-provisioning/src/proto/crypto/common_go_pb"
+)
+
+// AttrName is an attribute name.
+type AttrName string
+
+const (
+	AttrNameSymmetricWrappingMethod AttrName = "symmetricWrappingMethod"
+)
+
+// WrappingMethod provides the wrapping method for symmetric keys.
+type WrappingMethod string
+
+const (
+	WrappingMethodNone     WrappingMethod = "none"
+	WrappingMethodRSAPKCS1                = "rsa-pkcs"
+	WrappingMethodRSAOAEP                 = "rsa-oaep"
+)
+
+type Config struct {
+	Sku             string                    `yaml:"sku"`
+	SlotID          int                       `yaml:"slotId"`
+	NumSessions     int                       `yaml:"numSessions"`
+	SymmetricKeys   []SymmetricKey            `yaml:"symmetricKeys"`
+	PrivateKeys     []PrivateKey              `yaml:"privateKeys"`
+	PublicKeys      []PublicKey               `yaml:"publicKeys"`
+	Keys            []Key                     `yaml:"keyWrapConfig"`
+	Certs           []Certificate             `yaml:"certs"`
+	CertTemplates   []Certificate             `yaml:"certTemplates"`
+	CertTemplateSan CertificateSubjectAltName `yaml:"certTemplateSAN"`
+	Attributes      map[string]string         `yaml:"attributes"`
+}
+
+// KeyType is a type of key to generate.
+type KeyType string
+
+// KeyName represents signature algorithm.
+type KeyName int
+
+const (
+	Secp256r1 KeyName = iota
+	Secp384r1
+	RSA2048
+	RSA3072
+	RSA4096
+)
+
+type Key struct {
+	Type KeyType           `yaml:"type"`
+	Size int               `yaml:"size"`
+	Name KeyName           `yaml:"name"`
+	Hash pbcommon.HashType `yaml:"hash"`
+	Exp  []byte            `yaml:"exp"`
+}
+
+type SymmetricKey struct {
+	Name string `yaml:"name"`
+}
+
+type PublicKey struct {
+	Name string `yaml:"name"`
+}
+
+type PrivateKey struct {
+	Name          string `yaml:"name"`
+	EnsorsingCert string `yaml:"endorsingCert"`
+}
+
+type CertificateSubjectAltName struct {
+	Manufacturer string `yaml:"tpmManufacturer"`
+	Model        string `yaml:"tpmModel"`
+	Version      string `yaml:"tpmVersion"`
+}
+
+type Certificate struct {
+	Name string `yaml:"name"`
+	Path string `yaml:"path"`
+}
+
+type SkuAuth struct {
+	SkuAuth string   `yaml:"skuAuth"`
+	Methods []string `yaml:"methods"`
+}
+
+type Auth struct {
+	SkuAuthCfgList map[string]SkuAuth `yaml:"skuAuthCfgList"`
+}
+
+// GetAttribute returns the value of the attribute with the given name.
+func (c *Config) GetAttribute(name AttrName) (string, error) {
+	attr, ok := c.Attributes[string(name)]
+	if !ok {
+		return "", fmt.Errorf("attribute %s not found", name)
+	}
+	return attr, nil
+}


### PR DESCRIPTION
Move all SKU configuration settings to their own package to simplify maintenance. Add `PublicKeys`, and `Attributes` settings.

The `Attributes` setting will be used as a key-value store to manage general configuration settings.