### PR TITLE
[pa/spm] Add support for deriving new symmetric keys.

### DIFF
--- a/src/ate/ate_client_test.cc
+++ b/src/ate/ate_client_test.cc
@@ -98,8 +98,10 @@ TEST_F(AteTest, EndorseCerts) {
 
 TEST_F(AteTest, DeriveSymmetricKeys) {
   // Response that will be sent back for DeriveSymmetricKeys.
-  auto response = ParseTextProto<DeriveSymmetricKeysResponse>(R"pb(
-    keys: "fake-key-blob")pb");
+  auto response = ParseTextProto<DeriveSymmetricKeysResponse>(
+      R"pb(
+        keys: { key: "foobar" }
+      )pb");
 
   // Expect DeriveSymmetricKeys to be called.
   // The 2nd arg is expected to be a protobuf with the `sku` field.

--- a/src/ate/ate_dll.cc
+++ b/src/ate/ate_dll.cc
@@ -417,8 +417,9 @@ DLLEXPORT int DeriveSymmetricKeys(
   }
 
   for (int i = 0; i < resp.keys_size(); i++) {
-    auto &key = resp.keys(i);
+    auto &sk = resp.keys(i);
     auto &resp_key = keys[i];
+    auto key = sk.key();
 
     if (key.size() > sizeof(resp_key.key)) {
       LOG(ERROR) << "DeriveSymmetricKeys failed- key size is too big: "

--- a/src/pa/loadtest.go
+++ b/src/pa/loadtest.go
@@ -152,24 +152,28 @@ func testOTDeriveSymmetricKeys(ctx context.Context, numCalls int, skuName string
 				Type:        pbp.SymmetricKeyType_SYMMETRIC_KEY_TYPE_RAW,
 				Size:        pbp.SymmetricKeySize_SYMMETRIC_KEY_SIZE_128_BITS,
 				Diversifier: "test_unlock",
+				WrapSeed:    false,
 			},
 			{
 				Seed:        pbp.SymmetricKeySeed_SYMMETRIC_KEY_SEED_LOW_SECURITY,
 				Type:        pbp.SymmetricKeyType_SYMMETRIC_KEY_TYPE_RAW,
 				Size:        pbp.SymmetricKeySize_SYMMETRIC_KEY_SIZE_128_BITS,
 				Diversifier: "test_exit",
+				WrapSeed:    false,
 			},
 			{
 				Seed:        pbp.SymmetricKeySeed_SYMMETRIC_KEY_SEED_HIGH_SECURITY,
 				Type:        pbp.SymmetricKeyType_SYMMETRIC_KEY_TYPE_HASHED_OT_LC_TOKEN,
 				Size:        pbp.SymmetricKeySize_SYMMETRIC_KEY_SIZE_128_BITS,
 				Diversifier: "rma,device_id",
+				WrapSeed:    false,
 			},
 			{
 				Seed:        pbp.SymmetricKeySeed_SYMMETRIC_KEY_SEED_HIGH_SECURITY,
 				Type:        pbp.SymmetricKeyType_SYMMETRIC_KEY_TYPE_RAW,
 				Size:        pbp.SymmetricKeySize_SYMMETRIC_KEY_SIZE_256_BITS,
 				Diversifier: "was,device_id",
+				WrapSeed:    false,
 			},
 		},
 	}

--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -59,6 +59,9 @@ enum SymmetricKeySeed {
   SYMMETRIC_KEY_SEED_LOW_SECURITY = 1;
   // High Security: seed is rotated frequently.
   SYMMETRIC_KEY_SEED_HIGH_SECURITY = 2;
+  // Keygen: seed is a new generic key seed. The SPM does not store the seed in
+  // non-volatile memory.
+  SYMMETRIC_KEY_SEED_KEYGEN = 3;
 }
 
 // Symmetric key type.
@@ -101,6 +104,11 @@ message SymmetricKeygenParams{
   SymmetricKeySize size = 3;
   // Diversifier string to use in KDF operation. Required.
   string diversifier = 4;
+  // Returned wrapped seed in the response. Required.
+  // The seed is wrapped with a public key associated with the SKU. The client
+  // can use this seed to derive symmetric keys in the future. Set to true if
+  // using `SYMMETRIC_KEY_SEED_KEYGEN`.
+  bool wrap_seed = 5;
 }
 
 // Derive symmetric keys request.
@@ -111,10 +119,18 @@ message DeriveSymmetricKeysRequest{
   repeated SymmetricKeygenParams params = 2;
 }
 
+// Symmetric key.
+message SymmetricKey {
+  // Key. Size is provided in the request.
+  bytes key = 1;
+  // Wrapped seed. Required if `wrap_seed` is set in the request.
+  bytes wrapped_seed = 2;
+}
+
 // Derive symmetric keys response.
 message DeriveSymmetricKeysResponse{
-  // Key bytes. Size is provided in the request.
-  repeated bytes keys = 1;
+  // Key. Size is provided in the request.
+  repeated SymmetricKey keys = 1;
 }
 
 // Create key and endorsement certificates request.

--- a/src/spm/services/se.go
+++ b/src/spm/services/se.go
@@ -59,8 +59,8 @@ const (
 	// SymmetricKeyTypeSecurityLo indicates that the key should be a low
 	// security key.
 	SymmetricKeyTypeSecurityLo
-	// SymmetricKeyTypeRandom indicates that the key should be a random key.
-	SymmetricKeyTypeRandom
+	// SymmetricKeyTypeKeyGen indicates that the key should be a new key.
+	SymmetricKeyTypeKeyGen
 )
 
 // SymmetricKeyWrap specifies the wrapping mechanism for the key.

--- a/src/spm/services/se_pk11.go
+++ b/src/spm/services/se_pk11.go
@@ -374,7 +374,7 @@ func (h *HSM) GenerateSymmetricKeys(params []*SymmetricKeygenParams) ([]Symmetri
 	symmetricKeys := []SymmetricKeyResult{}
 	for _, p := range params {
 		// Only support extracting random keys using a wrapping key.
-		if p.KeyType != SymmetricKeyTypeRandom && p.Wrap != SymmetricKeyWrapNone {
+		if p.KeyType != SymmetricKeyTypeKeyGen && p.Wrap != SymmetricKeyWrapNone {
 			return nil, status.Errorf(codes.Internal, "unsupported key type %v and wrap %v", p.KeyType, p.Wrap)
 		}
 
@@ -400,7 +400,7 @@ func (h *HSM) GenerateSymmetricKeys(params []*SymmetricKeygenParams) ([]Symmetri
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to get KLsks key object: %v", err)
 			}
-		case SymmetricKeyTypeRandom:
+		case SymmetricKeyTypeKeyGen:
 			seed, err = session.GenerateGenericSecret(
 				p.SizeInBits,
 				&pk11.KeyOptions{

--- a/src/spm/services/se_pk11_test.go
+++ b/src/spm/services/se_pk11_test.go
@@ -214,7 +214,7 @@ func TestGenerateSymmKeysWrap(t *testing.T) {
 
 	// RMA token
 	rmaParams := SymmetricKeygenParams{
-		KeyType:     SymmetricKeyTypeRandom,
+		KeyType:     SymmetricKeyTypeKeyGen,
 		KeyOp:       SymmetricKeyOpHashedOtLcToken,
 		SizeInBits:  128,
 		Sku:         "test sku",


### PR DESCRIPTION
This change updates the `GenerateSymmetricKeys` API to add support for
symmetric key generation. Symmetric keys are ephemeral, thus the caller
is required to request a `wrapped_seed` with the result which will
return the seed encrypted by a public key.

Only review the last commit.