### PR TITLE
[pk11] Remove support for HSMType.

### DIFF
--- a/config/dev/spm/sku_tpm_1.yml
+++ b/config/dev/spm/sku_tpm_1.yml
@@ -34,3 +34,5 @@ keyWrapConfig:
 certs:
     - name: "RootCA"
       path: certs/NuvotonTPMRootCA0200.cer
+attributes:
+  WrappingMechanism: AesKwp

--- a/config/prod/containers/provapp.yml
+++ b/config/prod/containers/provapp.yml
@@ -14,7 +14,6 @@ spec:
   - name: spmserver
     args:
     - --port=5000
-    - --hsm_type=1
     - --hsm_so=/usr/safenet/lunaclient/lib/libCryptoki2_64.so
     - --spm_config_dir=/var/lib/opentitan/spm
     # TODO: Update label to point to specific release version.

--- a/src/pk11/ecdsa.go
+++ b/src/pk11/ecdsa.go
@@ -54,10 +54,6 @@ func (s *Session) GenerateECDSA(curve elliptic.Curve, opts *KeyOptions) (KeyPair
 		return KeyPair{}, err
 	}
 
-	sensitive := !opts.Extractable
-	if s.tok.m.hsmType == HSMTypeHW {
-		sensitive = true
-	}
 	mech := pkcs11.NewMechanism(pkcs11.CKM_EC_KEY_PAIR_GEN, nil)
 	pubTpl := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, oid),
@@ -68,7 +64,7 @@ func (s *Session) GenerateECDSA(curve elliptic.Curve, opts *KeyOptions) (KeyPair
 	privTpl := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_EC),
 		pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
-		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, sensitive),
+		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, opts.Sensitive),
 		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, opts.Extractable),
 		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, opts.Token),
 	}

--- a/src/pk11/kdf.go
+++ b/src/pk11/kdf.go
@@ -42,15 +42,10 @@ func (s *Session) GenerateGenericSecret(keyBitLen uint, opts *KeyOptions) (Secre
 	}
 	mech := pkcs11.NewMechanism(pkcs11.CKM_GENERIC_SECRET_KEY_GEN, nil)
 
-	sensitive := !opts.Extractable
-	if s.tok.m.hsmType == HSMTypeHW {
-		sensitive = true
-	}
-
 	tpl := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_VALUE_LEN, keyBitLen/8),
 		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_GENERIC_SECRET),
-		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, sensitive),
+		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, opts.Sensitive),
 		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, opts.Extractable),
 		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, opts.Token),
 		pkcs11.NewAttribute(pkcs11.CKA_WRAP, true),
@@ -301,15 +296,10 @@ func (s *Session) UnwrapKDFKey(key []byte, pko PrivateKey, m KdfWrapMechanism, o
 		opts = &KeyOptions{}
 	}
 
-	sensitive := !opts.Extractable
-	if s.tok.m.hsmType == HSMTypeHW {
-		sensitive = true
-	}
-
 	tpl := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_SECRET_KEY),
 		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_GENERIC_SECRET),
-		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, sensitive),
+		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, opts.Sensitive),
 		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, opts.Extractable),
 		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, opts.Token),
 		pkcs11.NewAttribute(pkcs11.CKA_WRAP, true),

--- a/src/pk11/kwp_test.go
+++ b/src/pk11/kwp_test.go
@@ -41,7 +41,7 @@ func TestAESKWPWrapPrivate(t *testing.T) {
 			pubi, err := kp.PublicKey.ExportKey()
 			ts.Check(t, err)
 			pub := pubi.(*ecdsa.PublicKey)
-			wrap, _, err := ko.WrapAES(kp.PrivateKey)
+			wrap, err := ko.WrapAESKWP(kp.PrivateKey)
 			ts.Check(t, err)
 
 			kwp, err := kwp.NewKWP(key)
@@ -83,7 +83,7 @@ func TestAESKWPWrapSecret(t *testing.T) {
 			ts.Check(t, err)
 			wrapped := wi.(pk11.AESKey)
 
-			wrap, _, err := ko.WrapAES(wo)
+			wrap, err := ko.WrapAESKWP(wo)
 			ts.Check(t, err)
 
 			kwp, err := kwp.NewKWP(key)

--- a/src/pk11/object.go
+++ b/src/pk11/object.go
@@ -40,13 +40,13 @@ type KeyOptions struct {
 	//
 	// Not all HSMs may permit this on some key types.
 	Extractable bool
+	// Sensitive keys cannot be exported in plaintext on the HSM.
+	Sensitive bool
 	// Set to true to make key a token object or false to make a session
 	// object.
 	Token bool
-
 	// Set to true to allow the key to be used for encryption/decryption.
 	Encryption bool
-
 	// Set to true to allow the key to be used for wrapping/unwrapping other keys.
 	Wrapping bool
 }

--- a/src/pk11/pk11.go
+++ b/src/pk11/pk11.go
@@ -20,17 +20,6 @@ import (
 	"github.com/miekg/pkcs11"
 )
 
-// HSMType is used to distinguish between SoftHSM versus Hardware specific
-// HSM features.
-type HSMType int64
-
-const (
-	// HSMTypeSoft is use to qualify SoftHSM specific functionality.
-	HSMTypeSoft HSMType = iota
-	// HSMTypeHW is use to qualify hardware HSM specific functionality.
-	HSMTypeHW
-)
-
 // Error represents a wrapped pkcs11.Error
 type Error struct {
 	// The raw error code returned by the library.
@@ -63,14 +52,13 @@ func (e Error) Error() string {
 type Mod struct {
 	ctx     *pkcs11.Ctx
 	version pkcs11.Version
-	hsmType HSMType
 }
 
 // Load loads a PKCS#11 plugin located at soPath.
 //
 // This operation can be quite slow, so it is recommended to call it from another
 // goroutine.
-func Load(hsmType HSMType, soPath string) (*Mod, error) {
+func Load(soPath string) (*Mod, error) {
 	ctx := pkcs11.New(soPath)
 	if ctx == nil {
 		return nil, fmt.Errorf("could not load module %q", soPath)
@@ -85,7 +73,7 @@ func Load(hsmType HSMType, soPath string) (*Mod, error) {
 		return nil, newError(err, "could not retrieve module information")
 	}
 
-	return &Mod{ctx, info.CryptokiVersion, hsmType}, nil
+	return &Mod{ctx, info.CryptokiVersion}, nil
 }
 
 // Raw returns the wrapped PKCS#11 context for performing operations on directly.

--- a/src/pk11/rsa.go
+++ b/src/pk11/rsa.go
@@ -26,10 +26,6 @@ func (s *Session) GenerateRSA(modBits uint, pubExp uint, opts *KeyOptions) (KeyP
 	}
 
 	mech := pkcs11.NewMechanism(pkcs11.CKM_RSA_PKCS_KEY_PAIR_GEN, nil)
-	sensitive := !opts.Extractable
-	if s.tok.m.hsmType == HSMTypeHW {
-		sensitive = true
-	}
 
 	pubTpl := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_MODULUS_BITS, modBits),
@@ -44,7 +40,7 @@ func (s *Session) GenerateRSA(modBits uint, pubExp uint, opts *KeyOptions) (KeyP
 	privTpl := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_RSA),
 		pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
-		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, sensitive),
+		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, opts.Sensitive),
 		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, opts.Extractable),
 		pkcs11.NewAttribute(pkcs11.CKA_LABEL, "privRSA"),
 		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, opts.Token),

--- a/src/pk11/test_support.go
+++ b/src/pk11/test_support.go
@@ -125,7 +125,7 @@ func loadSoftHSM() *pk11.Mod {
 		return nil
 	}
 
-	m, err := pk11.Load(pk11.HSMTypeSoft, Plugin())
+	m, err := pk11.Load(Plugin())
 	if err != nil {
 		panic(err)
 	}

--- a/src/pk11/tool/commands.go
+++ b/src/pk11/tool/commands.go
@@ -84,7 +84,7 @@ type State struct {
 // PKCS#11 module.
 func New(modPath string) (*State, error) {
 	m, err := offload(fmt.Sprintf("loading PKCS#11 module %q", modPath), func() (any, error) {
-		return pk11.Load(pk11.HSMTypeSoft, modPath)
+		return pk11.Load(modPath)
 	})
 	if err != nil {
 		return nil, err

--- a/src/spm/services/se.go
+++ b/src/spm/services/se.go
@@ -10,6 +10,26 @@ import (
 	"crypto/x509"
 )
 
+// WrappingMechanism specifies the wrapping mechanism for the key.
+type WrappingMechanism int
+
+const (
+	// WrappingMechanismNone indicates that the key should not be wrapped.
+	WrappingMechanismNone WrappingMechanism = iota
+	// WrappingMechanismRSAPCKS indicates that the key should be wrapped using
+	// RSA PKCS#1.5.
+	WrappingMechanismRSAPCKS
+	// WrappingMechanismRSAOAEP indicates that the key should be wrapped using
+	// RSA OAEP.
+	WrappingMechanismRSAOAEP
+	// WrappingMechanismAESKWP indicates that the key should be wrapped using
+	// AES Key Wrap with Padding.
+	WrappingMechanismAESKWP
+	// WrappingMechanismAESGCM indicates that the key should be wrapped using
+	// AES GCM.
+	WrappingMechanismAESGCM
+)
+
 // Parameters for generating an RSA keypair.
 type RSAParams struct {
 	ModBits, Exp int
@@ -22,6 +42,8 @@ type SigningParams struct {
 	// Parameters for generating the associated key pair; must be one
 	// of RSAParams or elliptic.Curve.
 	KeyParams any
+	// Wrapping mechanism to use.
+	Wrap WrappingMechanism
 }
 
 // Parameters for EndorseCert().
@@ -63,20 +85,6 @@ const (
 	SymmetricKeyTypeKeyGen
 )
 
-// SymmetricKeyWrap specifies the wrapping mechanism for the key.
-type SymmetricKeyWrap int
-
-const (
-	// SymmetricKeyWrapNone indicates that the key should not be wrapped.
-	SymmetricKeyWrapNone SymmetricKeyWrap = iota
-	// SymmetricKeyWrapRsaPcks indicates that the key should be wrapped using
-	// RSA PKCS#1.5.
-	SymmetricKeyWrapRsaPcks
-	// SymmetricKeyWrapRsaOaep indicates that the key should be wrapped using
-	// RSA OAEP.
-	SymmetricKeyWrapRsaOaep
-)
-
 // Parameters for GenerateSymmetricKeys().
 type SymmetricKeygenParams struct {
 	KeyType     SymmetricKeyType
@@ -84,7 +92,7 @@ type SymmetricKeygenParams struct {
 	SizeInBits  uint
 	Sku         string
 	Diversifier string
-	Wrap        SymmetricKeyWrap
+	Wrap        WrappingMechanism
 }
 
 type SymmetricKeyResult struct {
@@ -99,10 +107,6 @@ type SymmetricKeyResult struct {
 // An SE provides privileged access to cryptographic operations using high-value
 // assets, such as long-lived root secrets.
 type SE interface {
-	// Derives the transport secret for a device with the given ID, and wraps
-	// it with the device class's global secret.
-	DeriveAndWrapTransportSecret(deviceId []byte) ([]byte, error)
-
 	// Generates and signs certificates with the given parent corresponding to the
 	// arguments in certs.
 	//

--- a/src/spm/services/skucfg.go
+++ b/src/spm/services/skucfg.go
@@ -15,16 +15,18 @@ import (
 type AttrName string
 
 const (
-	AttrNameSymmetricWrappingMethod AttrName = "symmetricWrappingMethod"
+	AttrNameWrappingMechanism AttrName = "WrappingMechanism"
 )
 
-// WrappingMethod provides the wrapping method for symmetric keys.
-type WrappingMethod string
+// WrappingMechanism provides the wrapping method for symmetric keys.
+type WrappingMechanism string
 
 const (
-	WrappingMethodNone     WrappingMethod = "none"
-	WrappingMethodRSAPKCS1                = "rsa-pkcs"
-	WrappingMethodRSAOAEP                 = "rsa-oaep"
+	WrappingMechanismNone     WrappingMechanism = "none"
+	WrappingMechanismRSAPKCS1                   = "RsaPkcs"
+	WrappingMechanismRSAOAEP                    = "RsaOaep"
+	WrappingMechanismAESGCM                     = "AesGcm"
+	WrappingMechanismAESKWP                     = "AesKwp"
 )
 
 type Config struct {

--- a/src/spm/spm_server.go
+++ b/src/spm/spm_server.go
@@ -23,7 +23,6 @@ var (
 	port         = flag.Int("port", 0, "The port to bind the server on; required")
 	hsmPWFile    = flag.String("hsm_pw", "", "File path to the HSM's Password; required for TPM")
 	hsmSOPath    = flag.String("hsm_so", "", "File path to the PCKS#11 .so library used to interface to the HSM")
-	hsmType      = flag.Int64("hsm_type", 0, "The type of the hsm (SoftHSM or TokenHSM); required")
 	enableTLS    = flag.Bool("enable_tls", false, "Enable mTLS secure channel; optional")
 	serviceKey   = flag.String("service_key", "", "File path to the PEM encoding of the server's private key")
 	serviceCert  = flag.String("service_cert", "", "File path to the PEM encoding of the server's certificate chain")
@@ -46,7 +45,6 @@ func startSPMServer() (*grpc.Server, error) {
 	spmServer, err := spm.NewSpmServer(spm.Options{
 		HSMSOLibPath: *hsmSOPath,
 		SPMConfigDir: *spmConfigDir,
-		HsmType:      *hsmType,
 		HsmPWFile:    *hsmPWFile,
 	})
 	if err != nil {

--- a/src/spm/util/certgen.go
+++ b/src/spm/util/certgen.go
@@ -39,7 +39,6 @@ func initSession() (*se.HSM, error) {
 		SlotID:      *hsmSlot,
 		HSMPassword: *hsmPW,
 		NumSessions: 1,
-		HSMType:     pk11.HSMType(0),
 	})
 }
 


### PR DESCRIPTION
The HSM supported attributes and mechanisms should be part of the SKU
configuration. This change removes the `pl11.HSMType` in favor of
applying attributes via `pk11.KeyOptions`, and by defining the key wrap
mechanism via a `skucfg.Config{AttrName}` setting.
    
In a follow up PR, we are planning to add SKU configurations for the
Luna HSM.

Only review the last commit.