### PR TITLE
[bazel,pa,registry] add mechansim to enable vendor-specific registries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Build everything
         run: |
           bazel build //...
+          bazel build --//src/pa/services:use_vendor_shim //src/pa/services:pa
           bazel run //release:release -- \
               --norelease \
               --copy "${PWD}/artifacts" \

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -125,3 +125,12 @@ load("//third_party/docker:repos.bzl", "docker_repos")
 docker_repos()
 load("//third_party/docker:deps.bzl", "docker_deps")
 docker_deps()
+
+# Setup for linking in externally vendor customizations.
+load("//rules:vendor.bzl", "vendor_repo_setup")
+vendor_repo_setup(
+    name = "vendor_setup",
+    dummy = "src/vendor",
+)
+load("@vendor_setup//:repos.bzl", "vendor_repo")
+vendor_repo(name = "vendor_repo")

--- a/rules/vendor.bzl
+++ b/rules/vendor.bzl
@@ -1,0 +1,31 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+_VENDOR_REPO_TEMPLATE = """
+def vendor_repo(name):
+    native.local_repository(
+        name = name,
+        path = "{vendor_repo_dir}",
+    )
+"""
+
+_BUILD = """
+exports_files(glob(["**"]))
+"""
+
+def _vendor_repo_setup_impl(rctx):
+    vendor_repo_dir = rctx.os.environ.get("VENDOR_REPO_DIR", rctx.attr.dummy)
+    rctx.file("repos.bzl", _VENDOR_REPO_TEMPLATE.format(vendor_repo_dir = vendor_repo_dir))
+    rctx.file("BUILD.bazel", _BUILD)
+
+vendor_repo_setup = repository_rule(
+    implementation = _vendor_repo_setup_impl,
+    attrs = {
+        "dummy": attr.string(
+            mandatory = True,
+            doc = "Location of the dummy vendor repo directory.",
+        ),
+    },
+    environ = ["VENDOR_REPO_DIR"],
+)

--- a/src/pa/pa_server.go
+++ b/src/pa/pa_server.go
@@ -47,7 +47,7 @@ func startPAServer(spmClient pbs.SpmServiceClient, pbClient pbr.ProxyBufferServi
 	interceptor := auth_service.NewAuthInterceptor(*enableTLS)
 	opts = append(opts, grpc.UnaryInterceptor(interceptor.Unary))
 	server := grpc.NewServer(opts...)
-	pbp.RegisterProvisioningApplianceServiceServer(server, pa.NewProvisioningApplianceServer(spmClient, pbClient, *enableProxyBuffer))
+	pbp.RegisterProvisioningApplianceServiceServer(server, pa.NewProvisioningApplianceServer(spmClient, pbClient))
 	return server, nil
 }
 

--- a/src/pa/services/BUILD.bazel
+++ b/src/pa/services/BUILD.bazel
@@ -12,19 +12,15 @@ go_library(
     importpath = "github.com/lowRISC/opentitan-provisioning/src/pa/services/pa",
     deps = [
         "//src/pa/proto:pa_go_pb",
-        "//src/proto:device_id_go_pb",
-        "//src/proto:device_id_utils",
-        "//src/proto:registry_record_go_pb",
+        "//src/pa/services/registry_shim",
         "//src/proxy_buffer/proto:proxy_buffer_go_pb",
         "//src/spm/proto:spm_go_pb",
         "//src/transport/auth_service",
         "//src/utils",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
-        "@org_golang_google_protobuf//encoding/protojson",
     ],
 )
 

--- a/src/pa/services/BUILD.bazel
+++ b/src/pa/services/BUILD.bazel
@@ -2,9 +2,22 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//visibility:public"])
+
+bool_flag(
+    name = "use_vendor_shim",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "vendor_shim_select",
+    flag_values = {
+        ":use_vendor_shim": "True",
+    },
+)
 
 go_library(
     name = "pa",
@@ -12,7 +25,6 @@ go_library(
     importpath = "github.com/lowRISC/opentitan-provisioning/src/pa/services/pa",
     deps = [
         "//src/pa/proto:pa_go_pb",
-        "//src/pa/services/registry_shim",
         "//src/proxy_buffer/proto:proxy_buffer_go_pb",
         "//src/spm/proto:spm_go_pb",
         "//src/transport/auth_service",
@@ -21,7 +33,10 @@ go_library(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
-    ],
+    ] + select({
+        ":vendor_shim_select": ["@vendor_repo//registry_shim"],
+        "//conditions:default": ["@//src/pa/services/registry_shim"],
+    }),
 )
 
 go_test(

--- a/src/pa/services/pa_test.go
+++ b/src/pa/services/pa_test.go
@@ -34,7 +34,7 @@ const (
 func bufferDialer(t *testing.T, spmClient pbs.SpmServiceClient, pbClient pbr.ProxyBufferServiceClient) func(context.Context, string) (net.Conn, error) {
 	listener := bufconn.Listen(bufferConnectionSize)
 	server := grpc.NewServer()
-	pbp.RegisterProvisioningApplianceServiceServer(server, pa.NewProvisioningApplianceServer(spmClient, pbClient, false))
+	pbp.RegisterProvisioningApplianceServiceServer(server, pa.NewProvisioningApplianceServer(spmClient, pbClient))
 	go func(t *testing.T) {
 		if err := server.Serve(listener); err != nil {
 			t.Fatal(err)

--- a/src/pa/services/registry_shim/BUILD.bazel
+++ b/src/pa/services/registry_shim/BUILD.bazel
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "registry_shim",
+    srcs = ["registry_shim.go"],
+    importpath = "github.com/lowRISC/opentitan-provisioning/src/pa/services/registry_shim",
+    deps = [
+        "//src/pa/proto:pa_go_pb",
+        "//src/proto:device_id_utils",
+        "//src/proto:registry_record_go_pb",
+        "//src/proxy_buffer/proto:proxy_buffer_go_pb",
+        "//src/proxy_buffer/services:proxybuffer",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/src/pa/services/registry_shim/registry_shim.go
+++ b/src/pa/services/registry_shim/registry_shim.go
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package registry_shim implements the ProvisioningAppliance:RegisterDevice RPC.
+package registry_shim
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pap "github.com/lowRISC/opentitan-provisioning/src/pa/proto/pa_go_pb"
+	diu "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_utils"
+	rpb "github.com/lowRISC/opentitan-provisioning/src/proto/registry_record_go_pb"
+	pbr "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/proxy_buffer_go_pb"
+	pb "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/services/proxybuffer"
+)
+
+func RegisterDevice(ctx context.Context, buffer pb.Registry, request *pap.RegistrationRequest) (*pap.RegistrationResponse, error) {
+	log.Printf("In PA - Received RegisterDevice request with DeviceID: %v", diu.DeviceIdToHexString(request.DeviceData.DeviceId))
+
+	// Check if ProxyBuffer is enabled.
+	if buffer == nil {
+		return nil, status.Errorf(codes.Internal, "RegisterDevice ended with error, PA started without ProxyBuffer")
+	}
+
+	// Translate/embed ot.DeviceData to the registry request.
+	device_data_bytes, err := proto.Marshal(request.DeviceData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal device data: %v", err)
+	}
+	pb_request := &pbr.DeviceRegistrationRequest{
+		Record: &rpb.RegistryRecord{
+			DeviceId: diu.DeviceIdToHexString(request.DeviceData.DeviceId),
+			Sku:      request.DeviceData.Sku,
+			Version:  0,
+			Data:     device_data_bytes,
+		},
+	}
+
+	// Send record to the ProxyBuffer (the buffering front end of the registry service).
+	pb_response, err := buffer.RegisterDevice(ctx, pb_request)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "RegisterDevice returned error: %v", err)
+	}
+	log.Printf("In PA - device record (DeviceID: %v) accepted by ProxyBuffer: %v",
+		pb_response.DeviceId,
+		pb_response.Status)
+
+	return &pap.RegistrationResponse{}, nil
+}

--- a/src/proxy_buffer/services/BUILD.bazel
+++ b/src/proxy_buffer/services/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//src/proxy_buffer/proto:proxy_buffer_go_pb",
         "//src/proxy_buffer/proto:validators",
         "//src/proxy_buffer/store:db",
+        "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
     ],

--- a/src/proxy_buffer/services/proxybuffer.go
+++ b/src/proxy_buffer/services/proxybuffer.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"log"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -16,6 +17,11 @@ import (
 	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/validators"
 	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/db"
 )
+
+// Every registry service frontend must implement the `RegistryDevice` function.
+type Registry interface {
+	RegisterDevice(ctx context.Context, request *pbp.DeviceRegistrationRequest, opts ...grpc.CallOption) (*pbp.DeviceRegistrationResponse, error)
+}
 
 // server is the server object.
 type server struct {

--- a/src/vendor/BUILD.bazel
+++ b/src/vendor/BUILD.bazel
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])

--- a/src/vendor/WORKSPACE.bazel
+++ b/src/vendor/WORKSPACE.bazel
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+workspace(name = "vendor_repo")

--- a/src/vendor/registry_shim/BUILD.bazel
+++ b/src/vendor/registry_shim/BUILD.bazel
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "registry_shim",
+    srcs = ["registry_shim.go"],
+    importpath = "github.com/lowRISC/opentitan-provisioning/src/pa/services/registry_shim",
+    deps = [
+        "@//src/pa/proto:pa_go_pb",
+        "@//src/proto:device_id_utils",
+        "@//src/proxy_buffer/services:proxybuffer",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/src/vendor/registry_shim/registry_shim.go
+++ b/src/vendor/registry_shim/registry_shim.go
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package registry_shim implements the ProvisioningAppliance:RegisterDevice RPC.
+package registry_shim
+
+import (
+	"context"
+	"log"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pap "github.com/lowRISC/opentitan-provisioning/src/pa/proto/pa_go_pb"
+	diu "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_utils"
+	pb "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/services/proxybuffer"
+)
+
+func RegisterDevice(ctx context.Context, buffer pb.Registry, request *pap.RegistrationRequest) (*pap.RegistrationResponse, error) {
+	log.Printf("In PA - Received RegisterDevice request with DeviceID: %v", diu.DeviceIdToHexString(request.DeviceData.DeviceId))
+
+	// Vendor-specific implementation of RegisterDevice call goes here.
+	return nil, status.Errorf(codes.Unimplemented, "Vendor specific RegisterDevice RPC not implemented.")
+}


### PR DESCRIPTION
This PR contains several commits that enable a vendor to connect any registry or registry buffer services to the PA, instead of using the ProxyBuffer, by adding a local `vendor_repo` bazel external repo and build configuration setting to override the PA's registry_shim library. With this new mechanism, a vendor can:
1. define a vendor specific bazel repo somewhere on their system, pointed to by the `VENDOR_REPO_DIR` envar, that contains a custom implementation of the `registry_shim` library, and 
2. build the PA using the `--//src/pa/services:use_vendor_shim` bazel bool_flag