### PR TITLE
[spm] add `EndorseData` RPC

### DIFF
--- a/src/pa/services/pa_test.go
+++ b/src/pa/services/pa_test.go
@@ -65,6 +65,7 @@ type fakeSpmClient struct {
 	createKeyAndCert    createKeyAndCertFakeResponse
 	deriveSymmetricKeys deriveSymmetricKeysResponse
 	endorseCerts        endorseCertsResponse
+	endorseData         endorseDataResponse
 }
 
 type initSessionResponse struct {
@@ -87,6 +88,11 @@ type endorseCertsResponse struct {
 	err      error
 }
 
+type endorseDataResponse struct {
+	response *pbs.EndorseDataResponse
+	err      error
+}
+
 func (c *fakeSpmClient) InitSession(ctx context.Context, request *pbp.InitSessionRequest, opts ...grpc.CallOption) (*pbp.InitSessionResponse, error) {
 	return c.initSession.response, c.initSession.err
 }
@@ -101,6 +107,10 @@ func (c *fakeSpmClient) DeriveSymmetricKeys(ctx context.Context, request *pbp.De
 
 func (c *fakeSpmClient) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequest, opts ...grpc.CallOption) (*pbp.EndorseCertsResponse, error) {
 	return c.endorseCerts.response, c.endorseCerts.err
+}
+
+func (c *fakeSpmClient) EndorseData(ctx context.Context, request *pbs.EndorseDataRequest, opts ...grpc.CallOption) (*pbs.EndorseDataResponse, error) {
+	return c.endorseData.response, c.endorseData.err
 }
 
 func TestCreateKeyAndCert(t *testing.T) {

--- a/src/spm/proto/BUILD.bazel
+++ b/src/spm/proto/BUILD.bazel
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -12,6 +12,7 @@ proto_library(
     srcs = ["spm.proto"],
     deps = [
         "//src/pa/proto:pa_proto",
+        "//src/proto/crypto:cert_proto",
     ],
 )
 
@@ -22,5 +23,6 @@ go_proto_library(
     proto = ":spm_proto",
     deps = [
         "//src/pa/proto:pa_go_pb",
+        "//src/proto/crypto:cert_go_pb",
     ],
 )

--- a/src/spm/proto/spm.proto
+++ b/src/spm/proto/spm.proto
@@ -8,6 +8,7 @@ syntax = "proto3";
 package spm;
 
 import "src/pa/proto/pa.proto";
+import "src/proto/crypto/cert.proto";
 
 option go_package = "spm_go_bp";
 
@@ -44,4 +45,27 @@ service SpmService {
   // certificates are signed with a CA private key stored in the SPM.
   rpc EndorseCerts(pa.EndorseCertsRequest)
       returns (pa.EndorseCertsResponse) {}
+
+  // EndorseData endorses an arbitrary byte array for a given SKU. The data is
+  // hashed and signed with a private key stored in the SPM.
+  rpc EndorseData(EndorseDataRequest)
+      returns (EndorseDataResponse) {}
+}
+
+// Endorse data request.
+message EndorseDataRequest {
+  // SKU identifier. Required.
+  string sku = 1;
+  // Signing key parameters. Required.
+  crypto.cert.SigningKeyParams key_params = 2;
+  // Data payload to endorse. Required.
+  bytes data = 3;
+}
+
+// Endorse data response.
+message EndorseDataResponse {
+  // ASN.1 DER public key used to sign the data payload.
+  bytes pubkey = 1;
+  // ASN.1 DER signature of data payload.
+  bytes signature = 2;
 }

--- a/src/spm/services/se.go
+++ b/src/spm/services/se.go
@@ -63,8 +63,7 @@ type CertInfo struct {
 type SymmetricKeyOp int
 
 const (
-	// SymmetricKeyOpRaw indicates that the key should be generated as a raw
-	// key.
+	// SymmetricKeyOpRaw indicates that the key should be generated as a raw key.
 	SymmetricKeyOpRaw SymmetricKeyOp = iota
 	// SymmetricKeyOpHashedOtLcToken indicates that the key should be generated
 	// as a hashed OT/LC token.
@@ -134,8 +133,21 @@ type SE interface {
 	// The certificate is provided in raw form, and the SE will return the
 	// signed certificate in DER format.
 	//
+	// Note: only ECDSA signature algorithms are currently supported.
+	//
 	// Returns: Raw signature in bytes.
 	EndorseCert(tbs []byte, params EndorseCertParams) ([]byte, error)
+
+	// EndorseData hashes and signs an arbitrary data payload.
+	//
+	// This operation is used to sign an array of bytes with the SE's private key.
+	// The bytes are provided in raw form, and the SE will return the signature in
+	// ASN.1 DER encoded form.
+	//
+	// Note: only ECDSA signature algorithms are currently supported.
+	//
+	// Returns: ECDSA signature (ASN.1 DER encoded).
+	EndorseData(data []byte, params EndorseCertParams) ([]byte, []byte, error)
 
 	// GenerateRandom returns random data extracted from the HSM.
 	GenerateRandom(length int) ([]byte, error)

--- a/src/spm/services/se_pk11_test.go
+++ b/src/spm/services/se_pk11_test.go
@@ -264,9 +264,10 @@ func TestGenerateSymmKeysWrap(t *testing.T) {
 	}
 }
 
-// CreateCAKeys generates a Certificate Authority (CA) key pair which can be
-// used in any test case. It requires an initialized `hsm` instance.
-func CreateCAKeys(t *testing.T, hsm *HSM) (pk11.KeyPair, error) {
+// MintECDSAKeys generates a P256 ECDSA key pair to be used by various tests
+// below as the keys to a Certificate Authority (CA) or HSM identity.
+// It requires an initialized `hsm` instance.
+func MintECDSAKeys(t *testing.T, hsm *HSM) (pk11.KeyPair, error) {
 	session, release := hsm.sessions.getHandle()
 	defer release()
 	return session.GenerateECDSA(elliptic.P256(), &pk11.KeyOptions{Extractable: true})
@@ -276,7 +277,7 @@ func TestGenerateCert(t *testing.T) {
 	log.Printf("TestGenerateCert")
 	hsm, kg, _, _ := MakeHSM(t)
 
-	ca, err := CreateCAKeys(t, hsm)
+	ca, err := MintECDSAKeys(t, hsm)
 	ts.Check(t, err)
 	caKeyHandle, err := ca.PrivateKey.UID()
 	ts.Check(t, err)
@@ -462,7 +463,7 @@ func TestEndorseData(t *testing.T) {
 	hsm, _, _, _ := MakeHSM(t)
 
 	// Mint ECDSA keys on HSM.
-	identityKeyPair, err := CreateCAKeys(t, hsm)
+	identityKeyPair, err := MintECDSAKeys(t, hsm)
 	ts.Check(t, err)
 
 	_, release := hsm.sessions.getHandle()


### PR DESCRIPTION
This adds the `EndorseData` RPC to the SPM to enable the SPM to sign RegistryRecord.data payloads before sending them to the registry.

The remaining integration will be completed in a follow up PR.
