### PR TITLE
[loadtest] Move `dev` to /var/lib/opentitan/config/dev

### DIFF
--- a/config/dev/containers/provapp.yml
+++ b/config/dev/containers/provapp.yml
@@ -18,7 +18,7 @@ spec:
     args:
     - --port=5000
     - --hsm_so=/usr/local/lib/softhsm/libsofthsm2.so
-    - --spm_config_dir=/var/lib/opentitan/spm
+    - --spm_config_dir=/var/lib/opentitan/config/dev/spm
     # TODO: Update label to point to specific release version.
     image: localhost/spm_server:latest
     resources: {}
@@ -43,9 +43,9 @@ spec:
         - CAP_NET_RAW
         - CAP_AUDIT_WRITE
     volumeMounts:
-    - mountPath: /var/lib/opentitan/spm
+    - mountPath: /var/lib/opentitan/config/dev/spm
       name: var-lib-opentitan-spm-config-host-0
-    - mountPath: /var/lib/opentitan/spm/softhsm2
+    - mountPath: /var/lib/opentitan/config/dev/spm/softhsm2
       name: var-lib-opentitan-spm-softhsm2-host-1
   # Configuration for the `paserver` container.
   - name: paserver
@@ -86,11 +86,11 @@ spec:
   restartPolicy: Always
   volumes:
   - hostPath:
-      path: /var/lib/opentitan/spm
+      path: /var/lib/opentitan/config/dev/spm
       type: Directory
     name: var-lib-opentitan-spm-config-host-0
   - hostPath:
-      path: /var/lib/opentitan/spm/softhsm2
+      path: /var/lib/opentitan/config/dev/spm/softhsm2
       type: Directory
     name: var-lib-opentitan-spm-softhsm2-host-1
 status: {}

--- a/config/dev/deploy.sh
+++ b/config/dev/deploy.sh
@@ -41,19 +41,19 @@ if [ ! -d "${OPENTITAN_VAR_DIR}" ]; then
     sudo mkdir -p "${OPENTITAN_VAR_DIR}"
     sudo chown "${USER}" "${OPENTITAN_VAR_DIR}"
 fi
-cp -r "${CONFIG_DIR}/env" "${OPENTITAN_VAR_DIR}"
-mkdir -p "${OPENTITAN_VAR_DIR}/spm"
-cp -Rf ${CONFIG_DIR}/spm/* "${OPENTITAN_VAR_DIR}/spm"
+mkdir -p "${OPENTITAN_VAR_DIR}/config/dev/spm"
+cp -r "${CONFIG_DIR}/env" "${OPENTITAN_VAR_DIR}/config/dev"
+cp -Rf ${CONFIG_DIR}/spm/* "${OPENTITAN_VAR_DIR}/config/dev/spm"
 echo "Done."
 
 ################################################################################
 # Install SoftHSM2 to deployment dir and initialize it.
 ################################################################################
 echo "Installing and configuring SoftHSM2 ..."
-if [ ! -d "${OPENTITAN_VAR_DIR}/softhsm2" ]; then
-    mkdir -p "${OPENTITAN_VAR_DIR}/softhsm2"
+if [ ! -d "${OPENTITAN_VAR_DIR}/config/dev/softhsm2" ]; then
+    mkdir -p "${OPENTITAN_VAR_DIR}/config/dev/softhsm2"
     tar -xvf "${RELEASE_DIR}/softhsm_dev.tar.xz" \
-        --directory "${OPENTITAN_VAR_DIR}/softhsm2"
+        --directory "${OPENTITAN_VAR_DIR}/config/dev/softhsm2"
 fi
 
 # We create two separate SoftHSM configuration directories, one for the SPM HSM
@@ -65,14 +65,14 @@ fi
 # SPM HSM Instance.
 ${CONFIG_DIR}/softhsm/init.sh \
     "${CONFIG_DIR}" \
-    "${OPENTITAN_VAR_DIR}/softhsm2/softhsm2" \
+    "${OPENTITAN_VAR_DIR}/config/dev/softhsm2/softhsm2" \
     "${OPENTITAN_VAR_DIR}" \
     "${SPM_HSM_TOKEN_SPM}"
 
 # Offline HSM Instance.
 SOFTHSM2_CONF="${SOFTHSM2_CONF_OFFLINE}" ${CONFIG_DIR}/softhsm/init.sh \
     "${CONFIG_DIR}" \
-    "${OPENTITAN_VAR_DIR}/softhsm2/softhsm2" \
+    "${OPENTITAN_VAR_DIR}/config/dev/softhsm2/softhsm2" \
     "${OPENTITAN_VAR_DIR}" \
     "${SPM_HSM_TOKEN_OFFLINE}"
 

--- a/config/dev/env/spm.env
+++ b/config/dev/env/spm.env
@@ -10,19 +10,19 @@ export SPM_HSM_PIN_ADMIN="${SPM_HSM_PIN_ADMIN:-cryptoki}"
 export SPM_HSM_PIN_USER="${SPM_HSM_PIN_USER:-cryptoki}"
 
 # Tokens
-# - `MANUF`: Used in `CP` and `FT` manufacturing stages.
+# - `SPM`: Used in `CP` and `FT` manufacturing stages.
 # - `OFFLINE`: Used to generate SKU secrets and other infrastructure assets.
 export SPM_HSM_TOKEN_SPM="${SPM_HSM_TOKEN_SPM:-spm-hsm}"
 export SPM_HSM_TOKEN_OFFLINE="${SPM_HSM_TOKEN_OFFLINE:-offline-hsm}"
 
 # The SOFTHSM2_CONF variable is used by the softHSM dynamic library to locate
 # the HSM token configuration.
-export SOFTHSM2_CONF_SPM="${SOFTHSM2_CONF_SPM:-${OPENTITAN_VAR_DIR}/spm/softhsm2/softhsm2.conf}"
-export SOFTHSM2_CONF_OFFLINE="${SOFTHSM2_CONF_OFFLINE:-${OPENTITAN_VAR_DIR}/spm/softhsm2-offline/softhsm2.conf}"
+export SOFTHSM2_CONF_SPM="${SOFTHSM2_CONF_SPM:-${OPENTITAN_VAR_DIR}/config/dev/spm/softhsm2/softhsm2.conf}"
+export SOFTHSM2_CONF_OFFLINE="${SOFTHSM2_CONF_OFFLINE:-${OPENTITAN_VAR_DIR}/config/dev/spm/softhsm2-offline/softhsm2.conf}"
 export SOFTHSM2_CONF="${SOFTHSM2_CONF:-${SOFTHSM2_CONF_SPM}}"
 
 # `hsmtool` configuration options
-export HSMTOOL_MODULE=${OPENTITAN_VAR_DIR}/softhsm2/libsofthsm2.so
+export HSMTOOL_MODULE=${OPENTITAN_VAR_DIR}/config/dev/softhsm2/libsofthsm2.so
 export HSMTOOL_USER="user"
 export HSMTOOL_TOKEN="${SPM_HSM_TOKEN_SPM}"
 export HSMTOOL_PIN="${SPM_HSM_PIN_USER}"

--- a/config/dev/env/spm.yml
+++ b/config/dev/env/spm.yml
@@ -8,4 +8,4 @@ metadata:
   name: spm-config
 data:
   spm_hsm_pin_user: "cryptoki"
-  softhsm2_conf: "/var/lib/opentitan/spm/softhsm2/softhsm2.conf"
+  softhsm2_conf: "/var/lib/opentitan/config/dev/spm/softhsm2/softhsm2.conf"


### PR DESCRIPTION
This change moves the loadtest `dev` configuration to /var/lib/opentitan/config/dev. This will allow the Thales HSM configuration to be available under /var/lib/opentitan/config/prod.