### PR TITLE
[loadtest] Fix initialization error.

### DIFF
--- a/config/dev/spm/sku_sival.yml
+++ b/config/dev/spm/sku_sival.yml
@@ -10,12 +10,13 @@ symmetricKeys:
   - name: sival-kdf-losec-v0
 privateKeys:
     - name: sival-dice-key-p256-v0
+    - name: spm-hsm-id-v0.priv
 publicKeys:
     - name: sku-sival-rsa-rma-v0
 attributes:
-    - KdfSecHi: sival-kdf-hisec-v0
-    - KdfSecLo: sival-kdf-losec-v0
-    - WrappingMechanism: RsaPkcs
-    - WrappingKeyLabel: sku-sival-rsa-rma-v0
-    - SigningKey/Dice/v0: sival-dice-key-p256-v0
-    - SigningKey/Identity/v0: spm-hsm-id-v0
+    KdfSecHi: sival-kdf-hisec-v0
+    KdfSecLo: sival-kdf-losec-v0
+    WrappingMechanism: RsaPkcs
+    WrappingKeyLabel: sku-sival-rsa-rma-v0
+    SigningKey/Dice/v0: sival-dice-key-p256-v0
+    SigningKey/Identity/v0: spm-hsm-id-v0.priv

--- a/src/pa/loadtest.go
+++ b/src/pa/loadtest.go
@@ -356,6 +356,7 @@ func main() {
 		if err != nil {
 			result.pass = false
 			result.msg = fmt.Sprintf("failed to initialize client tasks: %v", err)
+			results = append(results, result)
 			continue
 		}
 		log.Printf("Running test %q", t.testName)

--- a/src/spm/services/se.go
+++ b/src/spm/services/se.go
@@ -86,13 +86,14 @@ const (
 
 // Parameters for GenerateSymmetricKeys().
 type SymmetricKeygenParams struct {
-	SeedLabel   string
-	KeyType     SymmetricKeyType
-	KeyOp       SymmetricKeyOp
-	SizeInBits  uint
-	Sku         string
-	Diversifier string
-	Wrap        WrappingMechanism
+	SeedLabel    string
+	KeyType      SymmetricKeyType
+	KeyOp        SymmetricKeyOp
+	SizeInBits   uint
+	Sku          string
+	Diversifier  string
+	Wrap         WrappingMechanism
+	WrapKeyLabel string
 }
 
 type SymmetricKeyResult struct {

--- a/src/spm/services/se_pk11.go
+++ b/src/spm/services/se_pk11.go
@@ -344,18 +344,18 @@ func (h *HSM) GenerateSymmetricKeys(params []*SymmetricKeygenParams) ([]Symmetri
 		var err error
 		switch p.KeyType {
 		case SymmetricKeyTypeSecurityHi:
-			khs, ok := h.SymmetricKeys["HighSecKdfSeed"]
+			khs, ok := h.SymmetricKeys[p.SeedLabel]
 			if !ok {
-				return nil, status.Errorf(codes.Internal, "failed to find HighSecKdfSeed key UID")
+				return nil, status.Errorf(codes.Internal, "failed to find %q key UID", p.SeedLabel)
 			}
 			seed, err = session.FindSecretKey(khs)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to get KHsks key object: %v", err)
 			}
 		case SymmetricKeyTypeSecurityLo:
-			kls, ok := h.SymmetricKeys["LowSecKdfSeed"]
+			kls, ok := h.SymmetricKeys[p.SeedLabel]
 			if !ok {
-				return nil, status.Errorf(codes.Internal, "failed to find LowSecKdfSeed key UID")
+				return nil, status.Errorf(codes.Internal, "failed to find %q key UID", p.SeedLabel)
 			}
 			seed, err = session.FindSecretKey(kls)
 			if err != nil {
@@ -407,13 +407,13 @@ func (h *HSM) GenerateSymmetricKeys(params []*SymmetricKeygenParams) ([]Symmetri
 		wkey := []byte{}
 		if p.Wrap == WrappingMechanismRSAPCKS || p.Wrap == WrappingMechanismRSAOAEP {
 			// Wrap the key with RSA PKCS1v1.5.
-			wk, ok := h.PublicKeys["TokenWrappingKey"]
+			wk, ok := h.PublicKeys[p.WrapKeyLabel]
 			if !ok {
-				return nil, status.Errorf(codes.Internal, "failed to find TokenWrappingKey key UID")
+				return nil, status.Errorf(codes.Internal, "failed to find %q key UID", p.WrapKeyLabel)
 			}
 			wkObj, err := session.FindPublicKey(wk)
 			if err != nil {
-				return nil, status.Errorf(codes.Internal, "failed to find TokenWrappingKey key object: %v", err)
+				return nil, status.Errorf(codes.Internal, "failed to find %q key object: %v", p.WrapKeyLabel, err)
 			}
 
 			var m pk11.KdfWrapMechanism

--- a/src/spm/services/se_pk11_test.go
+++ b/src/spm/services/se_pk11_test.go
@@ -137,6 +137,7 @@ func TestGenerateSymmKeys(t *testing.T) {
 	// Symmetric keygen parameters.
 	// test unlock token
 	testUnlockTokenParams := SymmetricKeygenParams{
+		SeedLabel:   "LowSecKdfSeed",
 		KeyType:     SymmetricKeyTypeSecurityLo,
 		KeyOp:       SymmetricKeyOpRaw,
 		SizeInBits:  128,
@@ -146,6 +147,7 @@ func TestGenerateSymmKeys(t *testing.T) {
 	}
 	// test exit token
 	testExitTokenParams := SymmetricKeygenParams{
+		SeedLabel:   "LowSecKdfSeed",
 		KeyType:     SymmetricKeyTypeSecurityLo,
 		KeyOp:       SymmetricKeyOpRaw,
 		SizeInBits:  128,
@@ -155,6 +157,7 @@ func TestGenerateSymmKeys(t *testing.T) {
 	}
 	// wafer authentication secret
 	wasParams := SymmetricKeygenParams{
+		SeedLabel:   "HighSecKdfSeed",
 		KeyType:     SymmetricKeyTypeSecurityHi,
 		KeyOp:       SymmetricKeyOpRaw,
 		SizeInBits:  256,
@@ -207,12 +210,13 @@ func TestGenerateSymmKeysWrap(t *testing.T) {
 
 	// RMA token
 	rmaParams := SymmetricKeygenParams{
-		KeyType:     SymmetricKeyTypeKeyGen,
-		KeyOp:       SymmetricKeyOpHashedOtLcToken,
-		SizeInBits:  128,
-		Sku:         "test sku",
-		Diversifier: "rma: device_id",
-		Wrap:        WrappingMechanismRSAPCKS,
+		KeyType:      SymmetricKeyTypeKeyGen,
+		KeyOp:        SymmetricKeyOpHashedOtLcToken,
+		SizeInBits:   128,
+		Sku:          "test sku",
+		Diversifier:  "rma: device_id",
+		Wrap:         WrappingMechanismRSAPCKS,
+		WrapKeyLabel: "TokenWrappingKey",
 	}
 	params := []*SymmetricKeygenParams{
 		&rmaParams,

--- a/src/spm/services/spm.go
+++ b/src/spm/services/spm.go
@@ -141,7 +141,7 @@ func (s *server) initSku(sku string) (string, error) {
 	err = s.initializeSKU(sku)
 	if err != nil {
 		log.Printf("failed to initialize sku: %v", err)
-		return "", status.Errorf(codes.Internal, "failed to initialize sku")
+		return "", status.Errorf(codes.Internal, "failed to initialize sku  %v", err)
 	}
 	return token, nil
 }
@@ -248,6 +248,12 @@ func (s *server) DeriveSymmetricKeys(ctx context.Context, request *pbp.DeriveSym
 			default:
 				return nil, status.Errorf(codes.Internal, "invalid wrapping method: %s", wmech)
 			}
+
+			wkl, err := sku.config.GetAttribute(skucfg.AttrNameWrappingKeyLabel)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "could not get wrapping key label: %s", err)
+			}
+			params.WrapKeyLabel = wkl
 		} else {
 			params.Wrap = se.WrappingMechanismNone
 		}


### PR DESCRIPTION
The `sku_sival.yml` was throwing an unmarshal error which was missed by loadtest.go.

This change fixes the loadtest error as well as the following spm errors:

- Get correct seed label in `se_pk11.GenerateSymmetricKeys`
- Get correct seed wrapping  key in `se_pk11.GenerateSymmetricKeys`
- Add `spm-hsm-id-v0.priv` to the list of `privateKeys` in sku_sival.yml.