### PR TITLE
[dut_lib] add support for loading SRAM binaries over JTAG

### DIFF
--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -13,7 +13,8 @@ namespace provisioning {
 namespace test_programs {
 
 extern "C" {
-void OtLibFpgaInit(const char* fpga, const char* fpga_bitstream);
+void* OtLibFpgaInit(const char* fpga, const char* fpga_bitstream);
+void* OtLibLoadSramElf(void* transport, const char* openocd, const char* elf);
 }
 
 std::unique_ptr<DutLib> DutLib::Create(void) {
@@ -23,8 +24,14 @@ std::unique_ptr<DutLib> DutLib::Create(void) {
 absl::Status DutLib::DutInit(const std::string& fpga,
                              const std::string& fpga_bitstream) {
   LOG(INFO) << "in DutLib::DutInit";
-  OtLibFpgaInit(fpga.c_str(), fpga_bitstream.c_str());
+  transport_ = OtLibFpgaInit(fpga.c_str(), fpga_bitstream.c_str());
   return absl::OkStatus();
+}
+
+void DutLib::DutLoadSramElf(const std::string& openocd,
+                            const std::string& elf) {
+  LOG(INFO) << "in DutLib::DutLoadSramElf";
+  OtLibLoadSramElf(transport_, openocd.c_str(), elf.c_str());
 }
 
 }  // namespace test_programs

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -13,6 +13,9 @@ namespace provisioning {
 namespace test_programs {
 
 class DutLib {
+ private:
+  void* transport_;
+
  public:
   DutLib(){};
 
@@ -25,6 +28,9 @@ class DutLib {
   // Calls opentitanlib backend transport init for FPGA.
   absl::Status DutInit(const std::string& fpga,
                        const std::string& fpga_bitstream);
+
+  // Calls opentitanlib test util to load an SRAM ELF into the DUT over JTAG.
+  void DutLoadSramElf(const std::string& openocd, const std::string& elf);
 };
 
 }  // namespace test_programs


### PR DESCRIPTION
This adds the ability to load SRAM programs into the DUT over JTAG to the dut_lib and otlib_wrapper. This is used by the CP test program to load the CP SRAM binary into the FPGA DUT.