### PR TITLE
[dut_lib] split transport init and FPGA bitstream load

### DIFF
--- a/src/ate/test_programs/cp.cc
+++ b/src/ate/test_programs/cp.cc
@@ -165,17 +165,9 @@ int main(int argc, char **argv) {
     return -1;
   }
 
-  // Init session with DUT.
-  auto dut = DutLib::Create();
-  absl::Status dut_status =
-      dut->DutInit(absl::GetFlag(FLAGS_fpga), fpga_bitstream_path);
-  if (!dut_status.ok()) {
-    LOG(ERROR) << "DutInit failed with " << dut_status.code() << ": "
-               << dut_status.message() << std::endl;
-    return -1;
-  }
-
-  // Load and execute CP SRAM provisioning binary.
+  // Init session with FPGA DUT and load CP provisioning firmware.
+  auto dut = DutLib::Create(absl::GetFlag(FLAGS_fpga));
+  dut->DutFpgaLoadBitstream(fpga_bitstream_path);
   dut->DutLoadSramElf(openocd_path, sram_elf_path);
 
   // Close session with PA.

--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -13,19 +13,19 @@ namespace provisioning {
 namespace test_programs {
 
 extern "C" {
-void* OtLibFpgaInit(const char* fpga, const char* fpga_bitstream);
-void* OtLibLoadSramElf(void* transport, const char* openocd, const char* elf);
+void* OtLibFpgaTransportInit(const char* fpga);
+void OtLibFpgaLoadBitstream(void* transport, const char* fpga_bitstream);
+void OtLibLoadSramElf(void* transport, const char* openocd, const char* elf);
 }
 
-std::unique_ptr<DutLib> DutLib::Create(void) {
-  return absl::make_unique<DutLib>();
+std::unique_ptr<DutLib> DutLib::Create(const std::string& fpga) {
+  return absl::WrapUnique<DutLib>(
+      new DutLib(OtLibFpgaTransportInit(fpga.c_str())));
 }
 
-absl::Status DutLib::DutInit(const std::string& fpga,
-                             const std::string& fpga_bitstream) {
-  LOG(INFO) << "in DutLib::DutInit";
-  transport_ = OtLibFpgaInit(fpga.c_str(), fpga_bitstream.c_str());
-  return absl::OkStatus();
+void DutLib::DutFpgaLoadBitstream(const std::string& fpga_bitstream) {
+  LOG(INFO) << "in DutLib::DutFpgaLoadBitstream";
+  OtLibFpgaLoadBitstream(transport_, fpga_bitstream.c_str());
 }
 
 void DutLib::DutLoadSramElf(const std::string& openocd,

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -16,18 +16,18 @@ class DutLib {
  private:
   void* transport_;
 
- public:
-  DutLib(){};
+  // Force users to call `Create` factory method.
+  DutLib(void* transport) : transport_(transport){};
 
+ public:
   // Forbids copies or assignments of DutLib.
   DutLib(const DutLib&) = delete;
   DutLib& operator=(const DutLib&) = delete;
 
-  static std::unique_ptr<DutLib> Create(void);
+  static std::unique_ptr<DutLib> Create(const std::string& fpga);
 
   // Calls opentitanlib backend transport init for FPGA.
-  absl::Status DutInit(const std::string& fpga,
-                       const std::string& fpga_bitstream);
+  void DutFpgaLoadBitstream(const std::string& fpga_bitstream);
 
   // Calls opentitanlib test util to load an SRAM ELF into the DUT over JTAG.
   void DutLoadSramElf(const std::string& openocd, const std::string& elf);


### PR DESCRIPTION
The above functionality was split into two separate functions:
1. the `Create` factory function, and
2. the `DutFpgaLoadBitstream`
functions. This enables the transport to be created when the DutLib is instantiated.