### PR TITLE
[loadtest] Enable loadtest with Thales HSM.

### DIFF
--- a/config/prod/BUILD.bazel
+++ b/config/prod/BUILD.bazel
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "deploy_config",
+    srcs = [
+        ":deploy.sh",
+    ] + glob(
+        [
+            "env/**",
+            "containers/**",
+            "spm/**",
+        ],
+        [
+            "certs/out/**",
+        ],
+    ),
+)

--- a/config/prod/containers/provapp.yml
+++ b/config/prod/containers/provapp.yml
@@ -9,51 +9,35 @@ metadata:
     app: provapp
   name: provapp
 spec:
+  hostNetwork: true
   containers:
-  # Configuration for the `spmserver` container.
-  - name: spmserver
+  # Configuration for the `paserver` container.
+  - name: paserver
     args:
-    - --port=5000
-    - --hsm_so=/usr/safenet/lunaclient/lib/libCryptoki2_64.so
-    - --spm_config_dir=/var/lib/opentitan/spm
+    - --port=5001
+    - --spm_address=localhost:5000
+    - --enable_pb
+    - --pb_address=localhost:5002
     # TODO: Update label to point to specific release version.
-    image: localhost/spm_server:latest
+    image: localhost/pa_server:latest
     resources: {}
     ports:
-      - containerPort: 5000
-        hostPort: 5000
-    env:
-      - name: SPM_HSM_PIN_USER
-        valueFrom:
-          configMapKeyRef:
-            name: spm-config
-            key: spm_hsm_pin_user
+      - containerPort: 5001
     securityContext:
       capabilities:
         drop:
         - CAP_MKNOD
         - CAP_NET_RAW
         - CAP_AUDIT_WRITE
-    volumeMounts:
-    - mountPath: /var/lib/opentitan/spm
-      name: var-lib-opentitan-spm-config-host-0
-    - mountPath: /var/lib/opentitan/spm/softhsm2
-      name: var-lib-opentitan-spm-softhsm2-host-1
-    - mountPath: /usr/safenet/lunaclient
-      name: usr-safenet-lunaclient-host-2
-    - mountPath: /etc/Chrystoki.conf
-      name: etc-chrystoki-host3
-  # Configuration for the `paserver` container.
-  - name: paserver
+  - name: pbserver
     args:
-    - --port=5001
-    - --spm_address=localhost:5000
+    - --port=5002
+    - --db_path=file::memory:?cache=shared
     # TODO: Update label to point to specific release version.
-    image: localhost/pa_server:latest
+    image: localhost/pb_server:latest
     resources: {}
     ports:
-      - containerPort: 5001
-        hostPort: 5001
+      - containerPort: 5002
     securityContext:
       capabilities:
         drop:
@@ -61,21 +45,4 @@ spec:
         - CAP_NET_RAW
         - CAP_AUDIT_WRITE
   restartPolicy: Always
-  volumes:
-  - name: var-lib-opentitan-spm-config-host-0
-    hostPath:
-      path: /var/lib/opentitan/spm
-      type: Directory
-  - name: var-lib-opentitan-spm-softhsm2-host-1
-    hostPath:
-      path: /var/lib/opentitan/spm/softhsm2
-      type: Directory
-  - name: usr-safenet-lunaclient-host-2
-    hostPath:
-      path: /usr/safenet/lunaclient
-      type: Directory
-  - name: etc-chrystoki-host3
-    hostPath:
-      path: /etc/Chrystoki.conf
-      type: File
 status: {}

--- a/config/prod/spm/sku_auth.yml
+++ b/config/prod/spm/sku_auth.yml
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+skuAuthCfgList:
+  "sival":
+    # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
+    skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
+    methods: ["DeriveSymmetricKeys", "EndorseCerts", "RegisterDevice",]

--- a/config/prod/spm/sku_sival.yml
+++ b/config/prod/spm/sku_sival.yml
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+sku: "sival"
+slotId: 0
+numSessions: 3
+symmetricKeys:
+  - name: sival-kdf-hisec-v0
+  - name: sival-kdf-losec-v0
+privateKeys:
+    - name: sival-dice-key-p256-v0
+    - name: spm-hsm-id-v0.priv
+publicKeys:
+    - name: sku-sival-rsa-rma-v0
+attributes:
+    KdfSecHi: sival-kdf-hisec-v0
+    KdfSecLo: sival-kdf-losec-v0
+    WrappingMechanism: RsaPkcs
+    WrappingKeyLabel: sku-sival-rsa-rma-v0
+    SigningKey/Dice/v0: sival-dice-key-p256-v0
+    SigningKey/Identity/v0: spm-hsm-id-v0.priv

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -55,7 +55,14 @@ pkg_tar(
         "//config/dev:deploy_config",
     ],
     extension = "tar.xz",
-    strip_prefix = "/config/dev",
+)
+
+pkg_tar(
+    name = "deploy_prod",
+    srcs = [
+        "//config/prod:deploy_config",
+    ],
+    extension = "tar.xz",
 )
 
 pkg_tar(
@@ -77,6 +84,7 @@ pkg_tar(
 release(
     name = "release",
     artifacts = {
+        ":deploy_prod": "Production deployment scripts",
         ":deploy_dev": "Development deployment scripts",
         ":provisioning_appliance_binaries": "Provisioning Appliance binaries",
         ":proxybuffer_binaries": "ProxyBuffer binaries",


### PR DESCRIPTION
This change enables the Thales HSM loadtest configuration. The `spm_server` is ran outside a container as a background process to be able to connect to the Thales HSM via ethernet. A follow up change will configure the HSM client to run inside a container.