### PR TITLE
[dut_lib] add console Wait, RX, and TX methods

### DIFF
--- a/src/ate/test_programs/cp.cc
+++ b/src/ate/test_programs/cp.cc
@@ -169,6 +169,8 @@ int main(int argc, char **argv) {
   auto dut = DutLib::Create(absl::GetFlag(FLAGS_fpga));
   dut->DutFpgaLoadBitstream(fpga_bitstream_path);
   dut->DutLoadSramElf(openocd_path, sram_elf_path);
+  dut->DutConsoleWaitForRx("Waiting for CP provisioning data ...",
+                           /*timeout_ms=*/1000);
 
   // Close session with PA.
   pa_status = ate->CloseSession();

--- a/src/ate/test_programs/dut_lib/BUILD.bazel
+++ b/src/ate/test_programs/dut_lib/BUILD.bazel
@@ -21,7 +21,6 @@ cc_library(
         "//src/ate:ate_client",
         "//src/ate/test_programs/otlib_wrapper",
         "@com_google_absl//absl/log",
-        "@com_google_absl//absl/status",
         "@lowrisc_opentitan//sw/host/opentitanlib",
     ],
 )

--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -16,6 +16,11 @@ extern "C" {
 void* OtLibFpgaTransportInit(const char* fpga);
 void OtLibFpgaLoadBitstream(void* transport, const char* fpga_bitstream);
 void OtLibLoadSramElf(void* transport, const char* openocd, const char* elf);
+void OtLibConsoleWaitForRx(void* transport, const char* msg,
+                           uint64_t timeout_ms);
+void OtLibConsoleRx(void* transport, bool quiet, uint64_t timeout_ms,
+                    uint8_t* msg, size_t* msg_size);
+void OtLibConsoleTx(void* transport, const char* msg);
 }
 
 std::unique_ptr<DutLib> DutLib::Create(const std::string& fpga) {
@@ -32,6 +37,25 @@ void DutLib::DutLoadSramElf(const std::string& openocd,
                             const std::string& elf) {
   LOG(INFO) << "in DutLib::DutLoadSramElf";
   OtLibLoadSramElf(transport_, openocd.c_str(), elf.c_str());
+}
+
+void DutLib::DutConsoleWaitForRx(const char* msg, uint64_t timeout_ms) {
+  LOG(INFO) << "in DutLib::DutConsoleWaitForRx";
+  OtLibConsoleWaitForRx(transport_, msg, timeout_ms);
+}
+
+std::string DutLib::DutConsoleRx(bool quiet, uint64_t timeout_ms) {
+  LOG(INFO) << "in DutLib::DutConsoleRx";
+  size_t msg_size = kMaxRxMsgSizeInBytes;
+  OtLibConsoleRx(transport_, quiet, timeout_ms,
+                 reinterpret_cast<uint8_t*>(console_msg_buf_), &msg_size);
+  std::string result(console_msg_buf_, msg_size);
+  return result;
+}
+
+void DutLib::DutConsoleTx(std::string& msg) {
+  LOG(INFO) << "in DutLib::DutConsoleTx";
+  OtLibConsoleTx(transport_, msg.c_str());
 }
 
 }  // namespace test_programs

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -12,38 +12,47 @@ namespace provisioning {
 namespace test_programs {
 
 class DutLib {
+ public:
+  /**
+   * Factory method for instantiating and initializing this object.
+   */
+  static std::unique_ptr<DutLib> Create(const std::string& fpga);
+  /**
+   * Forbids copies or assignments of DutLib.
+   */
+  DutLib(const DutLib&) = delete;
+  DutLib& operator=(const DutLib&) = delete;
+  /**
+   * Calls opentitanlib backend transport init for FPGA.
+   */
+  void DutFpgaLoadBitstream(const std::string& fpga_bitstream);
+  /**
+   * Calls opentitanlib test util to load an SRAM ELF into the DUT over JTAG.
+   */
+  void DutLoadSramElf(const std::string& openocd, const std::string& elf);
+  /**
+   * Calls opentitanlib test util to wait for a message over the SPI console.
+   */
+  void DutConsoleWaitForRx(const char*, uint64_t timeout_ms);
+  /**
+   * Calls opentitanlib test util to receive a message over the SPI console.
+   */
+  std::string DutConsoleRx(bool quiet, uint64_t timeout_ms);
+  /**
+   * Calls opentitanlib test util to send a message over the SPI console.
+   */
+  void DutConsoleTx(std::string& msg);
+
  private:
   // Must match the opentitanlib UartConsole buffer size defined here:
   // https://github.com/lowRISC/opentitan/blob/673199e30f85db799df6a31c983e8e41c8afb6c8/sw/host/opentitanlib/src/uart/console.rs#L46
   static constexpr size_t kMaxRxMsgSizeInBytes = 16384;
 
+  // Force users to call `Create` factory method.
+  DutLib(void* transport) : transport_(transport){};
+
   void* transport_;
   char console_msg_buf_[kMaxRxMsgSizeInBytes];
-
-  // Force users to call `Create` factory method.
-  DutLib(void* transport) : transport_(transport) {};
-
- public:
-  // Forbids copies or assignments of DutLib.
-  DutLib(const DutLib&) = delete;
-  DutLib& operator=(const DutLib&) = delete;
-
-  static std::unique_ptr<DutLib> Create(const std::string& fpga);
-
-  // Calls opentitanlib backend transport init for FPGA.
-  void DutFpgaLoadBitstream(const std::string& fpga_bitstream);
-
-  // Calls opentitanlib test util to load an SRAM ELF into the DUT over JTAG.
-  void DutLoadSramElf(const std::string& openocd, const std::string& elf);
-
-  // Calls opentitanlib test util to wait for a message over the SPI console.
-  void DutConsoleWaitForRx(const char*, uint64_t timeout_ms);
-
-  // Calls opentitanlib test util to receive a message over the SPI console.
-  std::string DutConsoleRx(bool quiet, uint64_t timeout_ms);
-
-  // Calls opentitanlib test util to send a message over the SPI console.
-  void DutConsoleTx(std::string& msg);
 };
 
 }  // namespace test_programs

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -5,19 +5,23 @@
 #ifndef OPENTITAN_PROVISIONING_SRC_ATE_TEST_PROGRAMS_DUT_LIB_DUT_LIB_H_
 #define OPENTITAN_PROVISIONING_SRC_ATE_TEST_PROGRAMS_DUT_LIB_DUT_LIB_H_
 
+#include <memory>
 #include <string>
-
-#include "absl/status/status.h"
 
 namespace provisioning {
 namespace test_programs {
 
 class DutLib {
  private:
+  // Must match the opentitanlib UartConsole buffer size defined here:
+  // https://github.com/lowRISC/opentitan/blob/673199e30f85db799df6a31c983e8e41c8afb6c8/sw/host/opentitanlib/src/uart/console.rs#L46
+  static constexpr size_t kMaxRxMsgSizeInBytes = 16384;
+
   void* transport_;
+  char console_msg_buf_[kMaxRxMsgSizeInBytes];
 
   // Force users to call `Create` factory method.
-  DutLib(void* transport) : transport_(transport){};
+  DutLib(void* transport) : transport_(transport) {};
 
  public:
   // Forbids copies or assignments of DutLib.
@@ -31,6 +35,15 @@ class DutLib {
 
   // Calls opentitanlib test util to load an SRAM ELF into the DUT over JTAG.
   void DutLoadSramElf(const std::string& openocd, const std::string& elf);
+
+  // Calls opentitanlib test util to wait for a message over the SPI console.
+  void DutConsoleWaitForRx(const char*, uint64_t timeout_ms);
+
+  // Calls opentitanlib test util to receive a message over the SPI console.
+  std::string DutConsoleRx(bool quiet, uint64_t timeout_ms);
+
+  // Calls opentitanlib test util to send a message over the SPI console.
+  void DutConsoleTx(std::string& msg);
 };
 
 }  // namespace test_programs

--- a/src/ate/test_programs/otlib_wrapper/BUILD.bazel
+++ b/src/ate/test_programs/otlib_wrapper/BUILD.bazel
@@ -12,6 +12,9 @@ rust_library(
         "src/lib.rs",
     ],
     deps = [
+        "@crate_index//:anyhow",
+        "@crate_index//:crc",
+        "@crate_index//:regex",
         "@lowrisc_opentitan//sw/host/opentitanlib",
     ],
 )


### PR DESCRIPTION
This adds several methods to the DUT lib for interacting with the SPI console including:
1. waiting for a specific message to be received,
2. UJSON message RX, and
3. UJSON message TX.

These primitives will be used to send and receive UJSON messages (a strict subset of JSON, specific to the OpenTitan project) to/from OpenTitan DUTs.