### PR TITLE
[dut_lib] optimize memory allocation of console RX buffer

### DIFF
--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -47,9 +47,11 @@ void DutLib::DutConsoleWaitForRx(const char* msg, uint64_t timeout_ms) {
 std::string DutLib::DutConsoleRx(bool quiet, uint64_t timeout_ms) {
   LOG(INFO) << "in DutLib::DutConsoleRx";
   size_t msg_size = kMaxRxMsgSizeInBytes;
+  std::string result(kMaxRxMsgSizeInBytes, '\0');
   OtLibConsoleRx(transport_, quiet, timeout_ms,
-                 reinterpret_cast<uint8_t*>(console_msg_buf_), &msg_size);
-  std::string result(console_msg_buf_, msg_size);
+                 reinterpret_cast<uint8_t*>(const_cast<char*>(result.data())),
+                 &msg_size);
+  result.resize(msg_size);
   return result;
 }
 

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -52,7 +52,6 @@ class DutLib {
   DutLib(void* transport) : transport_(transport){};
 
   void* transport_;
-  char console_msg_buf_[kMaxRxMsgSizeInBytes];
 };
 
 }  // namespace test_programs

--- a/src/ate/test_programs/otlib_wrapper/src/lib.rs
+++ b/src/ate/test_programs/otlib_wrapper/src/lib.rs
@@ -231,7 +231,9 @@ pub extern "C" fn OtLibConsoleRx(
     };
 
     // Receive the payload from DUT.
+    // SAFETY: msg_size should be a valid pointer to memory allocated by the caller.
     let msg_size = unsafe { &mut *msg_size };
+    // SAFETY: msg should be a valid pointer to memory allocated by the caller.
     let msg = unsafe { std::slice::from_raw_parts_mut(msg, *msg_size) };
     let result = console.interact(&spi_console, None, out).unwrap();
     println!();


### PR DESCRIPTION
This optimizing the memory allocation of the console RX buffer to address this review comment:
https://github.com/lowRISC/opentitan-provisioning/pull/101#discussion_r1996248605

Note, the version of the dut_lib this commit addresses should only ever be used in FPGA testing environments, where performance requirements are relaxed.