### PR TITLE
[spm] fix key size returned by `DeriveSymmetricKey`

### DIFF
--- a/src/spm/services/se_pk11.go
+++ b/src/spm/services/se_pk11.go
@@ -293,6 +293,11 @@ func (h *HSM) GenerateSymmetricKeys(params []*SymmetricKeygenParams) ([]Symmetri
 			return nil, status.Errorf(codes.Internal, "failed to hash seed: %v", err)
 		}
 
+		// Truncate token if size is 128-bits (only valid value < 256 bits).
+		if p.SizeInBits == 128 {
+			keyBytes = keyBytes[:16]
+		}
+
 		if p.KeyOp == SymmetricKeyOpHashedOtLcToken {
 			// OpenTitan lifecycle tokens are stored in OTP in hashed form using the
 			// cSHAKE128 algorithm with the "LC_CTRL" customization string.

--- a/src/spm/services/se_pk11_test.go
+++ b/src/spm/services/se_pk11_test.go
@@ -170,7 +170,7 @@ func TestGenerateSymmKeys(t *testing.T) {
 		}
 		h2 := hmac.New(sha256.New, k)
 		h2.Write([]byte(p.Sku + p.Diversifier))
-		expected_key := h2.Sum(nil)
+		expected_key := h2.Sum(nil)[:p.SizeInBits/8]
 
 		if p.KeyOp == SymmetricKeyOpHashedOtLcToken {
 			hasher := sha3.NewCShake128([]byte(""), []byte("LC_CTRL"))
@@ -231,6 +231,7 @@ func TestGenerateSymmKeysWrap(t *testing.T) {
 
 		keyBytes, err := seed.SignHMAC256([]byte(rmaParams.Sku + rmaParams.Diversifier))
 		ts.Check(t, err)
+		keyBytes = keyBytes[:rmaParams.SizeInBits/8]
 
 		hasher := sha3.NewCShake128([]byte(""), []byte("LC_CTRL"))
 		hasher.Write(keyBytes)


### PR DESCRIPTION
This fixes #112 by returning a key of the requested key size, i.e., the SPM now does the proper truncation after the HMAC-KDF operation instead of requiring the client to perform this operation.