### PR TITLE
[pa,spm] add GetStoredTokens RPC

### DIFF
--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -23,6 +23,8 @@ service ProvisioningApplianceService {
     returns (EndorseCertsResponse) {}
   rpc DeriveSymmetricKeys(DeriveSymmetricKeysRequest)
     returns (DeriveSymmetricKeysResponse) {}
+  rpc GetStoredTokens(GetStoredTokensRequest)
+    returns (GetStoredTokensResponse) {}
   rpc RegisterDevice(RegistrationRequest)
     returns (RegistrationResponse) {}
 }
@@ -127,10 +129,23 @@ message SymmetricKey {
 
 // Derive symmetric keys response.
 message DeriveSymmetricKeysResponse{
-  // Key. Size is provided in the request.
+  // Keys. Size is provided in the request.
   repeated SymmetricKey keys = 1;
 }
 
+// Get stored tokens response.
+message GetStoredTokensRequest{
+  // SKU identifier. Required.
+  string sku = 1;
+  // Token identifier. Required.
+  string token = 2;
+}
+
+// Get stored tokens response.
+message GetStoredTokensResponse{
+  // Tokens. Size is provided in the request.
+  repeated bytes tokens = 1;
+}
 
 // Initialize SKU session request.
 message InitSessionRequest {

--- a/src/pa/services/pa.go
+++ b/src/pa/services/pa.go
@@ -131,6 +131,16 @@ func (s *server) DeriveSymmetricKeys(ctx context.Context, request *pap.DeriveSym
 	return r, nil
 }
 
+// GetStoredTokens retrieves a token stored within the SPM.
+func (s *server) GetStoredTokens(ctx context.Context, request *pap.GetStoredTokensRequest) (*pap.GetStoredTokensResponse, error) {
+	log.Printf("In PA - Received GetStoredTokens request")
+	r, err := s.spmClient.GetStoredTokens(ctx, request)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "SPM returned error: %v", err)
+	}
+	return r, nil
+}
+
 // RegisterDevice registers a new device record in the registry database.
 //
 // The registry database is accessed through the ProxyBuffer or any downstream

--- a/src/pa/services/pa_test.go
+++ b/src/pa/services/pa_test.go
@@ -63,6 +63,7 @@ func (c *fakePbClient) RegisterDevice(ctx context.Context, request *pbr.DeviceRe
 type fakeSpmClient struct {
 	initSession         initSessionResponse
 	deriveSymmetricKeys deriveSymmetricKeysResponse
+	getStoredTokens     getStoredTokensResponse
 	endorseCerts        endorseCertsResponse
 	endorseData         endorseDataResponse
 }
@@ -74,6 +75,11 @@ type initSessionResponse struct {
 
 type deriveSymmetricKeysResponse struct {
 	response *pbp.DeriveSymmetricKeysResponse
+	err      error
+}
+
+type getStoredTokensResponse struct {
+	response *pbp.GetStoredTokensResponse
 	err      error
 }
 
@@ -93,6 +99,10 @@ func (c *fakeSpmClient) InitSession(ctx context.Context, request *pbp.InitSessio
 
 func (c *fakeSpmClient) DeriveSymmetricKeys(ctx context.Context, request *pbp.DeriveSymmetricKeysRequest, opts ...grpc.CallOption) (*pbp.DeriveSymmetricKeysResponse, error) {
 	return c.deriveSymmetricKeys.response, c.deriveSymmetricKeys.err
+}
+
+func (c *fakeSpmClient) GetStoredTokens(ctx context.Context, request *pbp.GetStoredTokensRequest, opts ...grpc.CallOption) (*pbp.GetStoredTokensResponse, error) {
+	return c.getStoredTokens.response, c.getStoredTokens.err
 }
 
 func (c *fakeSpmClient) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequest, opts ...grpc.CallOption) (*pbp.EndorseCertsResponse, error) {

--- a/src/spm/proto/spm.proto
+++ b/src/spm/proto/spm.proto
@@ -28,6 +28,10 @@ service SpmService {
   rpc DeriveSymmetricKeys(pa.DeriveSymmetricKeysRequest)
       returns (pa.DeriveSymmetricKeysResponse) {}
 
+  // GetStoredTokens retrieves a token preprovisioned on the SPM.
+  rpc GetStoredTokens(pa.GetStoredTokensRequest)
+      returns (pa.GetStoredTokensResponse) {}
+
   // EndorseCerts endorses a set of certificates for a given SKU. The
   // certificates are signed with a CA private key stored in the SPM.
   rpc EndorseCerts(pa.EndorseCertsRequest)

--- a/src/spm/services/spm.go
+++ b/src/spm/services/spm.go
@@ -311,6 +311,11 @@ func ecdsaSignatureAlgorithmFromHashType(h pbcommon.HashType) x509.SignatureAlgo
 	}
 }
 
+// GetStoredTokens retrieves a provisioned token from the SPM's HSM.
+func (s *server) GetStoredTokens(ctx context.Context, request *pbp.GetStoredTokensRequest) (*pbp.GetStoredTokensResponse, error) {
+	return nil, status.Errorf(codes.Internal, "SPM.GetStoredTokens - unimplemented")
+}
+
 func (s *server) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequest) (*pbp.EndorseCertsResponse, error) {
 	log.Printf("SPM.EndorseCertsRequest - Sku:%q", request.Sku)
 


### PR DESCRIPTION
This adds a GetStoredTokens RPC to the PA/SPM to support retrieving RawUnlock tokens from the SPM during CP. This does not yet implement the RPC, only adds the appropriate protos and template code. This partially addresses #116.