### PR TITLE
[spm] make SKU authorization file a runtime parameter

### DIFF
--- a/config/dev/containers/provapp.yml.tmpl
+++ b/config/dev/containers/provapp.yml.tmpl
@@ -23,6 +23,7 @@ spec:
     - --ca_root_certs=/var/lib/opentitan/config/dev/certs/out/ca-cert.pem
     - --port=${OTPROV_PORT_SPM}
     - --hsm_so=/usr/local/lib/softhsm/libsofthsm2.so
+    - --spm_auth_config=sku_auth.yml
     - --spm_config_dir=/var/lib/opentitan/config/dev/spm
     # TODO: Update label to point to specific release version.
     image: localhost/spm_server:latest

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -87,6 +87,7 @@ if [[ -n "${OT_PROV_PROD_EN}" ]]; then
     --ca_root_certs=${DEPLOYMENT_DIR}/certs/out/ca-cert.pem \
     --port=${OTPROV_PORT_SPM} \
     "--hsm_so=${HSMTOOL_MODULE}" \
+    --spm_auth_config="sku_auth.yml" \
     "--spm_config_dir=${DEPLOYMENT_DIR}/spm" &
   echo $! > "${SPM_PID_FILE}"
 fi

--- a/src/spm/spm_server.go
+++ b/src/spm/spm_server.go
@@ -20,15 +20,16 @@ import (
 )
 
 var (
-	port         = flag.Int("port", 0, "The port to bind the server on; required")
-	hsmPWFile    = flag.String("hsm_pw", "", "File path to the HSM's Password; required for TPM")
-	hsmSOPath    = flag.String("hsm_so", "", "File path to the PCKS#11 .so library used to interface to the HSM")
-	enableTLS    = flag.Bool("enable_tls", false, "Enable mTLS secure channel; optional")
-	serviceKey   = flag.String("service_key", "", "File path to the PEM encoding of the server's private key")
-	serviceCert  = flag.String("service_cert", "", "File path to the PEM encoding of the server's certificate chain")
-	caRootCerts  = flag.String("ca_root_certs", "", "File path to the PEM encoding of the CA root certificates")
-	spmConfigDir = flag.String("spm_config_dir", "", "Path to the configuration directory.")
-	version      = flag.Bool("version", false, "Print version information and exit")
+	port          = flag.Int("port", 0, "The port to bind the server on; required")
+	hsmPWFile     = flag.String("hsm_pw", "", "File path to the HSM's Password; required for TPM")
+	hsmSOPath     = flag.String("hsm_so", "", "File path to the PCKS#11 .so library used to interface to the HSM")
+	enableTLS     = flag.Bool("enable_tls", false, "Enable mTLS secure channel; optional")
+	serviceKey    = flag.String("service_key", "", "File path to the PEM encoding of the server's private key")
+	serviceCert   = flag.String("service_cert", "", "File path to the PEM encoding of the server's certificate chain")
+	caRootCerts   = flag.String("ca_root_certs", "", "File path to the PEM encoding of the CA root certificates")
+	spmAuthConfig = flag.String("spm_auth_config", "", "File path to the SPM Auth configuration file. Relative to the SPM configuration directory.")
+	spmConfigDir  = flag.String("spm_config_dir", "", "Path to the configuration directory.")
+	version       = flag.Bool("version", false, "Print version information and exit")
 )
 
 func startSPMServer() (*grpc.Server, error) {
@@ -43,9 +44,10 @@ func startSPMServer() (*grpc.Server, error) {
 	}
 
 	spmServer, err := spm.NewSpmServer(spm.Options{
-		HSMSOLibPath: *hsmSOPath,
-		SPMConfigDir: *spmConfigDir,
-		HsmPWFile:    *hsmPWFile,
+		HSMSOLibPath:      *hsmSOPath,
+		SPMAuthConfigFile: *spmAuthConfig,
+		SPMConfigDir:      *spmConfigDir,
+		HsmPWFile:         *hsmPWFile,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add `--spm_auth_config` CLI flag to spm_server to be able to configure the SKU authentication filename at runtime.

Fixes: https://github.com/lowRISC/opentitan-provisioning/issues/35