### PR TITLE
[pb] Update schema to match query patterns and add sync state.

### DIFF
--- a/src/pa/loadtest.go
+++ b/src/pa/loadtest.go
@@ -248,6 +248,9 @@ func testOTRegisterDevice(ctx context.Context, numCalls int, skuName string, c *
 			log.Printf("error: client id: %d, error: %v", c.id, err)
 		}
 		c.results <- &callResult{id: c.id, err: err}
+		// Since the device IDs need to be unique, subsequent calls with the same ID will
+		// result in an already exists error. Increment to prevent that from happening. bg; p\c
+		request.DeviceData.DeviceId.HardwareOrigin.DeviceIdentificationNumber++
 		time.Sleep(c.delayPerCall)
 	}
 }

--- a/src/pa/loadtest.go
+++ b/src/pa/loadtest.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"strconv"
 	"time"
@@ -231,7 +232,7 @@ func testOTRegisterDevice(ctx context.Context, numCalls int, skuName string, c *
 				HardwareOrigin: &dpb.HardwareOrigin{
 					SiliconCreatorId:           dpb.SiliconCreatorId_SILICON_CREATOR_ID_OPENSOURCE,
 					ProductId:                  dpb.ProductId_PRODUCT_ID_EARLGREY_Z1,
-					DeviceIdentificationNumber: uint64(c.id), // Each device ID must be unique.
+					DeviceIdentificationNumber: rand.Uint64(), // Each device ID must be unique.
 				},
 				SkuSpecific: make([]byte, dtd.DeviceIdSkuSpecificLenInBytes),
 			},
@@ -249,8 +250,8 @@ func testOTRegisterDevice(ctx context.Context, numCalls int, skuName string, c *
 		}
 		c.results <- &callResult{id: c.id, err: err}
 		// Since the device IDs need to be unique, subsequent calls with the same ID will
-		// result in an already exists error. Increment to prevent that from happening. bg; p\c
-		request.DeviceData.DeviceId.HardwareOrigin.DeviceIdentificationNumber++
+		// result in an already exists error.
+		request.DeviceData.DeviceId.HardwareOrigin.DeviceIdentificationNumber = rand.Uint64()
 		time.Sleep(c.delayPerCall)
 	}
 }

--- a/src/proxy_buffer/store/filedb_test.go
+++ b/src/proxy_buffer/store/filedb_test.go
@@ -23,18 +23,18 @@ func newDB(t *testing.T) connector.Connector {
 
 func TestInsert(t *testing.T) {
 	db := newDB(t)
-	if err := db.Insert(context.Background(), "key", "sku", []byte("value")); err != nil {
+	if err := db.Insert(context.Background(), "key1", "sku", []byte("value")); err != nil {
 		t.Errorf("Insert failed: %v", err)
 	}
 }
 
 func TestGet(t *testing.T) {
 	db := newDB(t)
-	if err := db.Insert(context.Background(), "key", "sku", []byte("value")); err != nil {
+	if err := db.Insert(context.Background(), "key2", "sku", []byte("value")); err != nil {
 		t.Errorf("Insert failed: %v", err)
 	}
 
-	value, err := db.Get(context.Background(), "key")
+	value, err := db.Get(context.Background(), "key2")
 	if err != nil {
 		t.Errorf("Get failed: %v", err)
 	}


### PR DESCRIPTION
All queries are based on the device ID which will now be used as the primary key. Also adds a sync state to be used for syncing with external registries.