### PR TITLE
[proto] add perso FW hash field to DeviceData

### DIFF
--- a/src/proto/device_id.proto
+++ b/src/proto/device_id.proto
@@ -162,4 +162,6 @@ message DeviceData {
   //
   // (Size is enforced at a higher level, not by protobuf).
   bytes perso_tlv_data = 6;
+  // Personalization firmware SHA256 hash.
+  bytes perso_fw_sha256_hash = 7;
 }


### PR DESCRIPTION
The perso FW hash will be logged during perso flows and should be registered in the database.