### PR TITLE
[dev] Generate SKU specific CA certificates.

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -17,6 +17,7 @@ g++
 git
 gnupg
 golang
+libengine-pkcs11-openssl
 libftdi1-2
 libftdi1-dev
 libncursesw5

--- a/config/dev/spm/sku/.gitignore
+++ b/config/dev/spm/sku/.gitignore
@@ -1,2 +1,4 @@
 **.bin
 **.pem
+**.csr
+**.tar.gz

--- a/config/dev/spm/sku/sival/01.hsm_offline.hjson
+++ b/config/dev/spm/sku/sival/01.hsm_offline.hjson
@@ -63,6 +63,25 @@
     }
     {
         "command": "ecdsa-generate",
+        "label": "opentitan-ca-root-v0",
+        "curve": "1.2.840.10045.3.1.7",
+        "wrapping": false,
+        "extractable": false,
+        "public_template": {
+            CKA_LABEL: "opentitan-ca-root-v0.pub",
+            CKA_VERIFY: true,
+            CKA_TOKEN: true,
+        },
+        "private_template": {
+            CKA_LABEL: "opentitan-ca-root-v0.priv",
+            CKA_SIGN: true,
+            CKA_TOKEN: true,
+            CKA_EXTRACTABLE: true,
+            CKA_SENSITIVE: true,
+        }
+    }
+    {
+        "command": "ecdsa-generate",
         "label": "sival-dice-key-p256-v0"
         "curve": "1.2.840.10045.3.1.7",
         "wrapping": false,
@@ -107,44 +126,44 @@
         "label": "sival-aes-wrap-v0",
         "wrap": "spm-rsa-wrap-v0",
         "wrap_mechanism": "RsaPkcs",
-        "output": "sival-aes-wrap-v0.bin"
+        "output": "hsm/sival-aes-wrap-v0.bin"
     }
     {
         "command": "rsa-export",
         "label": "sku-sival-rsa-rma-v0.pub",
         "private": false,
         "format": "Pem",
-        "filename": "sku-sival-rsa-rma-v0.pub.pem"
+        "filename": "pub/sku-sival-rsa-rma-v0.pub.pem"
     }
     {
         "command": "ecdsa-export",
         "label": "sival-dice-key-p256-v0.pub",
         "private": false,
         "format": "Pem",
-        "filename": "sival-dice-key-p256-v0.pub.pem"
+        "filename": "pub/sival-dice-key-p256-v0.pub.pem"
     }
     {
         "command": "ecdsa-export",
         "label": "sival-dice-key-p256-v0.priv",
         "private": true,
-        "format": "Pem",
+        "format": "Der",
         "wrap": "sival-aes-wrap-v0",
         "wrap_mechanism": "AesKeyWrap",
-        "filename": "sival-dice-key-p256-v0.pem"
+        "filename": "hsm/sival-dice-key-p256-v0.wrapped.bin"
     }
     {
         "command": "kdf-export",
         "label": "sival-kdf-hisec-v0",
         "wrap": "sival-aes-wrap-v0",
         "wrap_mechanism": "AesKeyWrap",
-        "output": "sival-kdf-hisec-v0.bin"
+        "output": "hsm/sival-kdf-hisec-v0.bin"
     }
     {
         "command": "kdf-export",
         "label": "sival-kdf-losec-v0",
         "wrap": "sival-aes-wrap-v0",
         "wrap_mechanism": "AesKeyWrap",
-        "output": "sival-kdf-losec-v0.bin"
+        "output": "hsm/sival-kdf-losec-v0.bin"
     }
 ]
 

--- a/config/dev/spm/sku/sival/02.hsm_spm.hjson
+++ b/config/dev/spm/sku/sival/02.hsm_spm.hjson
@@ -20,13 +20,13 @@
       CKA_TOKEN: true,
       CKA_UNWRAP: true,
     },
-    "filename": "sival-aes-wrap-v0.bin"
+    "filename": "hsm/sival-aes-wrap-v0.bin"
   }
   {
     "command": "rsa-import",
     "label": "sku-sival-rsa-rma-v0",
     "public": true,
-    "filename": "sku-sival-rsa-rma-v0.pub.pem",
+    "filename": "pub/sku-sival-rsa-rma-v0.pub.pem",
     "public_attrs": {
       CKA_ENCRYPT: true,
       CKA_TOKEN: true,
@@ -44,7 +44,7 @@
         CKA_SIGN: true
         CKA_TOKEN: true,
     }
-    "filename": "sival-dice-key-p256-v0.pem"
+    "filename": "hsm/sival-dice-key-p256-v0.wrapped.bin"
   }
   {
     "command": "kdf-import",
@@ -57,7 +57,7 @@
       CKA_SIGN: true,
       CKA_TOKEN: true,
     },
-    "filename": "sival-kdf-hisec-v0.bin"
+    "filename": "hsm/sival-kdf-hisec-v0.bin"
   }
   {
     "command": "kdf-import",
@@ -70,6 +70,6 @@
       CKA_SIGN: true,
       CKA_TOKEN: true,
     },
-    "filename": "sival-kdf-losec-v0.bin"
+    "filename": "hsm/sival-kdf-losec-v0.bin"
   }
 ]

--- a/config/dev/spm/sku/sival/ca_int_dice.conf
+++ b/config/dev/spm/sku/sival/ca_int_dice.conf
@@ -1,0 +1,18 @@
+[req]
+prompt = no
+default_md = sha256
+distinguished_name = dn
+x509_extensions = v3_ca
+
+[dn]
+C=US
+ST=CA
+O=Google
+OU=Engineering
+CN=Google Engineering OpenTitan ICA
+
+[v3_ca]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+basicConstraints = critical,CA:true
+keyUsage = digitalSignature, keyCertSign, cRLSign

--- a/config/dev/spm/sku/sival/ca_root.conf
+++ b/config/dev/spm/sku/sival/ca_root.conf
@@ -1,0 +1,17 @@
+[req]
+prompt = no
+default_md = sha256
+distinguished_name = dn
+x509_extensions = v3_ca
+
+[dn]
+C=IL
+O=Nuvoton Technology Corporation
+OU=Engineering
+CN=Nuvoton Technology OpenTitan Root CA
+
+[v3_ca]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+basicConstraints = critical,CA:true
+keyUsage = digitalSignature, keyCertSign, cRLSign

--- a/config/dev/spm/sku/sival/hsm_sku_init.sh
+++ b/config/dev/spm/sku/sival/hsm_sku_init.sh
@@ -6,10 +6,50 @@
 set -e
 
 # The script must be executed from its local directory.
+readonly OUTDIR_HSM="hsm"
+readonly OUTDIR_CA="ca"
+readonly OUTDIR_PUB="pub"
+
+# certgen generates a certificate for the given config file and signs it with
+# the given CA key.
+certgen () {
+  config_basename=$1
+  ca_key=$2
+  endorsing_key=$3
+
+  # Generate the CA certificate for the root CA.
+  SOFTHSM2_CONF="${SOFTHSM2_CONF_OFFLINE}" \
+  PKCS11_MODULE_PATH="${HSMTOOL_MODULE}" \
+  openssl req -new -engine pkcs11 -keyform engine \
+    -config "${config_basename}.conf" \
+    -out "${OUTDIR_CA}/${config_basename}.csr" \
+    -key "pkcs11:pin-value=${HSMTOOL_PIN};object=${ca_key}"
+
+  SOFTHSM2_CONF="${SOFTHSM2_CONF_OFFLINE}" \
+  PKCS11_MODULE_PATH="${HSMTOOL_MODULE}" \
+  openssl x509 -req -engine pkcs11 -keyform engine \
+    -in "${OUTDIR_CA}/${config_basename}.csr" \
+    -out "${OUTDIR_CA}/${config_basename}.pem" \
+    -days 3650 \
+    -extfile "${config_basename}.conf" \
+    -extensions v3_ca \
+    -signkey "pkcs11:pin-value=${HSMTOOL_PIN};object=${endorsing_key}"
+}
+
+# Create output directory for HSM exported files.
+mkdir -p "${OUTDIR_HSM}" "${OUTDIR_CA}" "${OUTDIR_PUB}"
+
+echo "Configuring Offline HSM"
 SOFTHSM2_CONF="${SOFTHSM2_CONF_OFFLINE}" "${OPENTITAN_VAR_DIR}/bin/hsmtool" \
   --logging=info                     \
   --token="${SPM_HSM_TOKEN_OFFLINE}" \
   exec "01.hsm_offline.hjson"
+
+echo "Generating CA certificates"
+certgen ca_root opentitan-ca-root-v0.priv opentitan-ca-root-v0.priv
+certgen ca_int_dice sival-dice-key-p256-v0.priv opentitan-ca-root-v0.priv
+
+tar -czvf sival.tar.gz "${OUTDIR_HSM}" "${OUTDIR_CA}" "${OUTDIR_PUB}"
 
 "${OPENTITAN_VAR_DIR}/bin/hsmtool" \
   --logging=info                   \


### PR DESCRIPTION
This change adds root and intermediate CA certificates for the SiVal SKU in the `DEV` environment. OpenSSL is used to generate CSRs and final certificates.

The output from the `hsm_sku_init.sh` script is now under the following subdirs:

* `hsm`: HSM intermediate outputs, i.e. wrapped keys exported from the offline HSM and imported into the SPM HSM.
* `ca`: SKU root and intermediate CAs.
* `pub`: SKU public keys.