### PR TITLE
[dev] split offline/spm HSM init scripts.

### DIFF
--- a/config/dev/spm/sku/BUILD.bazel
+++ b/config/dev/spm/sku/BUILD.bazel
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "spm_init",
+    srcs = [
+        ":hsm_spm_init.hjson",
+        ":hsm_spm_init.sh",
+    ],
+    extension = "tar.gz",
+)

--- a/config/dev/spm/sku/hsm_spm_init.hjson
+++ b/config/dev/spm/sku/hsm_spm_init.hjson
@@ -53,6 +53,6 @@
         "label": "spm-rsa-wrap-v0",
         "private": false,
         "format": "Pem",
-        "filename": "spm-rsa-wrap-v0.pem"
+        "filename": "pub/spm-rsa-wrap-v0.pem"
     }
 ]

--- a/config/dev/spm/sku/hsm_spm_init.sh
+++ b/config/dev/spm/sku/hsm_spm_init.sh
@@ -5,8 +5,54 @@
 
 set -e
 
+usage () {
+  echo "Usage: $0 [-o <output.tar.gz>]"
+  echo "  -o <output.tar.gz> Path to the output tarball."
+  exit 1
+}
+
+FLAGS_OUT_TAR=""
+
+while getopts 'o:' opt; do
+  case "${opt}" in
+    o)
+      FLAGS_OUT_TAR="${OPTARG}"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [[ "$#" -gt 0 ]]; then
+  echo "Unexpected arguments:" "$@" >&2
+  exit 1
+fi
+
+if [[ -z "${FLAGS_OUT_TAR}" ]]; then
+  echo "Error: Output tarball not specified."
+  exit 1
+fi
+
+if [[ "${FLAGS_OUT_TAR}" != *.tar.gz  ]]; then
+  echo "Error: Output tarball must have .tar.gz extension."
+  exit 1
+fi
+
+if [[ ! -x "${HSMTOOL_BIN}" ]]; then
+  echo "Error: HSMTOOL_BIN is not set or not executable."
+  exit 1
+fi
+
+readonly OUTDIR_PUB="pub"
+
+mkdir -p "${OUTDIR_PUB}"
+
 # The script must be executed from its local directory.
-"${OPENTITAN_VAR_DIR}/bin/hsmtool" \
+"${HSMTOOL_BIN}"                   \
   --logging=info                   \
   --token="${SPM_HSM_TOKEN_SPM}"   \
    exec "hsm_spm_init.hjson"
+
+tar -czvf "${FLAGS_OUT_TAR}" "${OUTDIR_PUB}"

--- a/config/dev/spm/sku/sival/01.hsm_offline.hjson
+++ b/config/dev/spm/sku/sival/01.hsm_offline.hjson
@@ -21,7 +21,7 @@
             CKA_WRAP: true,
             CKA_TOKEN: true,
         },
-        "filename": "../spm-rsa-wrap-v0.pem"
+        "filename": "pub/spm-rsa-wrap-v0.pem"
     }
 
     // Key generation commands.

--- a/config/dev/spm/sku/sival/BUILD.bazel
+++ b/config/dev/spm/sku/sival/BUILD.bazel
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "sival_offline_hsm",
+    srcs = [
+        ":01.hsm_offline.hjson",
+        ":ca_int_dice.conf",
+        ":ca_root.conf",
+        ":hsm_offline_init.sh",
+    ],
+)
+
+pkg_tar(
+    name = "sival_spm_hsm",
+    srcs = [
+        ":02.hsm_spm.hjson",
+        ":hsm_spm_init.sh",
+    ],
+)

--- a/config/dev/spm/sku/sival/hsm_offline_init.sh
+++ b/config/dev/spm/sku/sival/hsm_offline_init.sh
@@ -6,9 +6,63 @@
 set -e
 
 # The script must be executed from its local directory.
+usage () {
+  echo "Usage: $0 -i <input.tar.gz> -o <output.tar.gz>"
+  echo "  -i <input.tar.gz>  Path to the input tarball."
+  echo "  -o <output.tar.gz> Path to the output tarball."
+  exit 1
+}
+
 readonly OUTDIR_HSM="hsm"
 readonly OUTDIR_CA="ca"
 readonly OUTDIR_PUB="pub"
+
+FLAGS_IN_TAR=""
+FLAGS_OUT_TAR=""
+
+while getopts 'i:o:' opt; do
+  case "${opt}" in
+    i)
+      FLAGS_IN_TAR="${OPTARG}"
+      ;;
+    o)
+      FLAGS_OUT_TAR="${OPTARG}"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [[ "$#" -gt 0 ]]; then
+  echo "Unexpected arguments:" "$@" >&2
+  exit 1
+fi
+
+if [[ ! -x "${HSMTOOL_BIN}" ]]; then
+  echo "Error: HSMTOOL_BIN is not set or not executable."
+  exit 1
+fi
+
+if [[ -z "${FLAGS_IN_TAR}" ]]; then
+  echo "Error: Input tarball not specified."
+  exit 1
+fi
+if [[ "${FLAGS_IN_TAR}" != *.tar.gz  ]]; then
+  echo "Error: Input tarball must have .tar.gz extension."
+  exit 1
+fi
+if [[ -z "${FLAGS_OUT_TAR}" ]]; then
+  echo "Error: Output tarball not specified."
+  exit 1
+fi
+if [[ "${FLAGS_OUT_TAR}" != *.tar.gz  ]]; then
+  echo "Error: Output tarball must have .tar.gz extension."
+  exit 1
+fi
+
+tar -xzf "${FLAGS_IN_TAR}"
 
 # certgen generates a certificate for the given config file and signs it with
 # the given CA key.
@@ -34,13 +88,15 @@ certgen () {
     -extfile "${config_basename}.conf" \
     -extensions v3_ca \
     -signkey "pkcs11:pin-value=${HSMTOOL_PIN};object=${endorsing_key}"
+
+  rm "${OUTDIR_CA}/${config_basename}.csr"
 }
 
 # Create output directory for HSM exported files.
 mkdir -p "${OUTDIR_HSM}" "${OUTDIR_CA}" "${OUTDIR_PUB}"
 
 echo "Configuring Offline HSM"
-SOFTHSM2_CONF="${SOFTHSM2_CONF_OFFLINE}" "${OPENTITAN_VAR_DIR}/bin/hsmtool" \
+SOFTHSM2_CONF="${SOFTHSM2_CONF_OFFLINE}" "${HSMTOOL_BIN}" \
   --logging=info                     \
   --token="${SPM_HSM_TOKEN_OFFLINE}" \
   exec "01.hsm_offline.hjson"
@@ -49,9 +105,5 @@ echo "Generating CA certificates"
 certgen ca_root opentitan-ca-root-v0.priv opentitan-ca-root-v0.priv
 certgen ca_int_dice sival-dice-key-p256-v0.priv opentitan-ca-root-v0.priv
 
-tar -czvf sival.tar.gz "${OUTDIR_HSM}" "${OUTDIR_CA}" "${OUTDIR_PUB}"
-
-"${OPENTITAN_VAR_DIR}/bin/hsmtool" \
-  --logging=info                   \
-  --token="${SPM_HSM_TOKEN_SPM}"   \
-  exec "02.hsm_spm.hjson"
+tar -czvf "${FLAGS_OUT_TAR}" "${OUTDIR_HSM}" "${OUTDIR_CA}" "${OUTDIR_PUB}"
+rm -rf "${OUTDIR_HSM}" "${OUTDIR_CA}" "${OUTDIR_PUB}"

--- a/config/dev/spm/sku/sival/hsm_spm_init.sh
+++ b/config/dev/spm/sku/sival/hsm_spm_init.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+# The script must be executed from its local directory.
+usage () {
+  echo "Usage: $0 -i <input.tar.gz> -o <output.tar.gz>"
+  echo "  -i <input.tar.gz>  Path to the input tarball."
+  echo "  -o <output.tar.gz> Path to the output tarball."
+  exit 1
+}
+readonly OUTDIR_HSM="hsm"
+readonly OUTDIR_CA="ca"
+readonly OUTDIR_PUB="pub"
+
+FLAGS_IN_TAR=""
+FLAGS_OUT_TAR=""
+
+while getopts 'i:o:' opt; do
+  case "${opt}" in
+    i)
+      FLAGS_IN_TAR="${OPTARG}"
+      ;;
+    o)
+      FLAGS_OUT_TAR="${OPTARG}"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [[ "$#" -gt 0 ]]; then
+  echo "Unexpected arguments:" "$@" >&2
+  exit 1
+fi
+
+if [[ ! -x "${HSMTOOL_BIN}" ]]; then
+  echo "Error: HSMTOOL_BIN is not set or not executable."
+  exit 1
+fi
+
+if [[ -z "${FLAGS_IN_TAR}" ]]; then
+  echo "Error: Input tarball not specified."
+  exit 1
+fi
+if [[ "${FLAGS_IN_TAR}" != *.tar.gz  ]]; then
+  echo "Error: Input tarball must have .tar.gz extension."
+  exit 1
+fi
+if [[ -z "${FLAGS_OUT_TAR}" ]]; then
+  echo "Error: Output tarball not specified."
+  exit 1
+fi
+if [[ "${FLAGS_OUT_TAR}" != *.tar.gz  ]]; then
+  echo "Error: Output tarball must have .tar.gz extension."
+  exit 1
+fi
+
+tar -xvf "${FLAGS_IN_TAR}"
+
+"${HSMTOOL_BIN}"                   \
+  --logging=info                   \
+  --token="${SPM_HSM_TOKEN_SPM}"   \
+  exec "02.hsm_spm.hjson"
+
+# Remove the intermediate HSM folder.
+rm -rf "${OUTDIR_HSM}" "${INPUT_TAR}"
+
+# Generate tarball to deploy with the SPM.
+tar -czvf "${FLAGS_OUT_TAR}" "${OUTDIR_CA}" "${OUTDIR_PUB}"

--- a/config/dev/token_init.sh
+++ b/config/dev/token_init.sh
@@ -9,10 +9,7 @@ CONFIG_DIR="$(realpath "$(dirname "$0")")"
 
 source "${CONFIG_DIR}/env/spm.env"
 
-SKU_CONFIG_FILES=(
-  "${CONFIG_DIR}/spm/sku/hsm_spm_init.sh"
-  "${CONFIG_DIR}/spm/sku/sival/hsm_sku_init.sh"
-)
+export HSMTOOL_BIN="${OPENTITAN_VAR_DIR}/bin/hsmtool"
 
 # Check token initialization dependencies.
 if [ -z "${OPENTITAN_VAR_DIR}" ]; then
@@ -25,8 +22,8 @@ if [ ! -d "${OPENTITAN_VAR_DIR}" ]; then
   return 1
 fi
 
-if [ ! -x "${OPENTITAN_VAR_DIR}/bin/hsmtool" ]; then
-  echo "Error: '${OPENTITAN_VAR_DIR}/bin/hsmtool' is not executable or does not exist."
+if [ ! -x "${HSMTOOL_BIN}" ]; then
+  echo "Error: '${HSMTOOL_BIN}' is not executable or does not exist."
   return 1
 fi
 
@@ -48,9 +45,25 @@ function run_hsm_init() {
     return 1
   }
 
+  shift
+
   echo "Running HSM initialization script: ${init_script}"
-  "${init_script}"
+  "${init_script}" "$@"
 }
+
+# Run the HSM initialization script for SPM.
+run_hsm_init "${CONFIG_DIR}/spm/sku/hsm_spm_init.sh" \
+  -o "${CONFIG_DIR}/spm/sku/spm_hsm_init.tar.gz"
+
+# Run the SKU initilization script in the offline HSM partition.
+run_hsm_init "${CONFIG_DIR}/spm/sku/sival/hsm_offline_init.sh" \
+  -i "${CONFIG_DIR}/spm/sku/spm_hsm_init.tar.gz" \
+  -o "${CONFIG_DIR}/spm/sku/sival/hsm_offline_init.tar.gz"
+
+# Run the SKU initialization script in the SPM partition.
+run_hsm_init "${CONFIG_DIR}/spm/sku/sival/hsm_spm_init.sh" \
+  -i "${CONFIG_DIR}/spm/sku/sival/hsm_offline_init.tar.gz" \
+  -o "${CONFIG_DIR}/spm/sku/sival/hsm_sival_sku.tar.gz"
 
 for filename in "${SKU_CONFIG_FILES[@]}"; do
   echo "Processing file: ${filename}"


### PR DESCRIPTION
Split offline and SPM HSM initialization scripts. Each script takes an input (-i) and an output (-o) argument to facilitate sharing of files between HSM initialization stages.

This script also adds bazel targets to package the scripts and their dependencies into tar files.