### PR TITLE
Add store methods to sync unsynced records

### DIFF
--- a/src/proxy_buffer/store/BUILD.bazel
+++ b/src/proxy_buffer/store/BUILD.bazel
@@ -41,6 +41,8 @@ go_test(
         ":db",
         ":db_fake",
         "//src/proto:device_testdata",
+        "//src/proto:registry_record_go_pb",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp",
         "@org_golang_google_protobuf//testing/protocmp",
     ],
@@ -63,5 +65,7 @@ go_test(
     deps = [
         ":connector",
         ":filedb",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
     ],
 )

--- a/src/proxy_buffer/store/connector.go
+++ b/src/proxy_buffer/store/connector.go
@@ -18,4 +18,10 @@ type Connector interface {
 	// Get returns a value associated with a given `key`.
 	// It should respect context cancellation and timeout.
 	Get(ctx context.Context, key string) ([]byte, error)
+
+	// GetUnsynced returns up to `numRecords` UNSYNCED records.
+	GetUnsynced(ctx context.Context, numRecords int) ([][]byte, error)
+
+	// MarkAsSynced marks all records in `keys` as SYNCED.
+	MarkAsSynced(ctx context.Context, keys []string) error
 }

--- a/src/proxy_buffer/store/db.go
+++ b/src/proxy_buffer/store/db.go
@@ -50,3 +50,23 @@ func (d *DB) GetDevice(ctx context.Context, di string) (*rpb.RegistryRecord, err
 	}
 	return record, nil
 }
+
+func (d *DB) GetUnsyncedDevices(ctx context.Context, numDevices int) ([]*rpb.RegistryRecord, error) {
+	raw_records, err := d.conn.GetUnsynced(ctx, numDevices)
+	if err != nil {
+		return nil, err
+	}
+	records := make([]*rpb.RegistryRecord, len(raw_records))
+	for i, rr_bytes := range raw_records {
+		record := &rpb.RegistryRecord{}
+		if err := proto.Unmarshal(rr_bytes, record); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal registry record: %v", err)
+		}
+		records[i] = record
+	}
+	return records, nil
+}
+
+func (d *DB) MarkDevicesAsSynced(ctx context.Context, dis []string) error {
+	return d.conn.MarkAsSynced(ctx, dis)
+}

--- a/src/proxy_buffer/store/db_test.go
+++ b/src/proxy_buffer/store/db_test.go
@@ -13,24 +13,58 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	dtd "github.com/lowRISC/opentitan-provisioning/src/proto/device_testdata"
+	rpb "github.com/lowRISC/opentitan-provisioning/src/proto/registry_record_go_pb"
 	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/db"
 	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/db_fake"
 )
 
-func TestInsert(t *testing.T) {
+func TestInsertAndGet(t *testing.T) {
+	ctx := context.Background()
 	database := db.New(db_fake.New())
 	record := &dtd.RegistryRecordOk
 
-	if err := database.InsertDevice(context.Background(), record); err != nil {
+	if err := database.InsertDevice(ctx, record); err != nil {
 		t.Fatalf("failed to insert record: %v", err)
 	}
 
-	got, err := database.GetDevice(context.Background(), record.DeviceId)
+	got, err := database.GetDevice(ctx, record.DeviceId)
 	if err != nil {
 		t.Fatalf("failed to get record: %v", err)
 	}
 
 	if diff := cmp.Diff(record, got, protocmp.Transform()); diff != "" {
 		t.Errorf("GetDevice() returned unexpected diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestInsertAndSync(t *testing.T) {
+	ctx := context.Background()
+	database := db.New(db_fake.New())
+	record := &dtd.RegistryRecordOk
+
+	if err := database.InsertDevice(ctx, record); err != nil {
+		t.Fatalf("failed to insert record: %v", err)
+	}
+
+	got, err := database.GetUnsyncedDevices(ctx, 1)
+	if err != nil {
+		t.Fatalf("failed to read unsynced devices: %v", err)
+	}
+	want := []*rpb.RegistryRecord{record}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("GetUnsyncedDevices() (before sync) returned unexpected diff (-want +got):\n%s", diff)
+	}
+
+	if err := database.MarkDevicesAsSynced(ctx, []string{record.DeviceId}); err != nil {
+		t.Errorf("MarkDevicesAsSynced() returned unexpected error: %v", err)
+	}
+
+	got, err = database.GetUnsyncedDevices(ctx, 1)
+	if err != nil {
+		t.Fatalf("failed to read unsynced devices: %v", err)
+	}
+	want = []*rpb.RegistryRecord{}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("GetUnsyncedDevices() (after sync) returned unexpected diff (-want +got):\n%s", diff)
 	}
 }

--- a/src/proxy_buffer/store/filedb_test.go
+++ b/src/proxy_buffer/store/filedb_test.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/connector"
 	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/filedb"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func newDB(t *testing.T) connector.Connector {
+	t.Helper()
 	c, err := filedb.New("file::memory:?cache=shared")
 	if err != nil {
 		t.Fatalf("Failed to open database: %v", err)
@@ -21,24 +24,81 @@ func newDB(t *testing.T) connector.Connector {
 	return c
 }
 
+func closeDB(t *testing.T, db connector.Connector) {
+	t.Helper()
+	if err := filedb.Close(db); err != nil {
+		t.Fatalf("Failed to close database: %v", err)
+	}
+}
+
 func TestInsert(t *testing.T) {
 	db := newDB(t)
-	if err := db.Insert(context.Background(), "key1", "sku", []byte("value")); err != nil {
+	defer closeDB(t, db)
+	if err := db.Insert(context.Background(), "key", "sku", []byte("value")); err != nil {
 		t.Errorf("Insert failed: %v", err)
 	}
 }
 
 func TestGet(t *testing.T) {
 	db := newDB(t)
-	if err := db.Insert(context.Background(), "key2", "sku", []byte("value")); err != nil {
+	defer closeDB(t, db)
+	ctx := context.Background()
+	if err := db.Insert(ctx, "key", "sku", []byte("value")); err != nil {
 		t.Errorf("Insert failed: %v", err)
 	}
 
-	value, err := db.Get(context.Background(), "key2")
+	got, err := db.Get(ctx, "key")
 	if err != nil {
 		t.Errorf("Get failed: %v", err)
 	}
-	if string(value) != "value" {
-		t.Errorf("Get returned wrong value: got %q, want %q", value, "value")
+	want := "value"
+	if string(got) != want {
+		t.Errorf("Get returned wrong value: got %q, want %q", string(got), want)
+	}
+}
+
+func TestGetUnsynced(t *testing.T) {
+	db := newDB(t)
+	defer closeDB(t, db)
+	ctx := context.Background()
+	if err := db.Insert(ctx, "key1", "sku", []byte("value1")); err != nil {
+		t.Errorf("Insert failed: %v", err)
+	}
+	if err := db.Insert(ctx, "key2", "sku", []byte("value2")); err != nil {
+		t.Errorf("Insert failed: %v", err)
+	}
+	got, err := db.GetUnsynced(ctx, 5)
+	if err != nil {
+		t.Errorf("GetUnsynced failed: %v", err)
+	}
+	want := [][]byte{[]byte("value1"), []byte("value2")}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("GetUnsynced diff: (-got, +want)\n%s", diff)
+	}
+}
+
+func TestMarkAsSynced(t *testing.T) {
+	db := newDB(t)
+	defer closeDB(t, db)
+	ctx := context.Background()
+	if err := db.Insert(ctx, "key1", "sku", []byte("value1")); err != nil {
+		t.Errorf("Insert failed: %v", err)
+	}
+	if err := db.Insert(ctx, "key2", "sku", []byte("value2")); err != nil {
+		t.Errorf("Insert failed: %v", err)
+	}
+	if err := db.Insert(ctx, "key3", "sku", []byte("value3")); err != nil {
+		t.Errorf("Insert failed: %v", err)
+	}
+	if err := db.MarkAsSynced(ctx, []string{"key1", "key3"}); err != nil {
+		t.Errorf("MarkAsSynced failed: %v", err)
+	}
+	got, err := db.GetUnsynced(ctx, 5)
+	if err != nil {
+		t.Errorf("GetUnsynced failed: %v", err)
+	}
+	want := [][]byte{[]byte("value2")}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("GetUnsynced diff: (-got, +want)\n%s", diff)
 	}
 }


### PR DESCRIPTION
These methods allow provide functionality to access records that are in an `UNSYNCED` state and to mark said records as SYNCED. This is in preparation to support syncing records into an external registry.

I also added function `filedb.Close()` to close a connection and made tests in `filedb_test.go` independent of each other (each one has their own database now).