### PR TITLE
Add support for ProxyBufferServer BatchRegisterDevice

### DIFF
--- a/src/pa/services/pa_test.go
+++ b/src/pa/services/pa_test.go
@@ -46,7 +46,8 @@ func bufferDialer(t *testing.T, spmClient pbs.SpmServiceClient, pbClient pbr.Pro
 }
 
 type fakePbClient struct {
-	registerDevice registerDeviceResponse
+	registerDevice      registerDeviceResponse
+	batchRegisterDevice batchRegisterDeviceResponse
 }
 
 type registerDeviceResponse struct {
@@ -54,8 +55,17 @@ type registerDeviceResponse struct {
 	err      error
 }
 
+type batchRegisterDeviceResponse struct {
+	response *pbr.BatchDeviceRegistrationResponse
+	err      error
+}
+
 func (c *fakePbClient) RegisterDevice(ctx context.Context, request *pbr.DeviceRegistrationRequest, opts ...grpc.CallOption) (*pbr.DeviceRegistrationResponse, error) {
 	return c.registerDevice.response, c.registerDevice.err
+}
+
+func (c *fakePbClient) BatchRegisterDevice(ctx context.Context, request *pbr.BatchDeviceRegistrationRequest, opts ...grpc.CallOption) (*pbr.BatchDeviceRegistrationResponse, error) {
+	return c.batchRegisterDevice.response, c.batchRegisterDevice.err
 }
 
 // fakeSpmClient provides a fake client interface to the SPM server. Test

--- a/src/proxy_buffer/proto/proxy_buffer.proto
+++ b/src/proxy_buffer/proto/proxy_buffer.proto
@@ -16,6 +16,10 @@ service ProxyBufferService {
   // Registers a device.
   rpc RegisterDevice(DeviceRegistrationRequest)
     returns (DeviceRegistrationResponse) {}
+  
+  // Batch registers multiple devices.
+  rpc BatchRegisterDevice(BatchDeviceRegistrationRequest)
+    returns (BatchDeviceRegistrationResponse) {}
 }
 
 enum DeviceRegistrationStatus {
@@ -35,4 +39,13 @@ message DeviceRegistrationRequest {
 message DeviceRegistrationResponse {
   DeviceRegistrationStatus status = 1;
   string device_id = 2;
+  uint32 rpc_status = 3;
+}
+
+message BatchDeviceRegistrationRequest {
+  repeated DeviceRegistrationRequest requests = 1;
+}
+
+message BatchDeviceRegistrationResponse {
+  repeated DeviceRegistrationResponse responses = 1;
 }

--- a/src/proxy_buffer/services/BUILD.bazel
+++ b/src/proxy_buffer/services/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     deps = [
         ":proxybuffer",
         "//src/proto:device_testdata",
+        "//src/proto:registry_record_go_pb",
         "//src/proxy_buffer/proto:proxy_buffer_go_pb",
         "//src/proxy_buffer/store:db",
         "//src/proxy_buffer/store:db_fake",

--- a/src/proxy_buffer/services/proxybuffer.go
+++ b/src/proxy_buffer/services/proxybuffer.go
@@ -20,7 +20,10 @@ import (
 
 // Every registry service frontend must implement the `RegistryDevice` function.
 type Registry interface {
+	// RegisterDevice registers a device.
 	RegisterDevice(ctx context.Context, request *pbp.DeviceRegistrationRequest, opts ...grpc.CallOption) (*pbp.DeviceRegistrationResponse, error)
+	// BatchRegisterDevice registers multiple devices.
+	BatchRegisterDevice(ctx context.Context, request *pbp.BatchDeviceRegistrationRequest, opts ...grpc.CallOption) (*pbp.BatchDeviceRegistrationResponse, error)
 }
 
 // server is the server object.
@@ -47,15 +50,35 @@ func (s *server) RegisterDevice(ctx context.Context, request *pbp.DeviceRegistra
 
 	if err := validators.ValidateDeviceRegistrationRequest(request); err != nil {
 		response.Status = pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_BAD_REQUEST
+		response.RpcStatus = uint32(codes.InvalidArgument)
 		return response, status.Errorf(codes.InvalidArgument, "failed request validation: %v", err)
 	}
 
 	if err := s.db.InsertDevice(ctx, request.Record); err != nil {
 		// E.g. The given device is still in the buffer but its DeviceData has changed.
 		response.Status = pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_BAD_REQUEST
+		response.RpcStatus = uint32(codes.Internal)
 		return response, status.Errorf(codes.Internal, "failed to insert record: %v", err)
 	}
 
 	response.Status = pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_SUCCESS
+	response.RpcStatus = uint32(codes.OK)
+	return response, nil
+}
+
+// BatchRegisterDevice registers multiple new device records.
+//
+// Validates requests and then durably records them (locally).
+// Batch method always returns general success, each individual response
+// contains error details.
+func (s *server) BatchRegisterDevice(ctx context.Context, request *pbp.BatchDeviceRegistrationRequest) (*pbp.BatchDeviceRegistrationResponse, error) {
+	response := &pbp.BatchDeviceRegistrationResponse{
+		Responses: make([]*pbp.DeviceRegistrationResponse, len(request.Requests)),
+	}
+	for i, req := range request.Requests {
+		// Error is ignored, the code should be included in the individual
+		// response.
+		response.Responses[i], _ = s.RegisterDevice(ctx, req)
+	}
 	return response, nil
 }


### PR DESCRIPTION
This method allows us to register multiple devices in a single request.

I also added a new field in DeviceRegistrationResponse: a RPC status code.