### PR TITLE
Create BatchRegisterDevice method and messages

### DIFF
--- a/src/proxy_buffer/proto/proxy_buffer.proto
+++ b/src/proxy_buffer/proto/proxy_buffer.proto
@@ -35,4 +35,13 @@ message DeviceRegistrationRequest {
 message DeviceRegistrationResponse {
   DeviceRegistrationStatus status = 1;
   string device_id = 2;
+  uint32 rpc_code = 3;
+}
+
+message BatchDeviceRegistrationRequest {
+  repeated DeviceRegistrationRequest requests = 1;
+}
+
+message BatchDeviceRegistrationResponse {
+  repeated DeviceRegistrationResponse responses = 1;
 }

--- a/src/proxy_buffer/services/proxybuffer.go
+++ b/src/proxy_buffer/services/proxybuffer.go
@@ -21,6 +21,7 @@ import (
 // Every registry service frontend must implement the `RegistryDevice` function.
 type Registry interface {
 	RegisterDevice(ctx context.Context, request *pbp.DeviceRegistrationRequest, opts ...grpc.CallOption) (*pbp.DeviceRegistrationResponse, error)
+	BatchRegisterDevice(ctx context.Context, request *pbp.BatchDeviceRegistrationRequest, opts ...grpc.CallOption) (*pbp.BatchDeviceRegistrationResponse, error)
 }
 
 // server is the server object.


### PR DESCRIPTION
This is in preparation to support BatchRegister in both ProxyBufferServer and external registries. With this feature we can now register multiple devices with a single call.

I also added an RPC error message to the response field, so we can set individual failures for each request in a batch request.