### PR TITLE
[bitstreams] track bitstreams with Git LFS and update them in the process

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bit filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Currently, Ubuntu 22.04LTS is the only supported development environment. There
 are [build container](docs/containers.md#building-inside-the-build-container)
 instructions available for other OS distributions.
 
+### Git LFS
+
+This repo uses Git LFS to track larger files, such as FPGA bitstreams and DUT
+provisioning firmware binaries. To properly clone this repo, ensure you have
+Git LFS installed by following these [instructions](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage).
+See the Git LFS [collaboration](https://docs.github.com/en/repositories/working-with-files/managing-large-files/collaboration-with-git-large-file-storage)
+details on why this is necessary.
+
 ### Install Dependencies
 
 Install dependencies via `setup.sh`. This will run `apt` to install system-level

--- a/third_party/lowrisc/ot_bitstreams/README.md
+++ b/third_party/lowrisc/ot_bitstreams/README.md
@@ -1,0 +1,10 @@
+# Updating the Bitstreams
+
+CW310 and CW340 bitstreams are checked into this repo to enable emulating provisioning flow on an OpenTitan FPGA DUT.
+The bitstreams checked into this repo represent the state of a chip as it would be if it were entering CP, meaning the chip has a completely empty OTP and flash, except the lifecycle state is TEST\_UNLOCKED0.
+To update these bitstreams with the latest pinned version of the lowrisc\_opentitan repo, do the following:
+1. Make sure the `_OPENTITAN_VERSION` tag in `third_party/lowrisc/repos.bzl` matches the `_OT_REPO_BRANCH` tag in `third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh`.
+1. `./third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh <path to opentitan repo>`
+1. `git add third_party/lowrisc/ot_bitstreams/cp_cw340.bit`
+1. `git add third_party/lowrisc/ot_bitstreams/cp_hyper310.bit`
+1. Commit the newly added bitstreams.

--- a/third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh
+++ b/third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh
@@ -19,7 +19,7 @@ fi
 
 OT_REPO_TOP=$1
 
-_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC2"
+_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC3"
 _PROVISIONING_REPO_TOP=$(pwd)
 _FPGAS=("hyper310" "cw340")
 _CP_SKUS=("emulation")

--- a/third_party/lowrisc/ot_bitstreams/cp_cw340.bit
+++ b/third_party/lowrisc/ot_bitstreams/cp_cw340.bit
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e987abfe652f93594e91aab425bfa974a501863ab5a7dc8275cc110003f37f87
+size 35843488

--- a/third_party/lowrisc/ot_bitstreams/cp_hyper310.bit
+++ b/third_party/lowrisc/ot_bitstreams/cp_hyper310.bit
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcb1921c43a66fc6d42c1ccdbdc11e14b20ace39b37f9fe6f27afd0ede5d042b
+size 15878032

--- a/third_party/lowrisc/repos.bzl
+++ b/third_party/lowrisc/repos.bzl
@@ -8,6 +8,10 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 _MISC_LINTERS_VERSION = "20240820_01"
 _BAZEL_RELEASE_VERSION = "0.0.3"
 _BAZEL_SKYLIB_VERSION = "1.5.0"
+
+# When updating the lowrisc_opentitan repo, be sure to rebuild the builtstream
+# files too by following the instructions in
+# `third_party/lowrisc/ot_bitstreams/README.md`.
 _OPENTITAN_VERSION = "Earlgrey-A2-Provisioning-RC3"
 
 def lowrisc_repos(misc_linters = None, bazel_release = None, bazel_skylib = None, opentitan = None):


### PR DESCRIPTION
This fixes #53 by adding the (updated) FPGA bitstreams using Git LFS.
