### PR TITLE
Create syncer job between database and registry

### DIFF
--- a/src/proto/device_testdata.go
+++ b/src/proto/device_testdata.go
@@ -139,3 +139,12 @@ func NewDeviceIdBadOrigin() *dpb.DeviceId {
 		SkuSpecific:    make([]byte, DeviceIdSkuSpecificLenInBytes),
 	}
 }
+
+func NewRegistryRecordOk(deviceID *dpb.DeviceId) rpb.RegistryRecord {
+	return rpb.RegistryRecord{
+		DeviceId: diu.DeviceIdToHexString(deviceID),
+		Sku:      "sival",
+		Version:  0,
+		Data:     make([]byte, 1000),
+	}
+}

--- a/src/proxy_buffer/syncer/BUILD.bazel
+++ b/src/proxy_buffer/syncer/BUILD.bazel
@@ -1,0 +1,37 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "syncer",
+    srcs = ["syncer.go"],
+    importpath = "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/syncer",
+    deps = [
+        "//src/proto:registry_record_go_pb",
+        "//src/proxy_buffer/proto:proxy_buffer_go_pb",
+        "//src/proxy_buffer/services:proxybuffer",
+        "//src/proxy_buffer/store:db",
+        "@org_golang_google_grpc//codes",
+    ],
+)
+
+go_test(
+    name = "syncer_test",
+    srcs = ["syncer_test.go"],
+    deps = [
+        ":syncer",
+        "//src/proto:device_testdata",
+        "//src/proto:registry_record_go_pb",
+        "//src/proxy_buffer/proto:proxy_buffer_go_pb",
+        "//src/proxy_buffer/store:db",
+        "//src/proxy_buffer/store:db_fake",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//testing/protocmp",
+    ],
+)

--- a/src/proxy_buffer/syncer/syncer.go
+++ b/src/proxy_buffer/syncer/syncer.go
@@ -1,0 +1,118 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package syncer implements a job to sync data from local store to a remote
+// registry
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	pbp "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/proxy_buffer_go_pb"
+	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/services/proxybuffer"
+	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/db"
+)
+
+// Options contains configuration options for a syncer to use
+type Options struct {
+	Frequency     string
+	RecordsPerRun int
+}
+
+// DefaultOptions returns the default options for a syncer
+func DefaultOptions() *Options {
+	return &Options{
+		Frequency:     "10m",
+		RecordsPerRun: 100,
+	}
+}
+
+type syncer struct {
+	db            *db.DB
+	registry      proxybuffer.Registry
+	ticker        <-chan time.Time
+	recordsPerRun int
+	closeCh       chan struct{}
+}
+
+// New creates a new syncer that consumes a given db and publishes to a registry
+func New(db *db.DB, registry proxybuffer.Registry, options *Options) (*syncer, error) {
+	freq, err := time.ParseDuration(options.Frequency)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse options.Frequency: %v", err)
+	}
+	if options.RecordsPerRun <= 0 {
+		return nil, errors.New("options.RecordsPerRun must be at least 1")
+	}
+	return &syncer{
+		db:            db,
+		registry:      registry,
+		ticker:        time.Tick(freq),
+		recordsPerRun: options.RecordsPerRun,
+		closeCh:       make(chan struct{}),
+	}, nil
+}
+
+func (s *syncer) run() error {
+	ctx := context.Background()
+	records, err := s.db.GetUnsyncedDevices(ctx, s.recordsPerRun)
+	if err != nil {
+		return err
+	}
+	batchRequest := &pbp.BatchDeviceRegistrationRequest{
+		Requests: make([]*pbp.DeviceRegistrationRequest, len(records)),
+	}
+	for i, record := range records {
+		batchRequest.Requests[i] = &pbp.DeviceRegistrationRequest{
+			Record: record,
+		}
+	}
+	batchResponse, err := s.registry.BatchRegisterDevice(ctx, batchRequest)
+	if err != nil {
+		return err
+	}
+	successfulDeviceIDs := make([]string, 0)
+	for _, response := range batchResponse.Responses {
+		if response.Status == pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_SUCCESS {
+			successfulDeviceIDs = append(successfulDeviceIDs, response.DeviceId)
+		} else {
+			log.Printf(
+				"Request with ID %q failed: status: %s, rpc_status: %s",
+				response.DeviceId,
+				pbp.DeviceRegistrationStatus_name[int32(response.Status)],
+				codes.Code(response.RpcStatus),
+			)
+		}
+	}
+	return s.db.MarkDevicesAsSynced(ctx, successfulDeviceIDs)
+}
+
+func (s *syncer) listen() {
+	for {
+		select {
+		case <-s.ticker:
+			if err := s.run(); err != nil {
+				log.Printf("run() failed: %v", err)
+			}
+		case <-s.closeCh:
+			return
+		}
+	}
+}
+
+// Start starts the syncer
+func (s *syncer) Start() {
+	go s.listen()
+}
+
+// Stop stops the syncer
+func (s *syncer) Stop() {
+	s.closeCh <- struct{}{}
+}

--- a/src/proxy_buffer/syncer/syncer_test.go
+++ b/src/proxy_buffer/syncer/syncer_test.go
@@ -1,0 +1,107 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package syncer_test
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/google/go-cmp/cmp"
+	testdata "github.com/lowRISC/opentitan-provisioning/src/proto/device_testdata"
+	rpb "github.com/lowRISC/opentitan-provisioning/src/proto/registry_record_go_pb"
+	pbp "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/proxy_buffer_go_pb"
+	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/db"
+	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/store/db_fake"
+	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/syncer"
+)
+
+type fakeRegistry struct {
+	successfulIDs []string
+}
+
+func (f *fakeRegistry) RegisterDevice(ctx context.Context, request *pbp.DeviceRegistrationRequest, opts ...grpc.CallOption) (*pbp.DeviceRegistrationResponse, error) {
+	for _, successfulID := range f.successfulIDs {
+		if request.Record.DeviceId == successfulID {
+			return &pbp.DeviceRegistrationResponse{
+				DeviceId:  request.Record.DeviceId,
+				Status:    pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_SUCCESS,
+				RpcStatus: uint32(codes.OK),
+			}, nil
+		}
+	}
+	return &pbp.DeviceRegistrationResponse{
+		DeviceId:  request.Record.DeviceId,
+		Status:    pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_BAD_REQUEST,
+		RpcStatus: uint32(codes.InvalidArgument),
+	}, status.Errorf(codes.InvalidArgument, "fake failure for deviceID %s", request.Record.DeviceId)
+}
+
+func (f *fakeRegistry) BatchRegisterDevice(ctx context.Context, request *pbp.BatchDeviceRegistrationRequest, opts ...grpc.CallOption) (*pbp.BatchDeviceRegistrationResponse, error) {
+	response := &pbp.BatchDeviceRegistrationResponse{
+		Responses: make([]*pbp.DeviceRegistrationResponse, len(request.Requests)),
+	}
+	for i, req := range request.Requests {
+		response.Responses[i], _ = f.RegisterDevice(ctx, req, opts...)
+	}
+	return response, nil
+}
+
+func registryRecord(idOffset int) *rpb.RegistryRecord {
+	deviceID := &testdata.DeviceIdOk
+	binary.BigEndian.PutUint32(deviceID.SkuSpecific[0:4], uint32(idOffset))
+	record := testdata.NewRegistryRecordOk(deviceID)
+	return &record
+}
+
+func TestSyncer(t *testing.T) {
+	ctx := context.Background()
+	database := db.New(db_fake.New())
+	allRecords := make([]*rpb.RegistryRecord, 5)
+	for i := 0; i < 5; i++ {
+		allRecords[i] = registryRecord(i)
+		if err := database.InsertDevice(ctx, allRecords[i]); err != nil {
+			t.Fatalf("unexpected error when registering record: %v", err)
+		}
+	}
+
+	registry := &fakeRegistry{
+		successfulIDs: []string{
+			allRecords[0].DeviceId,
+			allRecords[1].DeviceId,
+			allRecords[2].DeviceId,
+		},
+	}
+	options := &syncer.Options{
+		Frequency:     "1s",
+		RecordsPerRun: 5,
+	}
+	sync, err := syncer.New(database, registry, options)
+	if err != nil {
+		t.Fatalf("unexpected error when creating syncer: %v", err)
+	}
+
+	sync.Start()
+	time.Sleep(time.Second * 2)
+	sync.Stop()
+
+	unsyncedRecords, err := database.GetUnsyncedDevices(ctx, 5)
+	if err != nil {
+		t.Fatalf("unexpected error when retrieving unsynced devices: %v", err)
+	}
+	expectedUnsyncedRecords := []*rpb.RegistryRecord{
+		allRecords[3],
+		allRecords[4],
+	}
+	if diff := cmp.Diff(unsyncedRecords, expectedUnsyncedRecords, protocmp.Transform()); diff != "" {
+		t.Errorf("unsynced records diffs (-got +want):\n%s", diff)
+	}
+}


### PR DESCRIPTION
This worker is used to sync records present in the database into the provided registry. It will periodically retrieve all unsynced records from the database, then send them to the registry in a batch request. Only the successful records will be listed as synced, the other ones will be retried in a later run.

This worker runs in the background as a goroutine and can be configured to run with different frequency and records per run.