### PR TITLE
[hsm] Document HSM configuration flow.

### DIFF
--- a/config/prod/spm/sku_sival.yml
+++ b/config/prod/spm/sku_sival.yml
@@ -9,14 +9,14 @@ symmetricKeys:
   - name: sival-kdf-hisec-v0
   - name: sival-kdf-losec-v0
 privateKeys:
-    - name: sival-dice-key-p256-v0
+    - name: sival-dice-key-p256-v0.priv
     - name: spm-hsm-id-v0.priv
 publicKeys:
-    - name: sku-sival-rsa-rma-v0
+    - name: sku-sival-rsa-rma-v0.pub
 attributes:
     SeedSecHi: sival-kdf-hisec-v0
     SeedSecLo: sival-kdf-losec-v0
     WrappingMechanism: RsaPkcs
-    WrappingKeyLabel: sku-sival-rsa-rma-v0
-    SigningKey/Dice/v0: sival-dice-key-p256-v0
+    WrappingKeyLabel: sku-sival-rsa-rma-v0.pub
+    SigningKey/Dice/v0: sival-dice-key-p256-v0.priv
     SigningKey/Identity/v0: spm-hsm-id-v0.priv

--- a/rules/hsm.bzl
+++ b/rules/hsm.bzl
@@ -712,15 +712,19 @@ def hsm_sku_wrapping_key(name, wrapping_key, wrapping_mechanism):
         wrapping_key: The key used to wrap the key.
         wrapping_mechanism: The mechanism used to wrap the key.
     """
+
+    # TODO(moidx): Remove WRAP and ENCRYPT from import template
+    # once `hsmtool` is updated to support querying based on
+    # unwrap attributes.
     hsm_key_template(
         name = name,
         import_template = hsmtool_pk11_attrs({
             "CKA_DECRYPT": True,
-            "CKA_ENCRYPT": False,
+            "CKA_ENCRYPT": True,
             "CKA_SENSITIVE": True,
             "CKA_TOKEN": True,
             "CKA_UNWRAP": True,
-            "CKA_WRAP": False,
+            "CKA_WRAP": True,
             "CKA_EXTRACTABLE": False,
         }),
         keygen_params = hsmtool_aes_keygen(


### PR DESCRIPTION
Update the hsm.md document to reflect the current implementation, which splits the offline and SPM configuration steps.

Also, update the `hsm_sku_wrapping_key()` key policy to work with Thales HSMs. Inserted a TODO to revisit the configuration later.

Fixes https://github.com/lowRISC/opentitan-provisioning/issues/110.