### PR TITLE
[utils] Add device id utility functions.

### DIFF
--- a/src/proto/device_id.proto
+++ b/src/proto/device_id.proto
@@ -58,6 +58,8 @@ message HardwareOrigin {
   //
   // A unique number given to each device within a Hardware Origin domain.
   fixed64 device_identification_number = 3;
+  // Reserved for future use. Allocated so that we can observe the value.
+  fixed32 cp_reserved = 4;
 };
 
 // OpenTitan Device ID.

--- a/src/utils/BUILD.bazel
+++ b/src/utils/BUILD.bazel
@@ -2,9 +2,28 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "devid",
+    srcs = ["devid.go"],
+    importpath = "github.com/lowRISC/opentitan-provisioning/src/utils/devid",
+    deps = [
+        "//src/proto:device_id_go_pb",
+        "//src/proto:validators",
+    ],
+)
+
+go_test(
+    name = "devid_test",
+    srcs = ["devid_test.go"],
+    embed = [":devid"],
+    deps = [
+        "//src/proto:device_id_go_pb",
+    ],
+)
 
 go_library(
     name = "utils",

--- a/src/utils/devid.go
+++ b/src/utils/devid.go
@@ -1,0 +1,129 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package devid
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+
+	dpb "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_go_pb"
+	"github.com/lowRISC/opentitan-provisioning/src/proto/validators"
+)
+
+type DeviceIDField struct {
+	start int
+	end   int
+}
+
+var (
+	FieldHWOriginSICreatorID = DeviceIDField{0, 2}
+	FieldHWOriginProductID   = DeviceIDField{2, 4}
+	FieldDIN                 = DeviceIDField{4, 12}
+	FieldReserved1           = DeviceIDField{12, 16}
+	FieldSKUSpecific         = DeviceIDField{16, 32}
+)
+
+// FromRawBytes converts a byte slice to a DeviceId object.
+// It expects the byte slice to be in little-endian format and of length 32
+// bytes.
+func FromRawBytes(raw []byte) (*dpb.DeviceId, error) {
+	if len(raw) < 32 {
+		return nil, fmt.Errorf("raw bytes length is less than 32")
+	}
+
+	siID := dpb.SiliconCreatorId(binary.LittleEndian.Uint16(raw[FieldHWOriginSICreatorID.start:FieldHWOriginSICreatorID.end]))
+	pID := dpb.ProductId(binary.LittleEndian.Uint16(raw[FieldHWOriginProductID.start:FieldHWOriginProductID.end]))
+	din := binary.LittleEndian.Uint64(raw[FieldDIN.start:FieldDIN.end])
+	rsvd := binary.LittleEndian.Uint32(raw[FieldReserved1.start:FieldReserved1.end])
+
+	deviceId := &dpb.DeviceId{
+		HardwareOrigin: &dpb.HardwareOrigin{
+			SiliconCreatorId:           siID,
+			ProductId:                  pID,
+			DeviceIdentificationNumber: din,
+			CpReserved:                 rsvd,
+		},
+		SkuSpecific: raw[FieldSKUSpecific.start:FieldSKUSpecific.end],
+	}
+
+	if err := validators.ValidateDeviceId(deviceId); err != nil {
+		return nil, fmt.Errorf("error validating device ID: %v", err)
+	}
+
+	return deviceId, nil
+}
+
+// Reverses the byte slice in place.
+// TODO(#155): Migrate to `slices.Reverse` in Go >= 1.21.
+func reverse(b []byte) {
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+}
+
+// FromHex converts a hex string to a DeviceId object.
+// It expects the hex string to be in little-endian format and of length 64
+// characters (32 bytes).
+func FromHex(h string) (*dpb.DeviceId, error) {
+	raw, err := hex.DecodeString(h)
+	reverse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding hex string: %v", err)
+	}
+	return FromRawBytes(raw)
+}
+
+// DeviceIDToRawBytes converts a DeviceId object to a byte slice.
+// It returns a byte slice of length 32 bytes in little-endian format.
+func DeviceIDToRawBytes(d *dpb.DeviceId) ([]byte, error) {
+	if err := validators.ValidateDeviceId(d); err != nil {
+		return nil, fmt.Errorf("error validating device ID: %v", err)
+	}
+
+	raw := make([]byte, 32)
+	binary.LittleEndian.PutUint16(raw[FieldHWOriginSICreatorID.start:FieldHWOriginSICreatorID.end], uint16(d.HardwareOrigin.SiliconCreatorId))
+	binary.LittleEndian.PutUint16(raw[FieldHWOriginProductID.start:FieldHWOriginProductID.end], uint16(d.HardwareOrigin.ProductId))
+	binary.LittleEndian.PutUint64(raw[FieldDIN.start:FieldDIN.end], d.HardwareOrigin.DeviceIdentificationNumber)
+	binary.LittleEndian.PutUint32(raw[FieldReserved1.start:FieldReserved1.end], d.HardwareOrigin.CpReserved)
+	copy(raw[FieldSKUSpecific.start:FieldSKUSpecific.end], d.SkuSpecific)
+
+	return raw, nil
+}
+
+// DeviceIDToHex converts a DeviceId object to a hex string.
+// It returns a hex string of length 64 characters (32 bytes) in little-endian
+// format.
+func DeviceIDToHex(d *dpb.DeviceId) (string, error) {
+	raw, err := DeviceIDToRawBytes(d)
+	if err != nil {
+		return "", fmt.Errorf("error converting device ID to raw bytes: %v", err)
+	}
+	reverse(raw)
+	return hex.EncodeToString(raw), nil
+}
+
+// HardwareOriginToRawBytes converts a HardwareOrigin object to a byte slice.
+// It returns a byte slice of length 16 bytes in little-endian format.
+func HardwareOriginToRawBytes(h *dpb.HardwareOrigin) ([]byte, error) {
+	raw := make([]byte, 16)
+	binary.LittleEndian.PutUint16(raw[FieldHWOriginSICreatorID.start:FieldHWOriginSICreatorID.end], uint16(h.SiliconCreatorId))
+	binary.LittleEndian.PutUint16(raw[FieldHWOriginProductID.start:FieldHWOriginProductID.end], uint16(h.ProductId))
+	binary.LittleEndian.PutUint64(raw[FieldDIN.start:FieldDIN.end], h.DeviceIdentificationNumber)
+	binary.LittleEndian.PutUint32(raw[FieldReserved1.start:FieldReserved1.end], h.CpReserved)
+	return raw, nil
+}
+
+// HardwareOriginToHex converts a HardwareOrigin object to a hex string.
+// It returns a hex string of length 32 characters (16 bytes) in little-endian
+// format.
+func HardwareOriginToHex(h *dpb.HardwareOrigin) (string, error) {
+	raw, err := HardwareOriginToRawBytes(h)
+	if err != nil {
+		return "", fmt.Errorf("error converting hardware origin to raw bytes: %v", err)
+	}
+	reverse(raw)
+	return hex.EncodeToString(raw), nil
+}

--- a/src/utils/devid_test.go
+++ b/src/utils/devid_test.go
@@ -1,0 +1,71 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package devid
+
+import (
+	"bytes"
+	"testing"
+
+	dpb "github.com/lowRISC/opentitan-provisioning/src/proto/device_id_go_pb"
+)
+
+const deviceIDHex = "0100000047425f54000000014742000000000000000790100500346400024001"
+
+var hardwareOriginHex = []byte{
+	0x01, 0x40, 0x02, 0x00,
+	0x64, 0x34, 0x00, 0x05,
+	0x10, 0x90, 0x07, 0x00,
+	0x00, 0x00, 0x00, 0x00,
+}
+
+func TestDevID(t *testing.T) {
+	d, err := FromHex(deviceIDHex)
+	if err != nil {
+		t.Fatalf("Failed to decode device ID: %v", err)
+	}
+	if d == nil {
+		t.Fatal("Decoded device ID is nil")
+	}
+	if d.HardwareOrigin == nil {
+		t.Fatal("Decoded device ID hardware origin is nil")
+	}
+
+	if d.HardwareOrigin.SiliconCreatorId != dpb.SiliconCreatorId_SILICON_CREATOR_ID_NUVOTON {
+		t.Errorf("Expected SiliconCreatorId %v, got %v", dpb.SiliconCreatorId_SILICON_CREATOR_ID_NUVOTON, d.HardwareOrigin.SiliconCreatorId)
+	}
+
+	if d.HardwareOrigin.ProductId != dpb.ProductId_PRODUCT_ID_EARLGREY_A1 {
+		t.Errorf("Expected ProductId %v, got %v", dpb.ProductId_PRODUCT_ID_EARLGREY_A1, d.HardwareOrigin.ProductId)
+	}
+	if d.HardwareOrigin.DeviceIdentificationNumber != 0x7901005003464 {
+		t.Errorf("Expected DeviceIdentificationNumber %v, got %x", 0x7901005003464, d.HardwareOrigin.DeviceIdentificationNumber)
+	}
+	if d.HardwareOrigin.CpReserved != 0x00000000 {
+		t.Errorf("Expected CpReserved %v, got %v", 0x00000000, d.HardwareOrigin.CpReserved)
+	}
+	if d.SkuSpecific == nil {
+		t.Fatal("Decoded device ID SKU specific is nil")
+	}
+	if len(d.SkuSpecific) != 16 {
+		t.Fatalf("Expected SKU specific length 16, got %d", len(d.SkuSpecific))
+	}
+	h, err := DeviceIDToHex(d)
+	if err != nil {
+		t.Fatalf("Failed to encode device ID: %v", err)
+	}
+	if h != deviceIDHex {
+		t.Errorf("Expected device ID hex %s, got %s", deviceIDHex, h)
+	}
+	hwRaw, err := HardwareOriginToRawBytes(d.HardwareOrigin)
+	if err != nil {
+		t.Fatalf("Failed to encode hardware origin: %v", err)
+	}
+	if len(hwRaw) != 16 {
+		t.Fatalf("Expected hardware origin raw length 16, got %d", len(hwRaw))
+	}
+	if !bytes.Equal(hwRaw, hardwareOriginHex) {
+		t.Errorf("Expected hardware origin raw %x, got %x", hardwareOriginHex, hwRaw)
+	}
+}


### PR DESCRIPTION
Introduce `devid` package with support for DeviceID operations. This includes having the ability to generate a Device ID proto message from a raw or hex bytes representation of the device ID.