### PR TITLE
[spm] Remove SKU from diversification string in GenerateTokens

### DIFF
--- a/src/pa/loadtest.go
+++ b/src/pa/loadtest.go
@@ -266,7 +266,6 @@ func NewEndorseCertTest() callFunc {
 		mac := hmac.New(sha256.New, result.Tokens[0].Token)
 		mac.Write(diceTBS)
 		sig := mac.Sum(nil)
-		fmt.Printf("Signature: %x\n", sig)
 
 		testOTEndorseCerts(ctx, numCalls, skuName, c, diceTBS, dBytes, sig)
 	})

--- a/src/spm/services/se_pk11.go
+++ b/src/spm/services/se_pk11.go
@@ -285,9 +285,12 @@ func (h *HSM) GenerateTokens(params []*TokenParams) ([]TokenResult, error) {
 			return nil, fmt.Errorf("unsupported key type: %v", p.Type)
 		}
 
+		if len(p.Diversifier) == 0 {
+			return nil, fmt.Errorf("invalid diversifier length: %d, expected > 0", len(p.Diversifier))
+		}
+
 		// Generate token from seed and extract.
-		rawData := append([]byte(p.Sku), p.Diversifier...)
-		tBytes, err := seed.SignHMAC256(rawData)
+		tBytes, err := seed.SignHMAC256(p.Diversifier)
 		if err != nil {
 			return nil, fmt.Errorf("failed to hash seed: %v", err)
 		}
@@ -517,7 +520,7 @@ func (h *HSM) VerifyWASSignature(params VerifyWASParams) error {
 		return fmt.Errorf("failed to find %q key object: %v", params.Seed, err)
 	}
 
-	dev := append([]byte(params.Sku), append([]byte("was"), params.DeviceID...)...)
+	dev := append([]byte("was"), params.DeviceID...)
 	was, err := ws.SignHMAC256(dev)
 	if err != nil {
 		return fmt.Errorf("failed to hash seed: %v", err)

--- a/src/spm/services/se_pk11_test.go
+++ b/src/spm/services/se_pk11_test.go
@@ -168,7 +168,6 @@ func TestGenerateTokens(t *testing.T) {
 			seed = lsSeed
 		}
 		h2 := hmac.New(sha256.New, seed)
-		h2.Write([]byte(p.Sku))
 		h2.Write(p.Diversifier)
 		expected_token := h2.Sum(nil)[:p.SizeInBits/8]
 
@@ -225,9 +224,7 @@ func TestGenerateSymmKeysWrap(t *testing.T) {
 		seed, err := s.UnwrapGenSecret(r.WrappedKey, pk, pk11.GenSecretWrapMechanismRsaPcks, &pk11.KeyOptions{Extractable: true})
 		ts.Check(t, err)
 
-		data := [][]byte{[]byte(rmaParams.Sku), rmaParams.Diversifier}
-		joinedData := bytes.Join(data, nil)
-		tBytes, err := seed.SignHMAC256(joinedData)
+		tBytes, err := seed.SignHMAC256(rmaParams.Diversifier)
 		ts.Check(t, err)
 		tBytes = tBytes[:rmaParams.SizeInBits/8]
 
@@ -377,7 +374,7 @@ func TestVerifyWASSignature(t *testing.T) {
 	devID, err := utils.GenerateRandom(16)
 	ts.Check(t, err)
 
-	dev := append([]byte("sival"), append([]byte("was"), devID...)...)
+	dev := append([]byte("was"), devID...)
 
 	mac := hmac.New(sha256.New, hsSeed)
 	mac.Write(dev)


### PR DESCRIPTION
The GenerateTokens function is expected to be used in both `CP` and `FT` stages, and in some cases, the derived tokens need to be reproducible. For example, the Wafer Authentication Secret is injected into the Device Under Test (DUT) in the `CP` stage, and then later reproduced by the HSM in the `FT` stage.

This change removes the use of the SKU name as a prefix in the diversification string because the customer SKU name may not be known by `CP`. For example, a Silicon Creator may want to process a batch of wafers in `CP` and later break it down into SKU allocations during `FT`. Removing the SKU identifier allows the Silicon Creator to use a reproducible derivation string that is not dependent on the SKU label.