### PR TITLE
Create client HTTP registry

### DIFF
--- a/src/proxy_buffer/services/BUILD.bazel
+++ b/src/proxy_buffer/services/BUILD.bazel
@@ -38,3 +38,27 @@ go_test(
         "@org_golang_google_protobuf//testing/protocmp",
     ],
 )
+
+go_library(
+    name = "http_registry",
+    srcs = ["http_registry.go"],
+    importpath = "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/services/httpregistry",
+    deps = [
+        "//src/proxy_buffer/proto:proxy_buffer_go_pb",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "http_registry_test",
+    srcs = ["http_registry_test.go"],
+    deps = [
+        ":http_registry",
+        "//src/proto:device_testdata",
+        "//src/proxy_buffer/proto:proxy_buffer_go_pb",
+        "@com_github_google_go_cmp//cmp",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_protobuf//testing/protocmp",
+    ],
+)

--- a/src/proxy_buffer/services/http_registry.go
+++ b/src/proxy_buffer/services/http_registry.go
@@ -1,0 +1,155 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package httpregistry creates an HTTP client that implements the Registry interface
+package httpregistry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	pbp "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/proxy_buffer_go_pb"
+
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc"
+)
+
+type RegistryConfig struct {
+	RegisterDeviceURL      string
+	BatchRegisterDeviceURL string
+	Headers                map[string]string
+}
+
+type Registry struct {
+	RegistryConfig
+	client *http.Client
+}
+
+// New creates a new HTTP registry that implements the proxybuffer.Registry interface
+func New(config *RegistryConfig) (*Registry, error) {
+	if _, err := url.Parse(config.RegisterDeviceURL); err != nil {
+		return nil, fmt.Errorf("failed to parse config.RegisterDeviceURL: %v", err)
+	}
+	if _, err := url.Parse(config.BatchRegisterDeviceURL); err != nil {
+		return nil, fmt.Errorf("failed to parse config.BatchRegisterDeviceURL: %v", err)
+	}
+	return &Registry{
+		RegistryConfig: *config,
+		client:         http.DefaultClient,
+	}, nil
+}
+
+type callConfig struct {
+	url        string
+	headers    map[string]string
+	httpClient *http.Client
+}
+
+// Types used for call
+
+type callError struct {
+	Code    uint32 `json:"code"`
+	Message string `json:"message"`
+	Status  string `json:"status"`
+}
+
+type registerResponse struct {
+	DeviceID string     `json:"deviceId"`
+	Error    *callError `json:"error"`
+}
+
+type batchRegisterResponse struct {
+	Responses []*registerResponse `json:"responses"`
+}
+
+// call is a generic wrapper around an HTTP call. It performs the following:
+// 1. Marshal request body
+// 2. Add request headers
+// 3. Send POST request
+// 4. Unmarshal response into a given pointer
+//
+// A response with a non-200 error code will be interpreted as success as long
+// as the response body is a JSON.
+func call[RequestMessage proto.Message, ResponseMessage any](ctx context.Context, config callConfig, req RequestMessage, resp ResponseMessage) error {
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request into JSON: %v", err)
+	}
+	rawReq, err := http.NewRequestWithContext(ctx, http.MethodPost, config.url, bytes.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %v", err)
+	}
+	for headerName, headerValue := range config.headers {
+		rawReq.Header.Add(headerName, headerValue)
+	}
+	rawReq.Header.Add("Content-Type", "application/json")
+	rawResp, err := config.httpClient.Do(rawReq)
+	if err != nil {
+		return fmt.Errorf("failed to execute HTTP request: %v", err)
+	}
+	respBody, err := ioutil.ReadAll(rawResp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read HTTP response body: %v", err)
+	}
+	if err := json.Unmarshal(respBody, resp); err != nil {
+		return fmt.Errorf("failed to unmarshal response body: %v", err)
+	}
+	return nil
+}
+
+func serverResponseToPBResponse(resp *registerResponse) *pbp.DeviceRegistrationResponse {
+	pbResp := &pbp.DeviceRegistrationResponse{
+		DeviceId:  resp.DeviceID,
+		Status:    pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_SUCCESS,
+		RpcStatus: 0,
+	}
+	if resp.Error != nil {
+		pbResp.RpcStatus = resp.Error.Code
+		pbResp.Status = pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_BAD_REQUEST
+	}
+	return pbResp
+}
+
+// RegisterDevice registers a device.
+func (r *Registry) RegisterDevice(ctx context.Context, request *pbp.DeviceRegistrationRequest, _ ...grpc.CallOption) (*pbp.DeviceRegistrationResponse, error) {
+	config := callConfig{
+		url:        r.RegisterDeviceURL,
+		headers:    r.Headers,
+		httpClient: r.client,
+	}
+	response := &registerResponse{}
+	err := call(ctx, config, request, response)
+	if err != nil {
+		return nil, err
+	}
+	pbResponse := serverResponseToPBResponse(response)
+	pbResponse.DeviceId = request.Record.DeviceId
+	return pbResponse, nil
+}
+
+// BatchRegisterDevice registers multiple devices.
+func (r *Registry) BatchRegisterDevice(ctx context.Context, request *pbp.BatchDeviceRegistrationRequest, _ ...grpc.CallOption) (*pbp.BatchDeviceRegistrationResponse, error) {
+	config := callConfig{
+		url:        r.BatchRegisterDeviceURL,
+		headers:    r.Headers,
+		httpClient: r.client,
+	}
+	response := &batchRegisterResponse{}
+	err := call(ctx, config, request, response)
+	if err != nil {
+		return nil, err
+	}
+	pbResponse := &pbp.BatchDeviceRegistrationResponse{
+		Responses: make([]*pbp.DeviceRegistrationResponse, len(response.Responses)),
+	}
+	for i, resp := range response.Responses {
+		pbResponse.Responses[i] = serverResponseToPBResponse(resp)
+	}
+	return pbResponse, nil
+}

--- a/src/proxy_buffer/services/http_registry_test.go
+++ b/src/proxy_buffer/services/http_registry_test.go
@@ -1,0 +1,214 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package httpregistry_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	dtd "github.com/lowRISC/opentitan-provisioning/src/proto/device_testdata"
+	pbp "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/proxy_buffer_go_pb"
+	"github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/services/httpregistry"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+var (
+	deviceRegistrationRequest = pbp.DeviceRegistrationRequest{
+		Record: &dtd.RegistryRecordOk,
+	}
+	batchDeviceRegistrationRequest = pbp.BatchDeviceRegistrationRequest{
+		Requests: []*pbp.DeviceRegistrationRequest{
+			&deviceRegistrationRequest,
+			&deviceRegistrationRequest,
+		},
+	}
+
+	deviceRegistrationResponseSuccess = pbp.DeviceRegistrationResponse{
+		Status:    pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_SUCCESS,
+		DeviceId:  dtd.RegistryRecordOk.GetDeviceId(),
+		RpcStatus: uint32(codes.OK),
+	}
+	deviceRegistrationResponseFailure = pbp.DeviceRegistrationResponse{
+		Status:    pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_BAD_REQUEST,
+		DeviceId:  dtd.RegistryRecordOk.GetDeviceId(),
+		RpcStatus: uint32(codes.InvalidArgument),
+	}
+
+	batchDeviceRegistrationResponseSuccess = pbp.BatchDeviceRegistrationResponse{
+		Responses: []*pbp.DeviceRegistrationResponse{
+			&deviceRegistrationResponseSuccess,
+			&deviceRegistrationResponseFailure,
+		},
+	}
+)
+
+var (
+	registerDeviceSuccessBody = fmt.Sprintf(`{
+	"deviceId": "%s"
+}`, dtd.RegistryRecordOk.DeviceId)
+
+	registerDeviceFailureBody = `{
+	"error": {
+		"code": 3,
+		"status": "INVALID_ARGUMENT",
+		"message": "Fake error"
+	}
+}`
+
+	batchRegisterDeviceSuccessBody = fmt.Sprintf(`{
+	"responses": [
+		{
+			"deviceId": "%s"
+		},
+		{
+			"deviceId": "%s",
+			"error": {
+				"code": 3,
+				"status": "INVALID_ARGUMENT",
+				"message": "Fake error"
+			}
+		}
+	]
+}`, dtd.RegistryRecordOk.DeviceId, dtd.RegistryRecordOk.DeviceId)
+)
+
+func registerDeviceSuccess(w http.ResponseWriter, _ *http.Request) {
+	w.Write([]byte(registerDeviceSuccessBody))
+}
+
+func registerDeviceFailure(w http.ResponseWriter, _ *http.Request) {
+	w.Write([]byte(registerDeviceFailureBody))
+	w.WriteHeader(http.StatusBadRequest)
+}
+
+func registerDeviceError(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Write([]byte("Internal server error"))
+}
+
+func batchRegisterDeviceSuccess(w http.ResponseWriter, _ *http.Request) {
+	w.Write([]byte(batchRegisterDeviceSuccessBody))
+}
+
+func batchRegisterDeviceError(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Write([]byte("Internal server error"))
+}
+
+func TestHTTPRegistryRegisterDevice(t *testing.T) {
+	tcs := []struct {
+		Name             string
+		RegistryHandler  http.HandlerFunc
+		Request          *pbp.DeviceRegistrationRequest
+		ExpectedResponse *pbp.DeviceRegistrationResponse
+		ExpectAnError    bool
+	}{
+		{
+			Name:             "Success",
+			RegistryHandler:  registerDeviceSuccess,
+			Request:          &deviceRegistrationRequest,
+			ExpectedResponse: &deviceRegistrationResponseSuccess,
+		},
+		{
+			Name:             "Failure",
+			RegistryHandler:  registerDeviceFailure,
+			Request:          &deviceRegistrationRequest,
+			ExpectedResponse: &deviceRegistrationResponseFailure,
+		},
+		{
+			Name:            "Error",
+			RegistryHandler: registerDeviceError,
+			Request:         &deviceRegistrationRequest,
+			ExpectAnError:   true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			server := httptest.NewServer(tc.RegistryHandler)
+			defer server.Close()
+			r, err := httpregistry.New(&httpregistry.RegistryConfig{
+				RegisterDeviceURL:      server.URL,
+				BatchRegisterDeviceURL: server.URL,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error when creating new HTTP registry: %v", err)
+			}
+
+			ctx := context.Background()
+			response, err := r.RegisterDevice(ctx, tc.Request)
+			if err != nil && !tc.ExpectAnError {
+				t.Fatalf("RegisterDevice() returned unexpected error: %v", err)
+			}
+			if err == nil && tc.ExpectAnError {
+				t.Fatal("RegisterDevice() expected an error, but returned none")
+			}
+			if err != nil && tc.ExpectAnError {
+				// Expected error
+				return
+			}
+			if diff := cmp.Diff(tc.ExpectedResponse, response, protocmp.Transform()); diff != "" {
+				t.Errorf("RegisterDevice() diff: (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHTTPRegistryBatchRegisterDevice(t *testing.T) {
+	tcs := []struct {
+		Name             string
+		RegistryHandler  http.HandlerFunc
+		Request          *pbp.BatchDeviceRegistrationRequest
+		ExpectedResponse *pbp.BatchDeviceRegistrationResponse
+		ExpectAnError    bool
+	}{
+		{
+			Name:             "Success",
+			RegistryHandler:  batchRegisterDeviceSuccess,
+			Request:          &batchDeviceRegistrationRequest,
+			ExpectedResponse: &batchDeviceRegistrationResponseSuccess,
+		},
+		{
+			Name:            "Error",
+			RegistryHandler: batchRegisterDeviceError,
+			Request:         &batchDeviceRegistrationRequest,
+			ExpectAnError:   true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			server := httptest.NewServer(tc.RegistryHandler)
+			defer server.Close()
+			r, err := httpregistry.New(&httpregistry.RegistryConfig{
+				RegisterDeviceURL:      server.URL,
+				BatchRegisterDeviceURL: server.URL,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error when creating new HTTP registry: %v", err)
+			}
+
+			ctx := context.Background()
+			response, err := r.BatchRegisterDevice(ctx, tc.Request)
+			if err != nil && !tc.ExpectAnError {
+				t.Fatalf("BatchRegisterDevice() returned unexpected error: %v", err)
+			}
+			if err == nil && tc.ExpectAnError {
+				t.Fatal("BatchRegisterDevice() expected an error, but returned none")
+			}
+			if err != nil && tc.ExpectAnError {
+				// Expected error
+				return
+			}
+			if diff := cmp.Diff(tc.ExpectedResponse, response, protocmp.Transform()); diff != "" {
+				t.Errorf("BatchRegisterDevice() diff: (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/src/proxy_buffer/syncer/BUILD.bazel
+++ b/src/proxy_buffer/syncer/BUILD.bazel
@@ -4,6 +4,8 @@
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//visibility:public"])
+
 go_library(
     name = "syncer",
     srcs = ["syncer.go"],


### PR DESCRIPTION
This PR introduces an implementation of an HTTP registry. This client uses custom intermediate types to pass from the server response (JSON) into proxy_buffer
protos.

I also fixed a visiblity rule in src/proxy_buffer/syncer.