### PR TITLE
[opentitan] bump lowrisc_opentitan repo version

### DIFF
--- a/third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh
+++ b/third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh
@@ -19,7 +19,7 @@ fi
 
 OT_REPO_TOP=$1
 
-_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC3"
+_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC6"
 _PROVISIONING_REPO_TOP=$(pwd)
 _FPGAS=("hyper310" "cw340")
 _CP_SKUS=("emulation")
@@ -42,10 +42,11 @@ for fpga in "${_FPGAS[@]}"; do
       //hw/bitstream/universal:splice
     if [[ "$fpga" == "cw340" ]]; then
       cp -f "${_BITSTREAM_PATH}" "${_PROVISIONING_REPO_TOP}/third_party/lowrisc/ot_bitstreams/cp_hyper340.bit"
+      chmod -x "${_PROVISIONING_REPO_TOP}/third_party/lowrisc/ot_bitstreams/cp_hyper340.bit"
     else
       cp -f "${_BITSTREAM_PATH}" "${_PROVISIONING_REPO_TOP}/third_party/lowrisc/ot_bitstreams/cp_${fpga}.bit"
+      chmod -x "${_PROVISIONING_REPO_TOP}/third_party/lowrisc/ot_bitstreams/cp_${fpga}.bit"
     fi
-    chmod -x "${_PROVISIONING_REPO_TOP}/third_party/lowrisc/ot_bitstreams/cp_${fpga}.bit"
   done
 done
 

--- a/third_party/lowrisc/ot_bitstreams/cp_hyper310.bit
+++ b/third_party/lowrisc/ot_bitstreams/cp_hyper310.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bcb1921c43a66fc6d42c1ccdbdc11e14b20ace39b37f9fe6f27afd0ede5d042b
+oid sha256:f842f986f293524bfc0d32eb335f96e708c979e5801c828df129f81374fe08f6
 size 15878032

--- a/third_party/lowrisc/ot_bitstreams/cp_hyper340.bit
+++ b/third_party/lowrisc/ot_bitstreams/cp_hyper340.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e987abfe652f93594e91aab425bfa974a501863ab5a7dc8275cc110003f37f87
+oid sha256:4121ca0ac7d9811950f5e1944152926119ce513c8c958d1c0db8aba6ea8f26d1
 size 35843488

--- a/third_party/lowrisc/ot_fw/build-orch-zip.sh
+++ b/third_party/lowrisc/ot_fw/build-orch-zip.sh
@@ -19,7 +19,7 @@ fi
 
 OT_REPO_TOP=$1
 
-_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC3"
+_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC6"
 _PROVISIONING_REPO_TOP=$(pwd)
 _ORCHESTRATOR_ZIP_PATH="bazel-bin/sw/host/provisioning/orchestrator/src/orchestrator.zip"
 

--- a/third_party/lowrisc/ot_fw/orchestrator.zip
+++ b/third_party/lowrisc/ot_fw/orchestrator.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15702ceb36a06cf7ea92c474095ac1d4715ce21335329f8d8fc2b1ba01ca77c3
-size 104450853
+oid sha256:5cf455942a1806dc6dc1d4f84d8ade88742dc5eab82ce3fd7eaa5a818308d2b4
+size 118757697

--- a/third_party/lowrisc/repos.bzl
+++ b/third_party/lowrisc/repos.bzl
@@ -12,7 +12,7 @@ _BAZEL_SKYLIB_VERSION = "1.5.0"
 # When updating the lowrisc_opentitan repo, be sure to rebuild the builtstream
 # files too by following the instructions in
 # `third_party/lowrisc/README.md`.
-_OPENTITAN_VERSION = "Earlgrey-A2-Provisioning-RC3"
+_OPENTITAN_VERSION = "Earlgrey-A2-Provisioning-RC6"
 
 def lowrisc_repos(misc_linters = None, bazel_release = None, bazel_skylib = None, opentitan = None):
     maybe(
@@ -45,7 +45,7 @@ def lowrisc_repos(misc_linters = None, bazel_release = None, bazel_skylib = None
         http_archive_or_local,
         local = opentitan,
         name = "lowrisc_opentitan",
-        sha256 = "67734361c39228a1f9fcb4e7f8f36e1ba048e37778b50a0ef290713c236c3321",
+        sha256 = "9517eb191fa5c2b2666204677fc0d35784f088cce163f319fbc3e3c2cc17defe",
         strip_prefix = "opentitan-{}".format(_OPENTITAN_VERSION),
         url = "https://github.com/lowRISC/opentitan/archive/refs/tags/{}.tar.gz".format(_OPENTITAN_VERSION),
     )


### PR DESCRIPTION
This bumps the lowrisc_opentitan repo version and regenerates the required static assets from said repo including:
1. bitstreams
2. orchestrator.zip