### PR TITLE
Create fake HTTP registry

### DIFF
--- a/src/proxy_buffer/services/BUILD.bazel
+++ b/src/proxy_buffer/services/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//src/proxy_buffer/proto:proxy_buffer_go_pb",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
     ],
 )
 

--- a/src/proxy_buffer/services/http_registry.go
+++ b/src/proxy_buffer/services/http_registry.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 // RegistryConfig holds the configuration for an HTTP registry
@@ -103,9 +104,9 @@ type callConfig struct {
 // Types used for call
 
 type callError struct {
-	Code    uint32 `json:"code"`
-	Message string `json:"message"`
-	Status  string `json:"status"`
+	Code    codes.Code `json:"code"`
+	Message string     `json:"message"`
+	Status  string     `json:"status"`
 }
 
 type registerResponse struct {
@@ -163,7 +164,7 @@ func serverResponseToPBResponse(resp *registerResponse) *pbp.DeviceRegistrationR
 		RpcStatus: 0,
 	}
 	if resp.Error != nil {
-		pbResp.RpcStatus = resp.Error.Code
+		pbResp.RpcStatus = uint32(resp.Error.Code)
 		pbResp.Status = pbp.DeviceRegistrationStatus_DEVICE_REGISTRATION_STATUS_BAD_REQUEST
 	}
 	return pbResp

--- a/src/testing/fake_registry/BUILD.bazel
+++ b/src/testing/fake_registry/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+go_binary(
+    name = "fake_registry_server",
+    srcs = ["fake_registry.go"],
+    deps = [
+        "//src/proxy_buffer/proto:proxy_buffer_go_pb",
+        "@org_golang_google_grpc//codes",
+    ],
+)
+
+go_image(
+    name = "fake_registry_server_image",
+    srcs = ["fake_registry.go"],
+    static = "on",
+    deps = [
+        "//src/proxy_buffer/proto:proxy_buffer_go_pb",
+        "@org_golang_google_grpc//codes",
+    ],
+)

--- a/src/testing/fake_registry/README.md
+++ b/src/testing/fake_registry/README.md
@@ -1,0 +1,21 @@
+[//]: # (Copyright lowRISC contributors \(OpenTitan project\).)
+[//]: # (Licensed under the Apache License, Version 2.0, see LICENSE for details.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+
+# Fake registry
+
+This package contains a fake HTTP registry to be used for testing.
+
+## Usage
+
+```
+bazelisk run //src/testing/fake_registry:fake_registry_server
+```
+
+## Flags
+
+- `port`: specifies the port in which the server listens. Defaults to 9999.
+- `register_device_url`: URL to listen to RegisterDevice requests. Defaults to
+  `/registerDevice`.
+- `batch_register_device_url`: URL to listen to BatchRegisterDevice requests.
+  Defaults to `/batchRegisterDevice`.

--- a/src/testing/fake_registry/fake_registry.go
+++ b/src/testing/fake_registry/fake_registry.go
@@ -1,0 +1,109 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is fake HTTP registry server. See README.md for more details.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	pbp "github.com/lowRISC/opentitan-provisioning/src/proxy_buffer/proto/proxy_buffer_go_pb"
+
+	"google.golang.org/grpc/codes"
+)
+
+var (
+	port                   = flag.Int("port", 9999, "Port to listen, defaults to 9999")
+	registerDeviceURL      = flag.String("register_device_url", "/registerDevice", "URL to listen to RegisterDevice requests. Defaults to '/registerDevice'")
+	batchRegisterDeviceURL = flag.String("batchRegister_device_url", "/batchRegisterDevice", "URL to listen to BatchRegisterDevice requests. Defaults to '/batchRegisterDevice'")
+)
+
+type callError struct {
+	Code codes.Code `json:"code"`
+}
+
+type registerResponse struct {
+	DeviceID string     `json:"deviceId"`
+	Error    *callError `json:"error"`
+}
+
+type batchRegisterResponse struct {
+	Responses []*registerResponse `json:"responses"`
+}
+
+var callErrorOK = callError{Code: codes.OK}
+
+func handleError(w http.ResponseWriter, errorMessage string) {
+	w.Write([]byte(errorMessage))
+	w.WriteHeader(http.StatusBadRequest)
+}
+
+func registerDevice(w http.ResponseWriter, r *http.Request) {
+	reqBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		handleError(w, "failed to read request body")
+		return
+	}
+	req := &pbp.DeviceRegistrationRequest{}
+	if err := json.Unmarshal(reqBytes, req); err != nil {
+		handleError(w, "failed to unmarshal request body")
+		return
+	}
+	resp := &registerResponse{
+		DeviceID: req.GetRecord().GetDeviceId(),
+		Error:    &callErrorOK,
+	}
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		handleError(w, "failed to marshal response body")
+		return
+	}
+	if _, err := w.Write(respBytes); err != nil {
+		handleError(w, "failed to write response body")
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func batchRegisterDevice(w http.ResponseWriter, r *http.Request) {
+	reqBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		handleError(w, "failed to read request body")
+		return
+	}
+	req := &pbp.BatchDeviceRegistrationRequest{}
+	if err := json.Unmarshal(reqBytes, req); err != nil {
+		handleError(w, "failed to unmarshal request body")
+		return
+	}
+	resp := &batchRegisterResponse{Responses: make([]*registerResponse, 0)}
+	for _, registerReq := range req.GetRequests() {
+		resp.Responses = append(resp.Responses, &registerResponse{
+			DeviceID: registerReq.GetRecord().GetDeviceId(),
+			Error:    &callErrorOK,
+		})
+	}
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		handleError(w, "failed to marshal response body")
+		return
+	}
+	if _, err := w.Write(respBytes); err != nil {
+		handleError(w, "failed to write response body")
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func main() {
+	http.HandleFunc(*registerDeviceURL, registerDevice)
+	http.HandleFunc(*batchRegisterDeviceURL, batchRegisterDevice)
+	log.Printf("Listening on port %d...", *port)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
+}


### PR DESCRIPTION
This registry is used for E2E testing when a real registry cannot be used.

This PR also changes the error response type in the real registry implementation to gRPC code, which supports unmarshal with both string and numeric codes.

In a follow-up CL I'll integrate this fake registry in the CI tests.