### PR TITLE
Enable RegistryServer and Syncer in CI jobs

### DIFF
--- a/config/dev/containers/provapp.yml.tmpl
+++ b/config/dev/containers/provapp.yml.tmpl
@@ -86,6 +86,11 @@ spec:
     - --ca_root_certs=/var/lib/opentitan/config/dev/certs/out/ca-cert.pem
     - --port=${OTPROV_PORT_PB}
     - --db_path=file::memory:?cache=shared
+    - --register_device_url=http://${OTPROV_DNS_REG}:${OTPROV_PORT_REG}/registerDevice
+    - --batch_register_device_url=http://${OTPROV_DNS_REG}:${OTPROV_PORT_REG}/batchRegisterDevice
+    - --enable_syncer=true
+    - --syncer_frequency=1m
+    - --syncer_records_per_run=5
     # TODO: Update label to point to specific release version.
     image: localhost/pb_server:latest
     resources: {}
@@ -100,6 +105,19 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/opentitan/config/dev
       name: var-lib-opentitan-spm-config-dev-0
+  - name: fakeregistry
+    args:
+    - --port=${OTPROV_PORT_REG}
+    image: localhost/fake_registry:latest
+    resources: {}
+    ports:
+      - containerPort: ${OTPROV_PORT_REG}
+    securityContext:
+      capabilities:
+        drop:
+        - CAP_MKNOD
+        - CAP_NET_RAW
+        - CAP_AUDIT_WRITE
   restartPolicy: Always
   volumes:
   - hostPath:

--- a/config/dev/env/spm.env
+++ b/config/dev/env/spm.env
@@ -9,15 +9,18 @@ export OTPROV_DNS_SPM="${OTPROV_DNS_SPM:-localhost}"
 export OTPROV_DNS_PA="${OTPROV_DNS_PA:-localhost}"
 export OTPROV_DNS_PB="${OTPROV_DNS_PB:-localhost}"
 export OTPROV_DNS_ATE="${OTPROV_DNS_ATE:-localhost}"
+export OTPROV_DNS_REG="${OTPROV_DNS_REG:-localhost}"
 
 export OTPROV_IP_SPM="${OTPROV_IP_SPM:-127.0.0.1}"
 export OTPROV_IP_PA="${OTPROV_IP_PA:-127.0.0.1}"
 export OTPROV_IP_PB="${OTPROV_IP_PB:-127.0.0.1}"
 export OTPROV_IP_ATE="${OTPROV_IP_ATE:-127.0.0.1}"
+export OTPROV_IP_REG="${OTPROV_DNS_REG:-127.0.0.1}"
 
 export OTPROV_PORT_SPM="${OTPROV_PORT_SPM:-5000}"
 export OTPROV_PORT_PA="${OTPROV_PORT_PA:-5001}"
 export OTPROV_PORT_PB="${OTPROV_PORT_PB:-5002}"
+export OTPROV_PORT_REG="${OTPROV_PORT_REG:-5003}"
 
 # The following variables are used for test purposes and are synchronized with
 # the ${REPO_TOP}/config/dev/softhsm/init.sh script.

--- a/config/prod/containers/provapp.yml.tmpl
+++ b/config/prod/containers/provapp.yml.tmpl
@@ -44,6 +44,12 @@ spec:
     - --ca_root_certs=/var/lib/opentitan/config/prod/certs/out/ca-cert.pem
     - --port=${OTPROV_PORT_PB}
     - --db_path=file::memory:?cache=shared
+    - --register_device_url=${OTPROV_SECRET_XXX}
+    - --batch_register_device_url=${OTPROV_SECRET_XXX}
+    - --registry_headers_file=${OTPROV_SECRET_XXX}
+    - --enable_syncer=true
+    - --syncer_frequency=1m
+    - --syncer_records_per_run=5
     # TODO: Update label to point to specific release version.
     image: localhost/pb_server:latest
     resources: {}


### PR DESCRIPTION
This PR enables them in both prod and dev test jobs. Prod talks to a real HTTP registry, dev hosts its own fake registry (see #168).