### PR TITLE
[ft] bootstrap the perso binary

### DIFF
--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -54,7 +54,7 @@ bazelisk run //src/ate/test_programs:ft -- \
   --sku="sival" \
   --sku_auth_pw="test_password" \
   --fpga="${FPGA}" \
-  --ft_individualization_elf="${DEPLOYMENT_BIN_DIR}/sram_ft_individualize_sival_fpga_${BIN_DEVICE}_rom_with_fake_keys.elf" \
-  --ft_personalize_bin="${DEPLOYMENT_BIN_DIR}/ft_personalize_sival_${BIN_DEVICE}_rom_with_fake_keys.elf" \
+  --ft_individualization_elf="${DEPLOYMENT_BIN_DIR}/sram_ft_individualize_sival_ate_fpga_${BIN_DEVICE}_rom_with_fake_keys.elf" \
+  --ft_personalize_bin="${DEPLOYMENT_BIN_DIR}/ft_personalize_sival_fpga_${BIN_DEVICE}_rom_with_fake_keys.prod_key_0.prod_key_0.signed.bin" \
   --openocd="${DEPLOYMENT_BIN_DIR}/openocd"
 echo "Done."

--- a/src/ate/test_programs/cp.cc
+++ b/src/ate/test_programs/cp.cc
@@ -227,7 +227,8 @@ int main(int argc, char **argv) {
   // Init session with FPGA DUT and load CP provisioning firmware.
   auto dut = DutLib::Create(absl::GetFlag(FLAGS_fpga));
   dut->DutFpgaLoadBitstream(fpga_bitstream_path);
-  dut->DutLoadSramElf(openocd_path, sram_elf_path);
+  dut->DutLoadSramElf(openocd_path, sram_elf_path, /*wait_for_done=*/false,
+                      /*timeout_ms=*/1000);
   dut->DutTxCpProvisioningData(spi_frame.payload, spi_frame.cursor,
                                /*timeout_ms=*/1000);
   std::string cp_device_id_str = dut->DutRxCpDeviceId(/*quiet=*/false,

--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -19,7 +19,8 @@ namespace test_programs {
 extern "C" {
 void* OtLibFpgaTransportInit(const char* fpga);
 void OtLibFpgaLoadBitstream(void* transport, const char* fpga_bitstream);
-void OtLibLoadSramElf(void* transport, const char* openocd, const char* elf);
+void OtLibLoadSramElf(void* transport, const char* openocd, const char* elf,
+                      bool wait_for_done, uint64_t timeout_ms);
 void OtLibConsoleWaitForRx(void* transport, const char* msg,
                            uint64_t timeout_ms);
 void OtLibConsoleRx(void* transport, bool quiet, uint64_t timeout_ms,
@@ -42,10 +43,11 @@ void DutLib::DutFpgaLoadBitstream(const std::string& fpga_bitstream) {
   OtLibFpgaLoadBitstream(transport_, fpga_bitstream.c_str());
 }
 
-void DutLib::DutLoadSramElf(const std::string& openocd,
-                            const std::string& elf) {
+void DutLib::DutLoadSramElf(const std::string& openocd, const std::string& elf,
+                            bool wait_for_done, uint64_t timeout_ms) {
   LOG(INFO) << "in DutLib::DutLoadSramElf";
-  OtLibLoadSramElf(transport_, openocd.c_str(), elf.c_str());
+  OtLibLoadSramElf(transport_, openocd.c_str(), elf.c_str(), wait_for_done,
+                   timeout_ms);
 }
 
 void DutLib::DutConsoleWaitForRx(const char* msg, uint64_t timeout_ms) {

--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -21,6 +21,9 @@ void* OtLibFpgaTransportInit(const char* fpga);
 void OtLibFpgaLoadBitstream(void* transport, const char* fpga_bitstream);
 void OtLibLoadSramElf(void* transport, const char* openocd, const char* elf,
                       bool wait_for_done, uint64_t timeout_ms);
+void OtLibBootstrap(void* transport, const char* bin);
+void OtLibWaitForGpioState(void* transport, const char* pin, bool state,
+                           uint64_t timeout_ms);
 void OtLibConsoleWaitForRx(void* transport, const char* msg,
                            uint64_t timeout_ms);
 void OtLibConsoleRx(void* transport, bool quiet, uint64_t timeout_ms,
@@ -48,6 +51,17 @@ void DutLib::DutLoadSramElf(const std::string& openocd, const std::string& elf,
   LOG(INFO) << "in DutLib::DutLoadSramElf";
   OtLibLoadSramElf(transport_, openocd.c_str(), elf.c_str(), wait_for_done,
                    timeout_ms);
+}
+
+void DutLib::DutBootstrap(const std::string& bin) {
+  LOG(INFO) << "in DutLib::DutBootstrap";
+  OtLibBootstrap(transport_, bin.c_str());
+}
+
+void DutLib::DutWaitForGpioState(const char* pin, bool state,
+                                 uint64_t timeout_ms) {
+  LOG(INFO) << "in DutLib::DutWaitForGpioState";
+  OtLibWaitForGpioState(transport_, pin, state, timeout_ms);
 }
 
 void DutLib::DutConsoleWaitForRx(const char* msg, uint64_t timeout_ms) {

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -32,6 +32,14 @@ class DutLib {
   void DutLoadSramElf(const std::string& openocd, const std::string& elf,
                       bool wait_for_done, uint64_t timeout_ms);
   /**
+   * Calls opentitanlib to bootstrap a binary into the DUT's flash over SPI.
+   */
+  void DutBootstrap(const std::string& bin);
+  /**
+   * Waits for a GPIO pin to toggle high.
+   */
+  void DutWaitForGpioState(const char* pin, bool state, uint64_t timeout_ms);
+  /**
    * Calls opentitanlib test util to wait for a message over the SPI console.
    */
   void DutConsoleWaitForRx(const char* msg, uint64_t timeout_ms);

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -29,11 +29,12 @@ class DutLib {
   /**
    * Calls opentitanlib test util to load an SRAM ELF into the DUT over JTAG.
    */
-  void DutLoadSramElf(const std::string& openocd, const std::string& elf);
+  void DutLoadSramElf(const std::string& openocd, const std::string& elf,
+                      bool wait_for_done, uint64_t timeout_ms);
   /**
    * Calls opentitanlib test util to wait for a message over the SPI console.
    */
-  void DutConsoleWaitForRx(const char*, uint64_t timeout_ms);
+  void DutConsoleWaitForRx(const char* msg, uint64_t timeout_ms);
   /**
    * Calls opentitanlib test util to receive a message over the SPI console.
    */

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -157,6 +157,13 @@ int main(int argc, char **argv) {
     return -1;
   }
   std::string ft_individ_elf_path = ft_individ_elf_result.value();
+  auto ft_perso_bin_result =
+      ValidateFilePathInput(absl::GetFlag(FLAGS_ft_personalize_bin));
+  if (!ft_perso_bin_result.ok()) {
+    LOG(ERROR) << ft_perso_bin_result.status().message() << std::endl;
+    return -1;
+  }
+  std::string ft_perso_bin_path = ft_perso_bin_result.value();
 
   // Instantiate an ATE client (gateway to PA).
   auto ate = AteClient::Create(ate_options);
@@ -181,7 +188,10 @@ int main(int argc, char **argv) {
                       /*wait_for_done=*/true,
                       /*timeout_ms=*/1000);
 
-  // TODO(timothytrippel): add perso loading and execution steps
+  // Run FT personalization firmware.
+  dut->DutBootstrap(ft_perso_bin_path);
+
+  // TODO(timothytrippel): add perso execution steps
 
   // Close session with PA.
   pa_status = ate->CloseSession();

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -170,12 +170,16 @@ int main(int argc, char **argv) {
     return -1;
   }
 
-  // Init session with FPGA DUT and load FT individualization firmware.
+  // Init session with FPGA DUT.
   //
   // Note: we do not reload the bitstream as the CP test program should be run
   // before running this test program.
   auto dut = DutLib::Create(absl::GetFlag(FLAGS_fpga));
-  dut->DutLoadSramElf(openocd_path, ft_individ_elf_path);
+
+  // Run FT individualization firmware.
+  dut->DutLoadSramElf(openocd_path, ft_individ_elf_path,
+                      /*wait_for_done=*/true,
+                      /*timeout_ms=*/1000);
 
   // TODO(timothytrippel): add perso loading and execution steps
 


### PR DESCRIPTION
This adds dut_lib functions to enable a test program to bootstrap a binary into the DUT's flash. Additionally, this updates the FT test program to bootstrap the personalization firmware.

Additionally, this waits for FT individualization binary to complete executing before the personalization binary is bootstrapped, by updating the dut_lib SRAM ELF loading function to be able to wait for the SRAM binary to complete execution.
