### PR TITLE
[ft] generate / inject RMA unlock token

### DIFF
--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -56,5 +56,6 @@ bazelisk run //src/ate/test_programs:ft -- \
   --fpga="${FPGA}" \
   --ft_individualization_elf="${DEPLOYMENT_BIN_DIR}/sram_ft_individualize_sival_ate_fpga_${BIN_DEVICE}_rom_with_fake_keys.elf" \
   --ft_personalize_bin="${DEPLOYMENT_BIN_DIR}/ft_personalize_sival_fpga_${BIN_DEVICE}_rom_with_fake_keys.signed.bin" \
+  --ft_fw_bundle_bin="${DEPLOYMENT_BIN_DIR}/ft_fw_bundle_sival_fpga_${BIN_DEVICE}_rom_with_fake_keys.img" \
   --openocd="${DEPLOYMENT_BIN_DIR}/openocd"
 echo "Done."

--- a/src/ate/test_programs/BUILD.bazel
+++ b/src/ate/test_programs/BUILD.bazel
@@ -37,5 +37,6 @@ cc_binary(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@lowrisc_opentitan//sw/device/lib/dif:lc_ctrl",
     ],
 )

--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -35,8 +35,11 @@ void OtLibRxCpDeviceId(void* transport, bool quiet, uint64_t timeout_ms,
                        uint8_t* cp_device_id_str,
                        size_t* cp_device_id_str_size);
 void OtLibResetAndLock(void* transport, const char* openocd);
-void OtLibTestUnlock(void* transport, const char* openocd, const uint8_t* token,
-                     size_t token_size);
+void OtLibLcTransition(void* transport, const char* openocd,
+                       const uint8_t* token, size_t token_size,
+                       uint32_t target_lc_state);
+void OtLibTxRmaUnlockTokenHash(void* transport, const uint8_t* spi_frame,
+                               size_t spi_frame_size, uint64_t timeout_ms);
 }
 
 std::unique_ptr<DutLib> DutLib::Create(const std::string& fpga) {
@@ -112,10 +115,18 @@ void DutLib::DutResetAndLock(const std::string& openocd) {
   OtLibResetAndLock(transport_, openocd.c_str());
 }
 
-void DutLib::DutTestUnlock(const std::string& openocd, const uint8_t* token,
-                           size_t token_size) {
-  LOG(INFO) << "in DutLib::DutTestUnlock";
-  OtLibTestUnlock(transport_, openocd.c_str(), token, token_size);
+void DutLib::DutLcTransition(const std::string& openocd, const uint8_t* token,
+                             size_t token_size, uint32_t target_lc_state) {
+  LOG(INFO) << "in DutLib::DutLcTransition";
+  OtLibLcTransition(transport_, openocd.c_str(), token, token_size,
+                    target_lc_state);
+}
+
+void DutLib::DutTxFtRmaUnlockTokenHash(const uint8_t* spi_frame,
+                                       size_t spi_frame_size,
+                                       uint64_t timeout_ms) {
+  LOG(INFO) << "in DutLib::DutTxFtRmaUnlockTokenHash";
+  OtLibTxRmaUnlockTokenHash(transport_, spi_frame, spi_frame_size, timeout_ms);
 }
 }  // namespace test_programs
 }  // namespace provisioning

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -71,8 +71,14 @@ class DutLib {
    * Calls opentitanlib test util to execute a life cycle transition to
    * TestUnlocked* (from TestLocked*).
    */
-  void DutTestUnlock(const std::string& openocd, const uint8_t* token,
-                     size_t token_size);
+  void DutLcTransition(const std::string& openocd, const uint8_t* token,
+                       size_t token_size, uint32_t target_lc_state);
+  /**
+   * Calls opentitanlib methods to send the RMA unlock token hash over the SPI
+   * console to the DUT.
+   */
+  void DutTxFtRmaUnlockTokenHash(const uint8_t* spi_frame,
+                                 size_t spi_frame_size, uint64_t timeout_ms);
 
  private:
   // Must match the opentitanlib UartConsole buffer size defined here:

--- a/util/integration_test_setup.sh
+++ b/util/integration_test_setup.sh
@@ -83,6 +83,7 @@ cp "${BUILD_BIN_DIR}"/sw/device/silicon_creator/manuf/base/sram_cp_provision*.el
 cp "${BUILD_BIN_DIR}"/sw/device/silicon_creator/manuf/base/sram_ft_individualize*.elf "${DEPLOYMENT_BIN_DIR}"
 cp "${BUILD_BIN_DIR}"/sw/device/silicon_creator/manuf/base/ft_personalize*.bin "${DEPLOYMENT_BIN_DIR}"
 cp "${BUILD_BIN_DIR}"/sw/device/silicon_creator/manuf/base/binaries/ft_personalize*.bin "${DEPLOYMENT_BIN_DIR}"
+cp "${BUILD_BIN_DIR}"/sw/device/silicon_creator/manuf/base/ft_fw_bundle*.img "${DEPLOYMENT_BIN_DIR}"
 cp "${BUILD_BIN_DIR}"/third_party/openocd/build_openocd/bin/openocd "${DEPLOYMENT_BIN_DIR}"
 chmod +x "${DEPLOYMENT_BIN_DIR}"/openocd
 


### PR DESCRIPTION
This updates the reference FT test program to:
1. generate the RMA unlock token hash, and
2. inject it into the DUT over the SPI console.