### PR TITLE
[spm/ate] Include `key_label` in `EndorseCerts` response.

### DIFF
--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -211,7 +211,11 @@ typedef struct endorse_cert_request {
   signature_encoding_t signature_encoding;
   /** Size of the key label. */
   size_t key_label_size;
-  /** Signing key label. */
+  /**
+   * The key label is used to identify the key used to sign the certificate.
+   * The label is a human-readable string that is used to identify the key.
+   * The size of the label is limited to kCertificateKeyLabelMaxSize bytes.
+   */
   char key_label[kCertificateKeyLabelMaxSize];
   /** Size of the TBS data. */
   size_t tbs_size;
@@ -223,12 +227,20 @@ typedef struct endorse_cert_request {
  * Response parameters for endorsing certificates.
  */
 typedef struct endorse_cert_response {
+  /** Size of the key label. */
+  size_t key_label_size;
+  /**
+   * The key label is used to identify the key used to sign the certificate.
+   * The label is a human-readable string that is used to identify the key.
+   * The size of the label is limited to kCertificateKeyLabelMaxSize bytes.
+   */
+  char key_label[kCertificateKeyLabelMaxSize];
   /**
    * The size of the buffer pointed by `cert`. The user should set the size
    * allocated before calling the `EndorseCerts()` function. The funtion will
    * update the value with the actual certificate size.
    */
-  size_t size;
+  size_t cert_size;
   /**
    * The endorsed certificate.
    */

--- a/src/ate/ate_client_test.cc
+++ b/src/ate/ate_client_test.cc
@@ -51,7 +51,10 @@ class AteTest : public ::testing::Test {
 TEST_F(AteTest, EndorseCerts) {
   // Response that will be sent back for EndorseCerts.
   auto response = ParseTextProto<EndorseCertsResponse>(R"pb(
-    certs: { blob: "fake-cert-blob" })pb");
+    certs: {
+      key_label: "fake-key-label"
+      cert: { blob: "fake-cert-blob" }
+    })pb");
 
   // Expect EndorseCerts to be called.
   // The 2nd arg is expected to be a protobuf with the `sku` field.

--- a/src/ate/ate_dll.cc
+++ b/src/ate/ate_dll.cc
@@ -501,15 +501,24 @@ DLLEXPORT int EndorseCerts(ate_client_ptr client, const char *sku,
     auto &c = resp.certs(i);
     auto &resp_cert = certs[i];
 
-    if (c.blob().size() > sizeof(resp_cert.cert)) {
+    if (c.cert().blob().size() > sizeof(resp_cert.cert)) {
       LOG(ERROR) << "EndorseCerts failed- certificate size is too big: "
-                 << c.blob().size() << " bytes. Certificate index: " << i
+                 << c.cert().blob().size() << " bytes. Certificate index: " << i
                  << ", expected max size: " << sizeof(resp_cert.cert);
       return static_cast<int>(absl::StatusCode::kInternal);
     }
 
-    resp_cert.size = c.blob().size();
-    memcpy(resp_cert.cert, c.blob().data(), c.blob().size());
+    resp_cert.cert_size = c.cert().blob().size();
+    memcpy(resp_cert.cert, c.cert().blob().data(), c.cert().blob().size());
+
+    if (c.key_label().size() > kCertificateKeyLabelMaxSize) {
+      LOG(ERROR) << "EndorseCerts failed - key label size is too big: "
+                 << c.key_label().size() << " bytes. Certificate index: " << i
+                 << ", expected max size: " << kCertificateKeyLabelMaxSize;
+      return static_cast<int>(absl::StatusCode::kInternal);
+    }
+    resp_cert.key_label_size = c.key_label().size();
+    memcpy(resp_cert.key_label, c.key_label().data(), c.key_label().size());
   }
   return 0;
 }

--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -52,10 +52,17 @@ message EndorseCertsRequest {
   bytes signature = 4;
 }
 
+message CertBundle {
+  // Key label used to sign the certificate.
+  string key_label = 1;
+  // Endorsed certificate.
+  crypto.cert.Certificate cert = 2;
+}
+
 // Endorse certs response.
 message EndorseCertsResponse {
   // Array of complete (endorsed) certificates to be installed in a device.
-  repeated crypto.cert.Certificate certs = 1;
+  repeated CertBundle certs = 1;
 }
 
 // Token seed type (seed is provisioned into HSM).

--- a/src/spm/services/spm.go
+++ b/src/spm/services/spm.go
@@ -343,7 +343,7 @@ func (s *server) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequ
 		return nil, status.Errorf(codes.Internal, "could not verify WAS signature: %s", err)
 	}
 
-	var certs []*pbc.Certificate
+	var certs []*pbp.CertBundle
 	for _, bundle := range request.Bundles {
 		keyLabel, err := sku.config.GetUnsafeAttribute(bundle.KeyParams.KeyLabel)
 		if err != nil {
@@ -359,7 +359,12 @@ func (s *server) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequ
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "could not endorse cert: %v", err)
 			}
-			certs = append(certs, &pbc.Certificate{Blob: cert})
+			certs = append(certs, &pbp.CertBundle{
+				KeyLabel: bundle.KeyParams.KeyLabel,
+				Cert: &pbc.Certificate{
+					Blob: cert,
+				},
+			})
 		default:
 			return nil, status.Errorf(codes.Unimplemented, "unsupported key format")
 		}


### PR DESCRIPTION
Include the `key_label` in the `EndorseCertsResponse` message to make it easier for the ATE library to determine which key was used to endore the cert.