### PR TITLE
[cp,ft] add lifecycle lock and unlock operations

### DIFF
--- a/src/ate/ate_api_json_commands.cc
+++ b/src/ate/ate_api_json_commands.cc
@@ -67,7 +67,7 @@ DLLEXPORT int TokensToJson(const token_t *wafer_auth_secret,
   const uint32_t *was_ptr =
       reinterpret_cast<const uint32_t *>(wafer_auth_secret->data);
   for (size_t i = 0; i < 8; ++i) {
-    tokens_cmd.add_wafer_auth_secret(ByteSwap32(was_ptr[i]));
+    tokens_cmd.add_wafer_auth_secret(was_ptr[i]);
   }
 
   if (test_unlock_token == nullptr ||
@@ -78,7 +78,7 @@ DLLEXPORT int TokensToJson(const token_t *wafer_auth_secret,
   const uint64_t *test_unlock_token_ptr =
       reinterpret_cast<const uint64_t *>(test_unlock_token->data);
   for (size_t i = 0; i < 2; ++i) {
-    tokens_cmd.add_test_unlock_token_hash(ByteSwap64(test_unlock_token_ptr[i]));
+    tokens_cmd.add_test_unlock_token_hash(test_unlock_token_ptr[i]);
   }
 
   if (test_exit_token == nullptr ||
@@ -89,7 +89,7 @@ DLLEXPORT int TokensToJson(const token_t *wafer_auth_secret,
   const uint64_t *test_exit_token_ptr =
       reinterpret_cast<const uint64_t *>(test_exit_token->data);
   for (size_t i = 0; i < 2; ++i) {
-    tokens_cmd.add_test_exit_token_hash(ByteSwap64(test_exit_token_ptr[i]));
+    tokens_cmd.add_test_exit_token_hash(test_exit_token_ptr[i]);
   }
 
   // Convert the provisioning data to a JSON string.

--- a/src/ate/ate_api_json_commands_test.cc
+++ b/src/ate/ate_api_json_commands_test.cc
@@ -24,17 +24,17 @@ class AteJsonTest : public ::testing::Test {};
 
 TEST_F(AteJsonTest, TokensToJson) {
   dut_spi_frame_t frame;
-  token_t wafer_auth_secret;
-  token_t test_unlock_token;
-  token_t test_exit_token;
+  token_t wafer_auth_secret = {0};
+  token_t test_unlock_token = {0};
+  token_t test_exit_token = {0};
 
   wafer_auth_secret.size = sizeof(uint32_t) * 8;
   test_unlock_token.size = sizeof(uint64_t) * 2;
   test_exit_token.size = sizeof(uint64_t) * 2;
 
-  wafer_auth_secret.data[0] = 0x11;
-  test_unlock_token.data[0] = 0x11;
-  test_exit_token.data[0] = 0x11;
+  wafer_auth_secret.data[0] = 1;
+  test_unlock_token.data[0] = 1;
+  test_exit_token.data[0] = 1;
 
   EXPECT_EQ(TokensToJson(&wafer_auth_secret, &test_unlock_token,
                          &test_exit_token, &frame),
@@ -51,7 +51,7 @@ TEST_F(AteJsonTest, TokensToJson) {
                                                   options);
   EXPECT_EQ(status.ok(), true);
   EXPECT_THAT(tokens_cmd, EqualsProto(R"pb(
-                wafer_auth_secret: 285212672
+                wafer_auth_secret: 1
                 wafer_auth_secret: 0
                 wafer_auth_secret: 0
                 wafer_auth_secret: 0
@@ -59,9 +59,9 @@ TEST_F(AteJsonTest, TokensToJson) {
                 wafer_auth_secret: 0
                 wafer_auth_secret: 0
                 wafer_auth_secret: 0
-                test_unlock_token_hash: 1224979098644774912
+                test_unlock_token_hash: 1
                 test_unlock_token_hash: 0
-                test_exit_token_hash: 1224979098644774912
+                test_exit_token_hash: 1
                 test_exit_token_hash: 0
               )pb"));
 }

--- a/src/ate/test_programs/BUILD.bazel
+++ b/src/ate/test_programs/BUILD.bazel
@@ -28,7 +28,7 @@ cc_binary(
     name = "ft",
     srcs = ["ft.cc"],
     deps = [
-        "//src/ate:ate_client",
+        "//src/ate:ate_lib",
         "//src/ate/test_programs/dut_lib",
         "//src/pa/proto:pa_cc_proto",
         "//src/version",

--- a/src/ate/test_programs/cp.cc
+++ b/src/ate/test_programs/cp.cc
@@ -122,7 +122,6 @@ bool SetDiversificationString(uint8_t *diversifier, const std::string &str) {
   memset(diversifier + str.size(), 0, kDiversificationStringSize - str.size());
   return true;
 }
-
 }  // namespace
 
 int main(int argc, char **argv) {
@@ -235,7 +234,8 @@ int main(int argc, char **argv) {
                                                       /*timeout_ms=*/1000);
   LOG(INFO) << "CP Device ID: " << cp_device_id_str;
 
-  // Close session with PA.
+  // Lock the chip and close session with PA.
+  dut->DutResetAndLock(openocd_path);
   if (CloseSession(ate_client) != 0) {
     LOG(ERROR) << "CloseSession with PA failed.";
     return -1;

--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -34,6 +34,9 @@ void OtLibTxCpProvisioningData(void* transport, const uint8_t* spi_frame,
 void OtLibRxCpDeviceId(void* transport, bool quiet, uint64_t timeout_ms,
                        uint8_t* cp_device_id_str,
                        size_t* cp_device_id_str_size);
+void OtLibResetAndLock(void* transport, const char* openocd);
+void OtLibTestUnlock(void* transport, const char* openocd, const uint8_t* token,
+                     size_t token_size);
 }
 
 std::unique_ptr<DutLib> DutLib::Create(const std::string& fpga) {
@@ -104,5 +107,15 @@ std::string DutLib::DutRxCpDeviceId(bool quiet, uint64_t timeout_ms) {
   return cp_device_id_str;
 }
 
+void DutLib::DutResetAndLock(const std::string& openocd) {
+  LOG(INFO) << "in DutLib::DutResetAndLock";
+  OtLibResetAndLock(transport_, openocd.c_str());
+}
+
+void DutLib::DutTestUnlock(const std::string& openocd, const uint8_t* token,
+                           size_t token_size) {
+  LOG(INFO) << "in DutLib::DutTestUnlock";
+  OtLibTestUnlock(transport_, openocd.c_str(), token, token_size);
+}
 }  // namespace test_programs
 }  // namespace provisioning

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -62,6 +62,17 @@ class DutLib {
    * the SPI console from the DUT.
    */
   std::string DutRxCpDeviceId(bool quiet, uint64_t timeout_ms);
+  /**
+   * Calls opentitanlib test util to execute a life cycle transition to
+   * TestLocked0 (from TestUnlocked0).
+   */
+  void DutResetAndLock(const std::string& openocd);
+  /**
+   * Calls opentitanlib test util to execute a life cycle transition to
+   * TestUnlocked* (from TestLocked*).
+   */
+  void DutTestUnlock(const std::string& openocd, const uint8_t* token,
+                     size_t token_size);
 
  private:
   // Must match the opentitanlib UartConsole buffer size defined here:

--- a/src/ate/test_programs/otlib_wrapper/BUILD.bazel
+++ b/src/ate/test_programs/otlib_wrapper/BUILD.bazel
@@ -13,10 +13,12 @@ rust_library(
     ],
     deps = [
         "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
         "@crate_index//:crc",
         "@crate_index//:regex",
         "@crate_index//:zerocopy",
         "@lowrisc_opentitan//sw/host/opentitanlib",
+        "@lowrisc_opentitan//sw/host/provisioning/cp_lib",
         "@lowrisc_opentitan//sw/host/provisioning/ujson_lib",
         "@lowrisc_opentitan//sw/host/provisioning/util_lib",
     ],


### PR DESCRIPTION
This udpates the CP and FT test programs, and supporting dut_lib, to actuate the lifecycle state of the DUT. Specifically:
1. CP was updated to move the DUT to a TEST_LOCKED state upon completion, and
2. FT was updated to move the DUT to a TEST_UNLOCKED state before executing any device firmware.

Additionally, this updates the FT test program to use the ATE DLL directly, instead of using the AteClient class.