### PR TITLE
Allow ProxyBuffer syncer to return fatal error on retry failure

### DIFF
--- a/src/proxy_buffer/pb_server.go
+++ b/src/proxy_buffer/pb_server.go
@@ -34,15 +34,25 @@ var (
 	batchRegisterDeviceURL = flag.String("batch_register_device_url", "", "URL to call for BatchRegisterDevice")
 	registryHeadersFile    = flag.String("registry_headers_file", "", "File containing all the headers. Each line should contain a header in the format `NAME: VALUE`.")
 	// Syncer
-	enableSyncer        = flag.Bool("enable_syncer", false, "If true, will create an HTTP register and a syncer.")
-	syncerFrequency     = flag.String("syncer_frequency", "10m", "Frequency with which the syncer runs. Must use a valid Go duration string (see https://pkg.go.dev/time#ParseDuration). Defaults to 10 minutes.")
-	syncerRecordsPerRun = flag.Int("syncer_records_per_run", 100, "Number of records for the syncer to process per run. Defaults to 100.")
+	enableSyncer              = flag.Bool("enable_syncer", false, "If true, will create an HTTP register and a syncer.")
+	syncerFrequency           = flag.String("syncer_frequency", "10m", "Frequency with which the syncer runs. Must use a valid Go duration string (see https://pkg.go.dev/time#ParseDuration). Defaults to 10 minutes.")
+	syncerRecordsPerRun       = flag.Int("syncer_records_per_run", 100, "Number of records for the syncer to process per run. Defaults to 100.")
+	syncerMaxRetriesPerRecord = flag.Int("syncer_max_retries_per_record", 5, "Number of times a record can be retried before it stops pb_server. Anything less than zero will not stop the service. Defaults to 5.")
 	// gRPC server
 	enableTLS   = flag.Bool("enable_tls", false, "Enable mTLS secure channel; optional")
 	serviceKey  = flag.String("service_key", "", "File path to the PEM encoding of the server's private key")
 	serviceCert = flag.String("service_cert", "", "File path to the PEM encoding of the server's certificate chain")
 	caRootCerts = flag.String("ca_root_certs", "", "File path to the PEM encoding of the CA root certificates")
 )
+
+func listenForSyncerFatalErrors(errCh <-chan error) {
+	for {
+		select {
+		case err := <-errCh:
+			log.Fatalf("Fatal error in syncer job: %v", err)
+		}
+	}
+}
 
 func main() {
 	flag.Parse()
@@ -70,14 +80,16 @@ func main() {
 
 		// Initialize syncer job
 		syncerOpts := &syncer.Options{
-			Frequency:     *syncerFrequency,
-			RecordsPerRun: *syncerRecordsPerRun,
+			Frequency:           *syncerFrequency,
+			RecordsPerRun:       *syncerRecordsPerRun,
+			MaxRetriesPerRecord: *syncerMaxRetriesPerRecord,
 		}
 		syncerJob, err := syncer.New(database, registry, syncerOpts)
 		if err != nil {
 			log.Fatalf("Failed to initialize syncer job: %v", err)
 		}
 		syncerJob.Start()
+		go listenForSyncerFatalErrors(syncerJob.FatalErrors())
 	}
 
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))


### PR DESCRIPTION
This commit allows us to have a maximum numbers of retries per device. If the device is retried more than said number, it will cause a fatal error, which is propagated via FatalErrors() channel.

I also fixed a bug in the Stop() logic by creating the channel with a size 1.