### PR TITLE
[bazel] bump lowrisc_opentitan version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,6 +56,10 @@ crate_universe_dependencies(bootstrap = True)
 load("@lowrisc_opentitan//third_party/rust/crates:crates.bzl", "crate_repositories")
 crate_repositories()
 
+# hwtrust
+load("@lowrisc_opentitan//third_party/hwtrust:repos.bzl", "hwtrust_repos")
+hwtrust_repos()
+
 # HyperDebug firmware (required for opentitanlib) from the lowrisc_opentitan repo.
 load("@lowrisc_opentitan//third_party/hyperdebug:repos.bzl", "hyperdebug_repos")
 hyperdebug_repos()

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -55,6 +55,6 @@ bazelisk run //src/ate/test_programs:ft -- \
   --sku_auth_pw="test_password" \
   --fpga="${FPGA}" \
   --ft_individualization_elf="${DEPLOYMENT_BIN_DIR}/sram_ft_individualize_sival_ate_fpga_${BIN_DEVICE}_rom_with_fake_keys.elf" \
-  --ft_personalize_bin="${DEPLOYMENT_BIN_DIR}/ft_personalize_sival_fpga_${BIN_DEVICE}_rom_with_fake_keys.prod_key_0.prod_key_0.signed.bin" \
+  --ft_personalize_bin="${DEPLOYMENT_BIN_DIR}/ft_personalize_sival_fpga_${BIN_DEVICE}_rom_with_fake_keys.signed.bin" \
   --openocd="${DEPLOYMENT_BIN_DIR}/openocd"
 echo "Done."

--- a/src/ate/test_programs/otlib_wrapper/src/lib.rs
+++ b/src/ate/test_programs/otlib_wrapper/src/lib.rs
@@ -464,14 +464,15 @@ pub extern "C" fn OtLibRxCpDeviceId(
     // Receive the CP device ID string from DUT.
     let timeout = Duration::from_millis(timeout_ms);
     let _ = UartConsole::wait_for(&spi_console, r"Exporting CP device ID ...", timeout);
-    let cp_dev_id_string = ManufCpProvisioningDataOut::recv(&spi_console, timeout, quiet)
-        .unwrap()
-        .cp_device_id
-        .iter()
-        .rev()
-        .map(|v| format!("{v:08X}"))
-        .collect::<Vec<String>>()
-        .join("");
+    let cp_dev_id_string =
+        ManufCpProvisioningDataOut::recv(&spi_console, timeout, quiet, /*skip_crc=*/ false)
+            .unwrap()
+            .cp_device_id
+            .iter()
+            .rev()
+            .map(|v| format!("{v:08X}"))
+            .collect::<Vec<String>>()
+            .join("");
     let cp_dev_id = cp_dev_id_string.as_str();
     // SAFETY: data_size should be a valid pointer to memory allocated by the caller.
     let cp_device_id_str_size = unsafe { &mut *cp_device_id_str_size };

--- a/third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh
+++ b/third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh
@@ -19,7 +19,7 @@ fi
 
 OT_REPO_TOP=$1
 
-_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC6"
+_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC8"
 _PROVISIONING_REPO_TOP=$(pwd)
 _FPGAS=("hyper310" "cw340")
 _CP_SKUS=("emulation")

--- a/third_party/lowrisc/ot_bitstreams/cp_hyper310.bit
+++ b/third_party/lowrisc/ot_bitstreams/cp_hyper310.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f842f986f293524bfc0d32eb335f96e708c979e5801c828df129f81374fe08f6
+oid sha256:1ef1c870fefa1487f6cf7c3e4741eadc7e53491dafe5de910c5aab50e03ec9f7
 size 15878032

--- a/third_party/lowrisc/ot_bitstreams/cp_hyper340.bit
+++ b/third_party/lowrisc/ot_bitstreams/cp_hyper340.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4121ca0ac7d9811950f5e1944152926119ce513c8c958d1c0db8aba6ea8f26d1
+oid sha256:bc7d2b66a1952c1d0d2011fe7d0a2269ba6661a77a8f5c6f2c87358ee2014d73
 size 35843488

--- a/third_party/lowrisc/ot_fw/build-orch-zip.sh
+++ b/third_party/lowrisc/ot_fw/build-orch-zip.sh
@@ -19,7 +19,7 @@ fi
 
 OT_REPO_TOP=$1
 
-_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC6"
+_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC8"
 _PROVISIONING_REPO_TOP=$(pwd)
 _ORCHESTRATOR_ZIP_PATH="bazel-bin/sw/host/provisioning/orchestrator/src/orchestrator.zip"
 

--- a/third_party/lowrisc/ot_fw/orchestrator.zip
+++ b/third_party/lowrisc/ot_fw/orchestrator.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5cf455942a1806dc6dc1d4f84d8ade88742dc5eab82ce3fd7eaa5a818308d2b4
-size 118757697
+oid sha256:0e457e4c56d08977dc692e9e82196a4d2242cf3f00db7eccdca98912eacbf226
+size 116537308

--- a/third_party/lowrisc/repos.bzl
+++ b/third_party/lowrisc/repos.bzl
@@ -12,7 +12,7 @@ _BAZEL_SKYLIB_VERSION = "1.5.0"
 # When updating the lowrisc_opentitan repo, be sure to rebuild the builtstream
 # files too by following the instructions in
 # `third_party/lowrisc/README.md`.
-_OPENTITAN_VERSION = "Earlgrey-A2-Provisioning-RC6"
+_OPENTITAN_VERSION = "Earlgrey-A2-Provisioning-RC8"
 
 def lowrisc_repos(misc_linters = None, bazel_release = None, bazel_skylib = None, opentitan = None):
     maybe(
@@ -45,7 +45,7 @@ def lowrisc_repos(misc_linters = None, bazel_release = None, bazel_skylib = None
         http_archive_or_local,
         local = opentitan,
         name = "lowrisc_opentitan",
-        sha256 = "9517eb191fa5c2b2666204677fc0d35784f088cce163f319fbc3e3c2cc17defe",
+        sha256 = "bd5b804c39a04911f5408441747a9b1715a7a38c9ab7f18c01b4490771917d15",
         strip_prefix = "opentitan-{}".format(_OPENTITAN_VERSION),
         url = "https://github.com/lowRISC/opentitan/archive/refs/tags/{}.tar.gz".format(_OPENTITAN_VERSION),
     )

--- a/util/integration_test_setup.sh
+++ b/util/integration_test_setup.sh
@@ -82,6 +82,7 @@ BUILD_BIN_DIR="bazel-bin/third_party/lowrisc/ot_fw/orchestrator/runfiles/lowrisc
 cp "${BUILD_BIN_DIR}"/sw/device/silicon_creator/manuf/base/sram_cp_provision*.elf "${DEPLOYMENT_BIN_DIR}"
 cp "${BUILD_BIN_DIR}"/sw/device/silicon_creator/manuf/base/sram_ft_individualize*.elf "${DEPLOYMENT_BIN_DIR}"
 cp "${BUILD_BIN_DIR}"/sw/device/silicon_creator/manuf/base/ft_personalize*.bin "${DEPLOYMENT_BIN_DIR}"
+cp "${BUILD_BIN_DIR}"/sw/device/silicon_creator/manuf/base/binaries/ft_personalize*.bin "${DEPLOYMENT_BIN_DIR}"
 cp "${BUILD_BIN_DIR}"/third_party/openocd/build_openocd/bin/openocd "${DEPLOYMENT_BIN_DIR}"
 chmod +x "${DEPLOYMENT_BIN_DIR}"/openocd
 


### PR DESCRIPTION
This bumps the lowrisc_opentitan version tag and rebuilds the firmware / bitstreams to match.