### PR TITLE
Enable registry in dev CI workflow

### DIFF
--- a/config/dev/containers/provapp.yml.tmpl
+++ b/config/dev/containers/provapp.yml.tmpl
@@ -86,6 +86,11 @@ spec:
     - --ca_root_certs=/var/lib/opentitan/config/dev/certs/out/ca-cert.pem
     - --port=${OTPROV_PORT_PB}
     - --db_path=file::memory:?cache=shared
+    - --registry_config_file=/var/lib/opentitan/config/dev/containers/registry_config.json
+    - --enable_syncer=true
+    - --syncer_frequency=30s
+    - --syncer_records_per_run=10
+    - --syncer_max_retries_per_record=0
     # TODO: Update label to point to specific release version.
     image: localhost/pb_server:latest
     resources: {}
@@ -100,6 +105,20 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/opentitan/config/dev
       name: var-lib-opentitan-spm-config-dev-0
+  # Configuration for the `fakeregistry` container.
+  - name: fakeregistry
+    args:
+    - --port=${OTPROV_PORT_REG}
+    image: localhost/fakeregistry_server:latest
+    resources: {}
+    ports:
+      - containerPort: ${OTPROV_PORT_REG}
+    securityContext:
+      capabilities:
+        drop:
+        - CAP_MKNOD
+        - CAP_NET_RAW
+        - CAP_AUDIT_WRITE
   restartPolicy: Always
   volumes:
   - hostPath:

--- a/config/dev/containers/registry_config.json.tmpl
+++ b/config/dev/containers/registry_config.json.tmpl
@@ -1,0 +1,4 @@
+{
+  "register_device_url": "http://${OTPROV_IP_REG}:${OTPROV_PORT_REG}/registerDevice",
+  "batch_register_device_url": "http://${OTPROV_IP_REG}:${OTPROV_PORT_REG}/batchRegisterDevice"
+}

--- a/config/dev/env/spm.env
+++ b/config/dev/env/spm.env
@@ -9,15 +9,18 @@ export OTPROV_DNS_SPM="${OTPROV_DNS_SPM:-localhost}"
 export OTPROV_DNS_PA="${OTPROV_DNS_PA:-localhost}"
 export OTPROV_DNS_PB="${OTPROV_DNS_PB:-localhost}"
 export OTPROV_DNS_ATE="${OTPROV_DNS_ATE:-localhost}"
+export OTPROV_DNS_REG="${OTPROV_DNS_REG:-localhost}"
 
 export OTPROV_IP_SPM="${OTPROV_IP_SPM:-127.0.0.1}"
 export OTPROV_IP_PA="${OTPROV_IP_PA:-127.0.0.1}"
 export OTPROV_IP_PB="${OTPROV_IP_PB:-127.0.0.1}"
 export OTPROV_IP_ATE="${OTPROV_IP_ATE:-127.0.0.1}"
+export OTPROV_IP_REG="${OTPROV_IP_REG:-127.0.0.1}"
 
 export OTPROV_PORT_SPM="${OTPROV_PORT_SPM:-5000}"
 export OTPROV_PORT_PA="${OTPROV_PORT_PA:-5001}"
 export OTPROV_PORT_PB="${OTPROV_PORT_PB:-5002}"
+export OTPROV_PORT_REG="${OTPROV_PORT_REG:-5003}"
 
 # The following variables are used for test purposes and are synchronized with
 # the ${REPO_TOP}/config/dev/softhsm/init.sh script.

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -21,6 +21,15 @@ filegroup(
     output_group = "tar",
 )
 
+pkg_tar(
+    name = "provisioning_appliance_binaries",
+    srcs = [
+        "//src/pa:pa_server",
+        "//src/spm:spm_server",
+    ],
+    extension = "tar.xz",
+)
+
 container_bundle(
     name = "proxybuffer_containers",
     images = {
@@ -35,17 +44,27 @@ filegroup(
 )
 
 pkg_tar(
-    name = "provisioning_appliance_binaries",
-    srcs = [
-        "//src/pa:pa_server",
-        "//src/spm:spm_server",
-    ],
+    name = "proxybuffer_binaries",
+    srcs = ["//src/proxy_buffer:pb_server"],
     extension = "tar.xz",
 )
 
+container_bundle(
+    name = "fakeregistry_containers",
+    images = {
+        "fakeregistry_server:latest": "//src/testing/fake_registry:fake_registry_server_image",
+    },
+)
+
+filegroup(
+    name = "fakeregistry_containers_tar",
+    srcs = [":fakeregistry_containers"],
+    output_group = "tar",
+)
+
 pkg_tar(
-    name = "proxybuffer_binaries",
-    srcs = ["//src/proxy_buffer:pb_server"],
+    name = "fakeregistry_binaries",
+    srcs = ["//src/testing/fake_registry:fake_registry_server"],
     extension = "tar.xz",
 )
 

--- a/src/testing/fake_registry/BUILD.bazel
+++ b/src/testing/fake_registry/BUILD.bazel
@@ -5,6 +5,8 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
+package(default_visibility = ["//visibility:public"])
+
 go_binary(
     name = "fake_registry_server",
     srcs = ["fake_registry.go"],

--- a/src/testing/fake_registry/fake_registry.go
+++ b/src/testing/fake_registry/fake_registry.go
@@ -102,6 +102,7 @@ func batchRegisterDevice(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	flag.Parse()
 	http.HandleFunc(*registerDeviceURL, registerDevice)
 	http.HandleFunc(*batchRegisterDeviceURL, batchRegisterDevice)
 	log.Printf("Listening on port %d...", *port)

--- a/util/containers/deploy_test_k8_pod.sh
+++ b/util/containers/deploy_test_k8_pod.sh
@@ -8,6 +8,7 @@ set -e
 readonly REPO_TOP=$(git rev-parse --show-toplevel)
 
 # Build release containers.
+bazelisk build --stamp //release:fakeregistry_containers_tar
 bazelisk build --stamp //release:hsmutils
 bazelisk build --stamp //release:provisioning_appliance_containers_tar
 bazelisk build --stamp //release:proxybuffer_containers_tar


### PR DESCRIPTION
This makes use of the fake_registry binary to start a registry in the CI workflow. It configures everything needed for it (the container and the configuration for pb_server to talk to it).

Prod CI workflow integration will come in a later commit.