### PR TITLE
[pa,spm] add RPC to query CA serial numbers

### DIFF
--- a/config/dev/spm/sku_auth.yml
+++ b/config/dev/spm/sku_auth.yml
@@ -6,4 +6,4 @@ skuAuthCfgList:
   "sival":
     # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
     skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
-    methods: ["DeriveTokens", "EndorseCerts", "RegisterDevice",]
+    methods: ["DeriveTokens", "GetCaSerialNumbers", "EndorseCerts", "RegisterDevice",]

--- a/config/dev/spm/sku_sival.yml
+++ b/config/dev/spm/sku_sival.yml
@@ -8,6 +8,9 @@ numSessions: 3
 symmetricKeys:
   - name: sival-kdf-hisec-v0
   - name: sival-kdf-losec-v0
+certs:
+  - name: dice-ica
+    path: sku/sival/ca/sival-dice-key-p256-v0.priv.der
 privateKeys:
     - name: sival-dice-key-p256-v0.priv
     - name: spm-hsm-id-v0.priv

--- a/rules/scripts/hsmtool_runner.template.sh
+++ b/rules/scripts/hsmtool_runner.template.sh
@@ -168,6 +168,8 @@ certgen () {
       -CAkeyform engine \
       -CAkey "pkcs11:pin-value=${HSMTOOL_PIN};object=${endorsing_key};token=${FLAGS_HSMTOOL_TOKEN}"
   fi
+  echo "Converting certificate for ${ca_key} to DER"
+  openssl x509 -in "${OUTDIR_CA}/${ca_key}.pem" -outform DER -out "${OUTDIR_CA}/${ca_key}.der"
   rm "${OUTDIR_CA}/${ca_key}.csr"
 }
 
@@ -223,5 +225,5 @@ done
 if [[ -n "${FLAGS_OUT_TAR}" ]]; then
   echo "Exporting HSM data to ${FLAGS_OUT_TAR}"
   tar -czvf "${FLAGS_OUT_TAR}" "${OUTDIR_HSM}" "${OUTDIR_CA}" "${OUTDIR_PUB}"
-  rm -rf "${OUTDIR_HSM}" "${OUTDIR_CA}" "${OUTDIR_PUB}"
+  rm -rf "${OUTDIR_HSM}" "${OUTDIR_PUB}"
 fi

--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -25,6 +25,8 @@ service ProvisioningApplianceService {
     returns (DeriveTokensResponse) {}
   rpc GetStoredTokens(GetStoredTokensRequest)
     returns (GetStoredTokensResponse) {}
+  rpc GetCaSerialNumbers(GetCaSerialNumbersRequest)
+    returns (GetCaSerialNumbersResponse) {}
   rpc RegisterDevice(RegistrationRequest)
     returns (RegistrationResponse) {}
 }
@@ -181,6 +183,22 @@ message InitSessionResponse {
   // List of authenticate methods. Required.
   repeated string auth_methods = 3;
 }
+
+// Get CA serial numbers request.
+message GetCaSerialNumbersRequest{
+  // SKU identifier. Required.
+  string sku = 1;
+  // CA cert labels (to locate the key within the SPM). Required.
+  repeated string cert_labels = 2;
+}
+
+// Get stored tokens response.
+message GetCaSerialNumbersResponse{
+  // Serial numbers. Size is fixed to 20 bytes (160-bits) per serial number as
+  // this is the size of the CA key IDs used by the OpenTitan project.
+  repeated bytes serial_numbers = 1;
+}
+
 
 // Close SKU session request.
 message CloseSessionRequest {

--- a/src/pa/services/pa.go
+++ b/src/pa/services/pa.go
@@ -136,6 +136,16 @@ func (s *server) GetStoredTokens(ctx context.Context, request *pap.GetStoredToke
 	return r, nil
 }
 
+// GetCaSerialNumbers retrieves the CA serial numbers for a given SKU.
+func (s *server) GetCaSerialNumbers(ctx context.Context, request *pap.GetCaSerialNumbersRequest) (*pap.GetCaSerialNumbersResponse, error) {
+	log.Printf("In PA - Received GetCaSerialNumbers request")
+	r, err := s.spmClient.GetCaSerialNumbers(ctx, request)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "SPM returned error: %v", err)
+	}
+	return r, nil
+}
+
 // RegisterDevice registers a new device record in the registry database.
 //
 // The registry database is accessed through the ProxyBuffer or any downstream

--- a/src/spm/proto/spm.proto
+++ b/src/spm/proto/spm.proto
@@ -28,6 +28,11 @@ service SpmService {
   rpc DeriveTokens(pa.DeriveTokensRequest)
       returns (pa.DeriveTokensResponse) {}
 
+  // GetCaSerialNumbers retrieves the CA certificate(s) serial numbers for a
+  // SKU.
+  rpc GetCaSerialNumbers(pa.GetCaSerialNumbersRequest)
+      returns (pa.GetCaSerialNumbersResponse) {}
+
   // GetStoredTokens retrieves a token preprovisioned on the SPM.
   rpc GetStoredTokens(pa.GetStoredTokensRequest)
       returns (pa.GetStoredTokensResponse) {}


### PR DESCRIPTION
The ICA serial numbers must be injected into the DUT over the console during FT in order for the DUT to generate DICE and SKU-specific certificates. This adds an RPC ot the PA and SPM to return the CA serial numbers as byte arrays.