### PR TITLE
[hsm] Split certificate CSR and signing operations.

### DIFF
--- a/config/dev/spm/sku/sival/BUILD.bazel
+++ b/config/dev/spm/sku/sival/BUILD.bazel
@@ -6,6 +6,7 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load(
     "//rules:hsm.bzl",
     "hsm_certgen",
+    "hsm_certgen_tar",
     "hsm_certificate_authority_intermediate",
     "hsm_certificate_authority_root",
     "hsm_config_tar",
@@ -38,8 +39,6 @@ hsm_certificate_authority_root(
 hsm_certificate_authority_intermediate(
     name = "sival-dice-key-p256-v0",
     curve = HSMTOOL_CONST.ECC_CURVE.PRIME256V1,
-    wrapping_key = ":sival-aes-wrap-v0",
-    wrapping_mechanism = "AesKeyWrap",
 )
 
 hsm_generic_secret(
@@ -71,48 +70,71 @@ hsm_certgen(
 hsm_config_tar(
     name = "offline_init",
     hsmtool_sequence = {
-        ":sival-aes-wrap-v0": "keygen",
-        ":sku-sival-rsa-rma-v0": "keygen",
         ":opentitan-ca-root-v0": "keygen",
-        ":sival-dice-key-p256-v0": "keygen",
+        ":sival-aes-wrap-v0": "keygen",
         ":sival-kdf-hisec-v0": "keygen",
         ":sival-kdf-losec-v0": "keygen",
+        ":sku-sival-rsa-rma-v0": "keygen",
     },
 )
 
 hsm_config_tar(
     name = "offline_export",
-    certgen = [
-        ":ca_root",
-        ":ca_int_dice",
-    ],
     hsmtool_sequence = {
         "//config/dev/spm/sku:spm-rsa-wrap-v0": "import",
         ":sival-aes-wrap-v0": "export",
-        ":sku-sival-rsa-rma-v0": "export",
-        ":sival-dice-key-p256-v0": "export",
         ":sival-kdf-hisec-v0": "export",
         ":sival-kdf-losec-v0": "export",
+        ":sku-sival-rsa-rma-v0": "export",
     },
 )
 
+# Initialize the SPM instance with the shared secrets produced by
+# offline_export.
 hsm_config_tar(
     name = "spm_sku_init",
     hsmtool_sequence = {
         ":sival-aes-wrap-v0": "import",
-        ":sku-sival-rsa-rma-v0": "import",
-        ":sival-dice-key-p256-v0": "import",
         ":sival-kdf-hisec-v0": "import",
         ":sival-kdf-losec-v0": "import",
+        ":sku-sival-rsa-rma-v0": "import",
     },
+)
+
+hsm_config_tar(
+    name = "spm_ca_keygen",
+    hsmtool_sequence = {
+        ":sival-dice-key-p256-v0": "keygen",
+    },
+)
+
+hsm_certgen_tar(
+    name = "ca_root_certgen",
+    certs = [
+        ":ca_root",
+    ],
+)
+
+hsm_certgen_tar(
+    name = "ca_intermediate_certgen",
+    certs = [
+        ":ca_int_dice",
+    ],
 )
 
 pkg_tar(
     name = "release",
     srcs = [
+        ":ca_intermediate_certgen",
+        ":ca_root_certgen",
         ":offline_export",
         ":offline_init",
+        ":spm_ca_keygen",
         ":spm_sku_init",
+    ] + [
+        # Certificate template files.
+        ":ca_int_dice.conf",
+        ":ca_root.conf",
     ],
     extension = "tar.gz",
     include_runfiles = True,

--- a/config/prod/spm/sku/sival/BUILD.bazel
+++ b/config/prod/spm/sku/sival/BUILD.bazel
@@ -6,6 +6,7 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load(
     "//rules:hsm.bzl",
     "hsm_certgen",
+    "hsm_certgen_tar",
     "hsm_certificate_authority_intermediate",
     "hsm_certificate_authority_root",
     "hsm_config_tar",
@@ -38,8 +39,6 @@ hsm_certificate_authority_root(
 hsm_certificate_authority_intermediate(
     name = "sival-dice-key-p256-v0",
     curve = HSMTOOL_CONST.ECC_CURVE.PRIME256V1,
-    wrapping_key = ":sival-aes-wrap-v0",
-    wrapping_mechanism = "VendorThalesAesKwp",
 )
 
 hsm_generic_secret(
@@ -71,48 +70,71 @@ hsm_certgen(
 hsm_config_tar(
     name = "offline_init",
     hsmtool_sequence = {
-        ":sival-aes-wrap-v0": "keygen",
-        ":sku-sival-rsa-rma-v0": "keygen",
         ":opentitan-ca-root-v0": "keygen",
-        ":sival-dice-key-p256-v0": "keygen",
+        ":sival-aes-wrap-v0": "keygen",
         ":sival-kdf-hisec-v0": "keygen",
         ":sival-kdf-losec-v0": "keygen",
+        ":sku-sival-rsa-rma-v0": "keygen",
     },
 )
 
 hsm_config_tar(
     name = "offline_export",
-    certgen = [
-        ":ca_root",
-        ":ca_int_dice",
-    ],
     hsmtool_sequence = {
         "//config/dev/spm/sku:spm-rsa-wrap-v0": "import",
         ":sival-aes-wrap-v0": "export",
-        ":sku-sival-rsa-rma-v0": "export",
-        ":sival-dice-key-p256-v0": "export",
         ":sival-kdf-hisec-v0": "export",
         ":sival-kdf-losec-v0": "export",
+        ":sku-sival-rsa-rma-v0": "export",
     },
 )
 
+# Initialize the SPM instance with the shared secrets produced by
+# offline_export.
 hsm_config_tar(
     name = "spm_sku_init",
     hsmtool_sequence = {
         ":sival-aes-wrap-v0": "import",
-        ":sku-sival-rsa-rma-v0": "import",
-        ":sival-dice-key-p256-v0": "import",
         ":sival-kdf-hisec-v0": "import",
         ":sival-kdf-losec-v0": "import",
+        ":sku-sival-rsa-rma-v0": "import",
     },
+)
+
+hsm_config_tar(
+    name = "spm_ca_keygen",
+    hsmtool_sequence = {
+        ":sival-dice-key-p256-v0": "keygen",
+    },
+)
+
+hsm_certgen_tar(
+    name = "ca_root_certgen",
+    certs = [
+        ":ca_root",
+    ],
+)
+
+hsm_certgen_tar(
+    name = "ca_intermediate_certgen",
+    certs = [
+        ":ca_int_dice",
+    ],
 )
 
 pkg_tar(
     name = "release",
     srcs = [
+        ":ca_intermediate_certgen",
+        ":ca_root_certgen",
         ":offline_export",
         ":offline_init",
+        ":spm_ca_keygen",
         ":spm_sku_init",
+    ] + [
+        # Certificate template files.
+        ":ca_int_dice.conf",
+        ":ca_root.conf",
     ],
     extension = "tar.gz",
     include_runfiles = True,

--- a/docs/KeyPolicies.md
+++ b/docs/KeyPolicies.md
@@ -117,18 +117,15 @@ CKA_VERIFY    | True  | True
 ### Intermediate Certificate Authority
 
 Intermediate Certificate Authority. Used to endorse Device Under Test (DUT)
-generated payloads. This key is deployed in the SPM HSM.
+generated payloads. This key is generated directly in the SPM HSM.
 
 > Note: Use the `hsm_certificate_authority_intermediate` macro to define this
 key.
 
-**Wrapping Configuration**
+**Key Generation**
 
-The following wrapping configuration shall be used for private keys.
-
-* Recommended mechanism: `VendorThalesAesKwp` or other approved `AesKwp`
-  mechanism.
-* Wrapping key: `Symmetric SKU-Specific Wrapping Key`
+The private key is generated directly in the SPM HSM and is not extractable.
+The CSR is generated in the SPM HSM and signed by the Root CA in the Offline HSM.
 
 #### Attributes
 
@@ -140,11 +137,11 @@ provisioning environment.
 
 Attribute       | SPM   | Offline
 ----------------|-------|--------
-CKA_DECRYPT     | False | False
-CKA_EXTRACTABLE | False | True
-CKA_SENSITIVE   | True  | True
-CKA_SIGN        | True  | True
-CKA_TOKEN       | True  | True
+CKA_DECRYPT     | False | N/A
+CKA_EXTRACTABLE | False | N/A
+CKA_SENSITIVE   | True  | N/A
+CKA_SIGN        | True  | N/A
+CKA_TOKEN       | True  | N/A
 
 **Public Key**
 
@@ -153,7 +150,6 @@ Attribute     | SPM   | Offline
 CKA_ENCRYPT   | False | False
 CKA_TOKEN     | True  | True
 CKA_VERIFY    | True  | True
-
 
 ## Generic Secrets
 

--- a/rules/scripts/hsm_ca_sign.sh
+++ b/rules/scripts/hsm_ca_sign.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+# The script must be executed from its local directory.
+usage () {
+  echo "Usage: $0 --input_tar <input.tar.gz> --output_tar <output.tar.gz>"
+  echo "  --hsm_module <pkcs.some>     Path to the PKCS#11 module."
+  echo "  --token <token>              Token name."
+  echo "  --softhsm_config <config>    Path to the SoftHSM config file. Optional."
+  echo "  --hsm_pin <pin>              PIN for the token."
+  echo "  --input_tar <input.tar.gz>   Path to the input tarball."
+  echo "  --output_tar <output.tar.gz> Path to the output tarball."
+  echo "  --csr_only                   Only export CSRs, do not sign them."
+  echo "  --sign_only                  Only sign certificates, skip CSR generation."
+  echo "  --help                       Show this help message."
+  exit 1
+}
+
+readonly OUTDIR_CA="ca"
+
+readonly CERTGEN_TEMPLATES=(@@CERTGEN_TEMPLATES@@)
+readonly CERTGEN_KEYS=(@@CERTGEN_KEYS@@)
+readonly CERTGEN_ENDORSING_KEYS=(@@CERTGEN_ENDORSING_KEYS@@)
+
+FLAGS_HSMTOOL_MODULE=""
+FLAGS_HSMTOOL_TOKEN=""
+FLAGS_SOFTHSM_CONFIG=""
+FLAGS_HSMTOOL_PIN=""
+FLAGS_IN_TAR=""
+FLAGS_OUT_TAR=""
+FLAGS_CSR_ONLY=false
+FLAGS_SIGN_ONLY=false
+
+LONGOPTS="hsm_module:,token:,softhsm_config:,hsm_pin:,input_tar:,output_tar:,csr_only,sign_only,help"
+OPTS=$(getopt -o "" --long "${LONGOPTS}" -n "$0" -- "$@")
+
+if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
+
+eval set -- "$OPTS"
+
+while true; do
+  case "$1" in
+    --hsm_module)
+      FLAGS_HSMTOOL_MODULE="$2"
+      shift 2
+      ;;
+    --token)
+      FLAGS_HSMTOOL_TOKEN="$2"
+      shift 2
+      ;;
+    --softhsm_config)
+      FLAGS_SOFTHSM_CONFIG="$2"
+      shift 2
+      ;;
+    --hsm_pin)
+      FLAGS_HSMTOOL_PIN="$2"
+      shift 2
+      ;;
+    --input_tar)
+      FLAGS_IN_TAR="$2"
+      shift 2
+      ;;
+    --output_tar)
+      FLAGS_OUT_TAR="$2"
+      shift 2
+      ;;
+    --csr_only)
+      FLAGS_CSR_ONLY=true
+      shift
+      ;;
+    --sign_only)
+      FLAGS_SIGN_ONLY=true
+      shift
+      ;;
+    --help)
+      usage
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [[ "$#" -gt 0 ]]; then
+  echo "Unexpected arguments:" "$@" >&2
+  exit 1
+fi
+
+if [[ -z "${FLAGS_HSMTOOL_MODULE}" ]]; then
+  echo "Error: -m HSMTOOL_MODULE is not set."
+  exit 1
+fi
+
+if [[ -z "${FLAGS_HSMTOOL_TOKEN}" ]]; then
+  echo "Error: -t HSMTOOL_TOKEN is not set."
+  exit 1
+fi
+
+if [[ -z "${FLAGS_HSMTOOL_PIN}" ]]; then
+  echo "Error: -p HSMTOOL_PIN is not set."
+  exit 1
+fi
+
+if [[ ${#CERTGEN_TEMPLATES[@]} -ne ${#CERTGEN_ENDORSING_KEYS[@]} ]]; then
+  echo "Error: Number of certgen templates and endorsing keys do not match."
+  exit 1
+fi
+
+if [[ "${FLAGS_CSR_ONLY}" == true ]] && [[ "${FLAGS_SIGN_ONLY}" == true ]]; then
+  echo "Error: --csr_only and --sign_only cannot be used together."
+  exit 1
+fi
+
+if [[ -n "${FLAGS_IN_TAR}" && "${FLAGS_IN_TAR}" != *.tar.gz  ]]; then
+  echo "Error: Input tarball must have .tar.gz extension."
+  exit 1
+fi
+
+if [[ -n "${FLAGS_OUT_TAR}" && "${FLAGS_OUT_TAR}" != *.tar.gz  ]]; then
+  echo "Error: Output tarball must have .tar.gz extension."
+  exit 1
+fi
+
+if [[ -n "${FLAGS_IN_TAR}" ]]; then
+  if [[ ! -f "${FLAGS_IN_TAR}" ]]; then
+    echo "Error: Input tarball does not exist."
+    exit 1
+  fi
+  echo "Extracting input tarball ${FLAGS_IN_TAR}"
+  tar -xzf "${FLAGS_IN_TAR}"
+fi
+
+
+# Create output directory for HSM exported files.
+mkdir -p "${OUTDIR_CA}"
+
+# If the GEM engine is used, we need to initialize a session with the HSM.
+# The following variable is used to track if the session has been initialized.
+# The close_gem_engine_session function will be called on exit to close the session.
+CA_GEM_ENGINE_INIT=false
+close_gem_engine_session () {
+  if [ "${OTPROV_USE_GEM_ENGINE}" == true ] && [ "${CA_GEM_ENGINE_INIT}" == true ]; then
+    echo "Closing Gem engine session."
+    sautil -s "${OTPROV_GEM_SLOT_CERT_OPS}" -i 10:11 -c
+    CA_GEM_ENGINE_INIT=false
+  fi
+}
+trap close_gem_engine_session EXIT
+
+if [ "${OTPROV_USE_GEM_ENGINE}" == true ]; then
+  if ! command -v "sautil" &> /dev/null; then
+    echo "Error: Required command 'sautil' is not installed or not in your PATH." >&2
+    exit 1
+  fi
+
+  if [[ -z "${OTPROV_GEM_SLOT_CERT_OPS}" ]]; then
+    echo "Error: -p OTPROV_GEM_SLOT_CERT_OPS is not set."
+    exit 1
+  fi
+
+  # Initialize a session with the HSM using the sautil command. Provided by
+  # the Gem engine.
+  # The user is expected to set this environment variable to set the correct
+  # HSM slot for certificate operations.
+  sautil -s "${OTPROV_GEM_SLOT_CERT_OPS}" -i 10:11 -o -p "${FLAGS_HSMTOOL_PIN}"
+  CA_GEM_ENGINE_INIT=true
+fi
+
+
+# certgen generates a certificate for the given config file and signs it with
+# the given CA key.
+certgen () {
+  config_basename="${1%.conf}"
+  ca_key="${2}"
+  endorsing_key="${3}"
+
+  certvars=()
+  if [[ -n "${FLAGS_SOFTHSM_CONFIG}" ]]; then
+    certvars+=(SOFTHSM2_CONF="${FLAGS_SOFTHSM_CONFIG}")
+  fi
+  certvars+=(
+    PKCS11_MODULE_PATH="${FLAGS_HSMTOOL_MODULE}"
+  )
+
+  ENGINE="pkcs11"
+  if [ "${OTPROV_USE_GEM_ENGINE}" == true ]; then
+    ENGINE="gem"
+  fi
+
+  KEY="pkcs11:pin-value=${FLAGS_HSMTOOL_PIN};object=${ca_key};token=${FLAGS_HSMTOOL_TOKEN}"
+  if [ "${OTPROV_USE_GEM_ENGINE}" == true ]; then
+    KEY="${ca_key}"
+  fi
+
+  CONFIG_FILE="${config_basename}.conf"
+  CSR_FILE="${OUTDIR_CA}/${ca_key}.csr"
+  CERT_FILE="${OUTDIR_CA}/${ca_key}.pem"
+
+
+  
+  if [[ "${FLAGS_SIGN_ONLY}" == false ]]; then
+    # Generate a CSR for the CA key. This can be either a root CA or an
+    # intermediate CA.
+    echo "Generating CSR for ${ca_key}"
+    env "${certvars[@]}" \
+    openssl req -new -engine "${ENGINE}" -keyform engine \
+        -config "${CONFIG_FILE}" \
+        -out "${CSR_FILE}" \
+        -key "${KEY}"
+  else
+    # Running in sign only mode means that the CSR is already present in the
+    # input tarball and/or ca directory. Only need to check if the CSR file
+    # exists. 
+    if [[ ! -f "${CSR_FILE}" ]]; then
+      echo "Error: CSR file ${CSR_FILE} does not exist."
+      exit 1
+    fi
+  fi
+
+  # Skip certificate signing if we are only generating CSRs.
+  if [[ "${FLAGS_CSR_ONLY}" == true ]]; then
+    return
+  fi
+
+  ENDORSING_KEY="pkcs11:pin-value=${HSMTOOL_PIN};object=${endorsing_key};token=${FLAGS_HSMTOOL_TOKEN}"
+  if [ "${OTPROV_USE_GEM_ENGINE}" == true ]; then
+    ENDORSING_KEY="${endorsing_key}"
+  fi
+
+  if [[ "${ca_key}" == "${endorsing_key}" ]]; then
+    echo "Generating root CA certificate for ${ca_key}"
+    env "${certvars[@]}" \
+    openssl x509 -req -engine "${ENGINE}" -keyform engine \
+      -in "${CSR_FILE}" \
+      -out "${CERT_FILE}" \
+      -days 7300 \
+      -extfile "${CONFIG_FILE}" \
+      -extensions v3_ca \
+      -signkey "${ENDORSING_KEY}"
+  else
+    echo "Generating certificate for ${ca_key} signed by ${endorsing_key}"
+
+    CA_ENDORSING_CERT_FILE="${OUTDIR_CA}/${endorsing_key}.pem"
+    if [[ ! -f "${CA_ENDORSING_CERT_FILE}" ]]; then
+      echo "Error: CA endorsing certificate file ${CA_ENDORSING_CERT_FILE} does not exist."
+      exit 1
+    fi
+
+    env "${certvars[@]}" \
+    openssl x509 -req -engine "${ENGINE}" -keyform engine \
+      -in "${CSR_FILE}" \
+      -out "${CERT_FILE}" \
+      -days 7300 \
+      -extfile "${CONFIG_FILE}" \
+      -extensions v3_ca \
+      -CA "${CA_ENDORSING_CERT_FILE}" \
+      -CAkeyform engine \
+      -CAkey "${ENDORSING_KEY}"
+  fi
+}
+
+for i in "${!CERTGEN_TEMPLATES[@]}"; do
+  template="${CERTGEN_TEMPLATES[$i]}"
+  key="${CERTGEN_KEYS[$i]}"
+  endorsing_key="${CERTGEN_ENDORSING_KEYS[$i]}"
+
+  echo "Generating certificate for ${template}"
+  certgen "${template}" "${key}" "${endorsing_key}"
+done
+
+if [[ -n "${FLAGS_OUT_TAR}" ]]; then
+  echo "Exporting HSM data to ${FLAGS_OUT_TAR}"
+  tar -czvf "${FLAGS_OUT_TAR}" "${OUTDIR_CA}"
+fi
+

--- a/rules/scripts/hsm_ca_sign.sh
+++ b/rules/scripts/hsm_ca_sign.sh
@@ -206,7 +206,7 @@ certgen () {
   CERT_FILE="${OUTDIR_CA}/${ca_key}.pem"
 
 
-  
+
   if [[ "${FLAGS_SIGN_ONLY}" == false ]]; then
     # Generate a CSR for the CA key. This can be either a root CA or an
     # intermediate CA.
@@ -219,7 +219,7 @@ certgen () {
   else
     # Running in sign only mode means that the CSR is already present in the
     # input tarball and/or ca directory. Only need to check if the CSR file
-    # exists. 
+    # exists.
     if [[ ! -f "${CSR_FILE}" ]]; then
       echo "Error: CSR file ${CSR_FILE} does not exist."
       exit 1
@@ -266,6 +266,9 @@ certgen () {
       -CAkeyform engine \
       -CAkey "${ENDORSING_KEY}"
   fi
+
+  echo "Converting certificate for ${ca_key} to DER"
+  openssl x509 -in "${CERT_FILE}" -outform DER -out "${OUTDIR_CA}/${ca_key}.der"
 }
 
 for i in "${!CERTGEN_TEMPLATES[@]}"; do

--- a/rules/scripts/hsmtool_runner.template.sh
+++ b/rules/scripts/hsmtool_runner.template.sh
@@ -14,22 +14,18 @@ usage () {
   echo "  -p <pin>           PIN for the token."
   echo "  -i <input.tar.gz>  Path to the input tarball."
   echo "  -w                 Execute destroy commands before initializing the assets."
-  echo "  -o <output.tar.gz> Path to the output tarball."
+  echo "  -o <output.tar.gz> Path to the output tarball. Optional."
   echo "  -c                 Only run certificate generation, do not run hsmtool init or destroy."
   echo "  -h                 Show this help message."
   exit 1
 }
 
 readonly OUTDIR_HSM="hsm"
-readonly OUTDIR_CA="ca"
 readonly OUTDIR_PUB="pub"
 
 readonly INIT_HJSON=@@INIT_HJSON@@
 readonly DESTROY_HJSON=@@DESTROY_HJSON@@
 readonly HSMTOOL_BIN_DEFAULT=@@HSMTOOL_BIN@@
-readonly CERTGEN_TEMPLATES=(@@CERTGEN_TEMPLATES@@)
-readonly CERTGEN_KEYS=(@@CERTGEN_KEYS@@)
-readonly CERTGEN_ENDORSING_KEYS=(@@CERTGEN_ENDORSING_KEYS@@)
 
 HSMTOOL_BIN="${HSMTOOL_BIN:-./${HSMTOOL_BIN_DEFAULT}}"
 
@@ -64,9 +60,6 @@ while getopts 'm:t:s:p:i:o:wch' opt; do
       ;;
     w)
       FLAGS_WIPE=true
-      ;;
-    c)
-      FLAGS_CA_CERTGEN_ONLY=true
       ;;
     h)
       # Display usage information and exit.
@@ -114,16 +107,6 @@ if [[ -n "${FLAGS_OUT_TAR}" && "${FLAGS_OUT_TAR}" != *.tar.gz  ]]; then
   exit 1
 fi
 
-if [[ ${#CERTGEN_TEMPLATES[@]} -ne ${#CERTGEN_KEYS[@]} ]]; then
-  echo "Error: Number of certgen templates and keys do not match."
-  exit 1
-fi
-
-if [[ ${#CERTGEN_TEMPLATES[@]} -ne ${#CERTGEN_ENDORSING_KEYS[@]} ]]; then
-  echo "Error: Number of certgen templates and endorsing keys do not match."
-  exit 1
-fi
-
 if [[ -n "${FLAGS_IN_TAR}" ]]; then
   if [[ ! -f "${FLAGS_IN_TAR}" ]]; then
     echo "Error: Input tarball does not exist."
@@ -133,159 +116,49 @@ if [[ -n "${FLAGS_IN_TAR}" ]]; then
   tar -xzf "${FLAGS_IN_TAR}"
 fi
 
-# If the GEM engine is used, we need to initialize a session with the HSM.
-# The following variable is used to track if the session has been initialized.
-# The close_gem_engine_session function will be called on exit to close the session.
-CA_GEM_ENGINE_INIT=false
-close_gem_engine_session () {
-  if [ "${OTPROV_USE_GEM_ENGINE}" == true ] && [ "${CA_GEM_ENGINE_INIT}" == true ]; then
-    echo "Closing Gem engine session."
-    sautil -s "${OTPROV_GEM_SLOT_CERT_OPS}" -i 10:11 -c
-    CA_GEM_ENGINE_INIT=false
-  fi
-}
-trap close_gem_engine_session EXIT
-
-if [ "${OTPROV_USE_GEM_ENGINE}" == true ]; then
-  if ! command -v "sautil" &> /dev/null; then
-    echo "Error: Required command 'sautil' is not installed or not in your PATH." >&2
-    exit 1
-  fi
-
-  if [[ -z "${OTPROV_GEM_SLOT_CERT_OPS}" ]]; then
-    echo "Error: -p OTPROV_GEM_SLOT_CERT_OPS is not set."
-    exit 1
-  fi
-
-  # Initialize a session with the HSM using the sautil command. Provided by
-  # the Gem engine.
-  # The user is expected to set this environment variable to set the correct
-  # HSM slot for certificate operations.
-  sautil -s "${OTPROV_GEM_SLOT_CERT_OPS}" -i 10:11 -o -p "${FLAGS_HSMTOOL_PIN}"
-  CA_GEM_ENGINE_INIT=true
-fi
-
-
-# certgen generates a certificate for the given config file and signs it with
-# the given CA key.
-certgen () {
-  config_basename="${1%.conf}"
-  ca_key="${2}"
-  endorsing_key="${3}"
-
-  certvars=()
-  if [[ -n "${FLAGS_SOFTHSM_CONFIG}" ]]; then
-    certvars+=(SOFTHSM2_CONF="${FLAGS_SOFTHSM_CONFIG}")
-  fi
-  certvars+=(
-    PKCS11_MODULE_PATH="${FLAGS_HSMTOOL_MODULE}"
-  )
-
-  ENGINE="pkcs11"
-  if [ "${OTPROV_USE_GEM_ENGINE}" == true ]; then
-    ENGINE="gem"
-  fi
-
-  KEY="pkcs11:pin-value=${FLAGS_HSMTOOL_PIN};object=${ca_key};token=${FLAGS_HSMTOOL_TOKEN}"
-  if [ ${OTPROV_USE_GEM_ENGINE} == true ]; then
-    KEY="${ca_key}"
-  fi
-
-  # Generate a CSR for the CA key. This can be either a root CA or an
-  # intermediate CA.
-  echo "Generating CSR for ${ca_key}"
-  env "${certvars[@]}" \
-  openssl req -new -engine "${ENGINE}" -keyform engine \
-    -config "${config_basename}.conf" \
-    -out "${OUTDIR_CA}/${ca_key}.csr" \
-    -key "${KEY}"
-
-  ENDORSING_KEY="pkcs11:pin-value=${HSMTOOL_PIN};object=${endorsing_key};token=${FLAGS_HSMTOOL_TOKEN}"
-  if [ ${OTPROV_USE_GEM_ENGINE} == true ]; then
-    ENDORSING_KEY="${endorsing_key}"
-  fi
-
-  if [[ "${ca_key}" == "${endorsing_key}" ]]; then
-    echo "Generating root CA certificate for ${ca_key}"
-    env "${certvars[@]}" \
-    openssl x509 -req -engine "${ENGINE}" -keyform engine \
-      -in "${OUTDIR_CA}/${ca_key}.csr" \
-      -out "${OUTDIR_CA}/${ca_key}.pem" \
-      -days 3650 \
-      -extfile "${config_basename}.conf" \
-      -extensions v3_ca \
-      -signkey "${ENDORSING_KEY}"
-  else
-    echo "Generating certificate for ${ca_key} signed by ${endorsing_key}"
-    env "${certvars[@]}" \
-    openssl x509 -req -engine "${ENGINE}" -keyform engine \
-      -in "${OUTDIR_CA}/${ca_key}.csr" \
-      -out "${OUTDIR_CA}/${ca_key}.pem" \
-      -days 3650 \
-      -extfile "${config_basename}.conf" \
-      -extensions v3_ca \
-      -CA "${OUTDIR_CA}/${endorsing_key}.pem" \
-      -CAkeyform engine \
-      -CAkey "${ENDORSING_KEY}"
-  fi
-  echo "Converting certificate for ${ca_key} to DER"
-  openssl x509 -in "${OUTDIR_CA}/${ca_key}.pem" -outform DER -out "${OUTDIR_CA}/${ca_key}.der"
-}
 
 # Create output directory for HSM exported files.
-mkdir -p "${OUTDIR_HSM}" "${OUTDIR_CA}" "${OUTDIR_PUB}"
+mkdir -p "${OUTDIR_HSM}" "${OUTDIR_PUB}"
 
 echo "softhsm-config: ${FLAGS_SOFTHSM_CONFIG}"
 echo "hsmtool-module: ${FLAGS_HSMTOOL_MODULE}"
 echo "hsmtool-token: ${FLAGS_HSMTOOL_TOKEN}"
 echo "hsmtool-bin: ${HSMTOOL_BIN}"
 
-if [[ "${FLAGS_CA_CERTGEN_ONLY}" == false ]]; then
-  hsmtool_vars=()
-  if [[ -n "${FLAGS_SOFTHSM_CONFIG}" ]]; then
-    hsmtool_vars+=(SOFTHSM2_CONF="${FLAGS_SOFTHSM_CONFIG}")
+hsmtool_vars=()
+if [[ -n "${FLAGS_SOFTHSM_CONFIG}" ]]; then
+  hsmtool_vars+=(SOFTHSM2_CONF="${FLAGS_SOFTHSM_CONFIG}")
+fi
+hsmtool_vars+=(
+  HSMTOOL_MODULE="${FLAGS_HSMTOOL_MODULE}"
+  HSMTOOL_USER="user"
+  HSMTOOL_TOKEN="${FLAGS_HSMTOOL_TOKEN}"
+  HSMTOOL_PIN="${FLAGS_HSMTOOL_PIN}"
+)
+
+hsmtool_args=(
+  "${HSMTOOL_BIN}"
+  --logging=info
+)
+
+if [[ "${FLAGS_WIPE}" == true ]]; then
+  echo "Running hsmtool destroy (--wipe) operation."
+
+  read -p "Are you sure you want to run the ${DESTROY_HJSON} script? (y/n) " -n 1 -r
+  echo
+  if [[ ! ${REPLY} =~ ^[Yy]$ ]]; then
+    echo "Aborting destroy operation."
+    exit 1
   fi
-  hsmtool_vars+=(
-    HSMTOOL_MODULE="${FLAGS_HSMTOOL_MODULE}"
-    HSMTOOL_USER="user"
-    HSMTOOL_TOKEN="${FLAGS_HSMTOOL_TOKEN}"
-    HSMTOOL_PIN="${FLAGS_HSMTOOL_PIN}"
-  )
 
-  hsmtool_args=(
-    "${HSMTOOL_BIN}"
-    --logging=info
-  )
-
-  if [[ "${FLAGS_WIPE}" == true ]]; then
-    echo "Running hsmtool destroy (--wipe) operation."
-
-    read -p "Are you sure you want to run the ${DESTROY_HJSON} script? (y/n) " -n 1 -r
-    echo
-    if [[ ! ${REPLY} =~ ^[Yy]$ ]]; then
-      echo "Aborting destroy operation."
-      exit 1
-    fi
-
-    env "${hsmtool_vars[@]}" "${hsmtool_args[@]}" exec "${DESTROY_HJSON}"
-  fi
-  echo "Running hsmtool"
-  env "${hsmtool_vars[@]}" "${hsmtool_args[@]}" exec "${INIT_HJSON}"
-else
-  echo "Skipping hsmtool commands."
+  env "${hsmtool_vars[@]}" "${hsmtool_args[@]}" exec "${DESTROY_HJSON}"
 fi
 
-for i in "${!CERTGEN_TEMPLATES[@]}"; do
-  template="${CERTGEN_TEMPLATES[$i]}"
-  key="${CERTGEN_KEYS[$i]}"
-  endorsing_key="${CERTGEN_ENDORSING_KEYS[$i]}"
-
-  echo "Generating certificate for ${template}"
-  certgen "${template}" "${key}" "${endorsing_key}"
-done
+echo "Running hsmtool"
+env "${hsmtool_vars[@]}" "${hsmtool_args[@]}" exec "${INIT_HJSON}"
 
 if [[ -n "${FLAGS_OUT_TAR}" ]]; then
   echo "Exporting HSM data to ${FLAGS_OUT_TAR}"
-  tar -czvf "${FLAGS_OUT_TAR}" "${OUTDIR_HSM}" "${OUTDIR_CA}" "${OUTDIR_PUB}"
+  tar -czvf "${FLAGS_OUT_TAR}" "${OUTDIR_HSM}" "${OUTDIR_PUB}"
   rm -rf "${OUTDIR_HSM}"
 fi

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -23,6 +23,12 @@ echo "Done."
 
 # Run the CP and FT flows (default to hyper340 since that is installed in CI).
 FPGA="${FPGA:-hyper340}"
+
+if [[ "${FPGA}" == "skip" ]]; then
+  echo "Skipping FPGA tests."
+  exit 0
+fi
+
 if [[ "$FPGA" == "hyper340" ]]; then
   BIN_DEVICE="cw340"
 else


### PR DESCRIPTION
This commit refactors the HSM rules as follows:

* `offline_init`: Generates RMA high and low security seeds as well as
  CA root keys.
* `offline_export`: Exports RMA public wrapping (i.e. Public) key.
* `spm_sku_init`: Imports RMA publick key, as well as high and low security
  seeds. Only required when sharing seeds across SPM environments.
* `spm_ca_keygen`: Generates Intermediate CA (ICA) certificates for a
  particular SKU.

The `hsm_certgen_tar` rule implements CSR export and certificate signing
functionality. See `token_init.sh` for examples. The following targets
where added to support certgen operations:

* `ca_root_certgen`: Generates root CA certificate. Expected to target
  an offline HSM.
* `ca_intermediate_certgen`: Generates ICA certificate.
  * SPM: Run in CSR export mode.
  * Offline: Run in SignOnly mode.