### PR TITLE
[spm] Verify certificate chain before returning each cert in `EndorseCerts` API

### DIFF
--- a/config/spm/sku/sival/ca_int_dice.conf
+++ b/config/spm/sku/sival/ca_int_dice.conf
@@ -9,7 +9,7 @@ C=US
 ST=CA
 O=Google
 OU=Engineering
-CN=Google Engineering OpenTitan ICA
+CN=Google Engineering ICA
 
 [v3_ca]
 subjectKeyIdentifier = hash

--- a/config/spm/sku_cr01.yml.tmpl
+++ b/config/spm/sku_cr01.yml.tmpl
@@ -9,9 +9,11 @@ symmetricKeys:
   - name: eg-kdf-hisec-v0
   - name: eg-kdf-losec-v0
 certs:
-  - name: dice-ica
+  - name: RootCA
+    path: sku/eg/common/ca/opentitan-ca-root-v0.priv.der
+  - name: SigningKey/Dice/v0
     path: sku/eg/cr/ca/cr01-ica-dice-key-p256-v0.priv.der
-  - name: ext-ica
+  - name: SigningKey/Ext/v0
     path: sku/eg/cr/ca/cr01-ica-ext-key-p256-v0.priv.der
 privateKeys:
     - name: cr01-ica-dice-key-p256-v0.priv

--- a/config/spm/sku_pi01.yml.tmpl
+++ b/config/spm/sku_pi01.yml.tmpl
@@ -9,9 +9,11 @@ symmetricKeys:
   - name: eg-kdf-hisec-v0
   - name: eg-kdf-losec-v0
 certs:
-  - name: dice-ica
+  - name: RootCA
+    path: sku/eg/common/ca/opentitan-ca-root-v0.priv.der
+  - name: SigningKey/Dice/v0
     path: sku/eg/pi/ca/pi01-ica-dice-key-p256-v0.priv.der
-  - name: ext-ica
+  - name: SigningKey/Ext/v0
     path: sku/eg/pi/ca/pi01-ica-ext-key-p256-v0.priv.der
 privateKeys:
     - name: pi01-ica-dice-key-p256-v0.priv

--- a/config/spm/sku_sival.yml.tmpl
+++ b/config/spm/sku_sival.yml.tmpl
@@ -9,7 +9,9 @@ symmetricKeys:
   - name: eg-kdf-hisec-v0
   - name: eg-kdf-losec-v0
 certs:
-  - name: dice-ica
+  - name: RootCA
+    path: sku/eg/common/ca/opentitan-ca-root-v0.priv.der
+  - name: SigningKey/Dice/v0
     path: sku/sival/ca/sival-dice-key-p256-v0.priv.der
 privateKeys:
     - name: sival-dice-key-p256-v0.priv

--- a/config/spm/sku_ti01.yml.tmpl
+++ b/config/spm/sku_ti01.yml.tmpl
@@ -9,7 +9,9 @@ symmetricKeys:
   - name: eg-kdf-hisec-v0
   - name: eg-kdf-losec-v0
 certs:
-  - name: dice-ica
+  - name: RootCA
+    path: sku/eg/common/ca/opentitan-ca-root-v0.priv.der
+  - name: SigningKey/Dice/v0
     path: sku/eg/ti/ca/ti01-ica-dice-key-p256-v0.priv.der
 privateKeys:
     - name: ti01-ica-dice-key-p256-v0.priv

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -25,6 +25,8 @@ bazelisk run //src/pa:loadtest -- \
    --sku_auth="test_password" \
    --parallel_clients=2 \
    --total_calls_per_method=4 \
+   --spm_config_dir="${DEPLOYMENT_DIR}/spm" \
+   --hsm_so="${HSMTOOL_MODULE}" \
    --sku_names="${SKU_NAMES}"
 echo "Done."
 

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -238,7 +238,7 @@ int main(int argc, char **argv) {
 
   // Generate CA serial numbers.
   constexpr size_t kNumIcas = 1;
-  const char *kIcaCertLabels[] = {"dice-ica"};
+  const char *kIcaCertLabels[] = {"SigningKey/Dice/v0"};
   ca_serial_number_t serial_numbers[kNumIcas];
   if (GetCaSerialNumbers(ate_client, absl::GetFlag(FLAGS_sku).c_str(),
                          /*count=*/kNumIcas, kIcaCertLabels,

--- a/src/pa/BUILD.bazel
+++ b/src/pa/BUILD.bazel
@@ -52,6 +52,8 @@ go_binary(
         "//src/proto/crypto:common_go_pb",
         "//src/proto/crypto:ecdsa_go_pb",
         "//src/spm/proto:spm_go_pb",
+        "//src/spm/services/skumgr",
+        "//src/spm/services/testutils:tbsgen",
         "//src/transport:grpconn",
         "//src/utils:devid",
         "@io_bazel_rules_go//go/tools/bazel",

--- a/src/spm/services/se.go
+++ b/src/spm/services/se.go
@@ -36,6 +36,11 @@ type EndorseCertParams struct {
 	KeyLabel string
 	// Signature algorithm to use.
 	SignatureAlgorithm x509.SignatureAlgorithm
+	// Certificate chain to use for endorsement.
+	// This is typically the CA certificate chain that will be used to verify
+	// the signed certificate.
+	Intermediates []*x509.Certificate
+	Roots         []*x509.Certificate
 }
 
 // TokenOp specifies the operation to perform on the token.

--- a/src/spm/services/skumgr/skumgr.go
+++ b/src/spm/services/skumgr/skumgr.go
@@ -95,9 +95,14 @@ func (m *Manager) LoadSku(skuName string) (*Sku, error) {
 	if hsmPassword == "" {
 		val, ok := os.LookupEnv("SPM_HSM_PIN_USER")
 		if !ok {
-			return nil, fmt.Errorf("LoadSku failed: set hsm_password_file or SPM_HSM_PIN_USER environment variable.")
+			val, ok := os.LookupEnv("HSMTOOL_PIN")
+			if !ok {
+				return nil, fmt.Errorf("LoadSku failed: set hsm_password_file or SPM_HSM_PIN_USER or HSMTOOL_PIN environment variable.")
+			}
+			hsmPassword = val
+		} else {
+			hsmPassword = val
 		}
-		hsmPassword = val
 	}
 
 	log.Printf("Initializing symmetric keys: %v", cfg.SymmetricKeys)

--- a/src/spm/services/testutils/BUILD.bazel
+++ b/src/spm/services/testutils/BUILD.bazel
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "tbsgen",
+    testonly = True,
+    srcs = ["tbsgen.go"],
+    importpath = "github.com/lowRISC/opentitan-provisioning/src/spm/services/testutils/tbsgen",
+    deps = [
+        "//src/pk11",
+        "//src/spm/services:se",
+        "//src/spm/services/skumgr",
+        "//src/utils",
+    ],
+)

--- a/src/spm/services/testutils/tbsgen.go
+++ b/src/spm/services/testutils/tbsgen.go
@@ -1,0 +1,137 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package tbsgen
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/lowRISC/opentitan-provisioning/src/pk11"
+	"github.com/lowRISC/opentitan-provisioning/src/spm/services/se"
+	"github.com/lowRISC/opentitan-provisioning/src/spm/services/skumgr"
+)
+
+// computeSKI calculates the Subject Key Identifier for a public key.
+func computeSKI(pubKey crypto.PublicKey) ([]byte, error) {
+	spki, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		return nil, err
+	}
+	hash := sha1.Sum(spki)
+	return hash[:], nil
+}
+
+// buildTestTbsCert creates a To-Be-Signed (TBS) certificate for testing purposes.
+// It takes an intermediate CA certificate. It generates a new key pair for the
+// subject, creates a certificate, and returns the TBS part of it.
+// The public key of the new certificate is also returned.
+func buildTestTbsCert(session *pk11.Session, label string, intermediateCACert *x509.Certificate) ([]byte, crypto.PublicKey, error) {
+	// Get the private key object.
+	keyID, err := se.GetKeyIDByLabel(session, pk11.ClassPrivateKey, label)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get key ID by label %q: %v", label, err)
+	}
+
+	key, err := session.FindPrivateKey(keyID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to find key object %q: %v", keyID, err)
+	}
+
+	privKey, err := key.Signer()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get signer: %v", err)
+	}
+
+	// Generate a new public key outside the HSM.
+	dutKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate public key: %v", err)
+	}
+	pubKey := dutKey.PublicKey
+
+	ski, err := computeSKI(&pubKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Test Certificate"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+		Issuer:                intermediateCACert.Subject,
+		AuthorityKeyId:        intermediateCACert.SubjectKeyId,
+		SubjectKeyId:          ski,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, intermediateCACert, &pubKey, privKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert.RawTBSCertificate, &pubKey, nil
+}
+
+// BuildTestTBSCerts generates a set of TBS certificates for a given SKU.
+// It returns a map of TBS certificates and a map of the corresponding public keys.
+func BuildTestTBSCerts(opts skumgr.Options, skuName string, certLabels []string) (map[string][]byte, map[string]crypto.PublicKey, error) {
+	mgr := skumgr.NewManager(opts)
+	sku, err := mgr.LoadSku(skuName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load SKU %q: %w", skuName, err)
+	}
+
+	tbsCerts := make(map[string][]byte)
+	pubKeys := make(map[string]crypto.PublicKey)
+	for _, label := range certLabels {
+		issuerCert, ok := sku.Certs[label]
+		if !ok {
+			return nil, nil, fmt.Errorf("issuer certificate %q not found for SKU %q", label, skuName)
+		}
+		privKeyLabel, err := sku.Config.GetUnsafeAttribute(label)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get private key label for %q: %v", label, err)
+		}
+		hsm := sku.SeHandle.(*se.HSM)
+		if err := hsm.ExecuteCmd(func(session *pk11.Session) error {
+			tbs, pub, err := buildTestTbsCert(session, privKeyLabel, issuerCert)
+			if err != nil {
+				return err
+			}
+			tbsCerts[label] = tbs
+			pubKeys[label] = pub
+			return nil
+		}); err != nil {
+			return nil, nil, fmt.Errorf("failed to generate TBS certificate: %w", err)
+		}
+	}
+
+	return tbsCerts, pubKeys, nil
+}

--- a/src/transport/grpconn.go
+++ b/src/transport/grpconn.go
@@ -114,12 +114,9 @@ func CheckEndpointInterceptor(ctx context.Context, req interface{}, info *grpc.U
 		ips, err := net.LookupAddr(clientIP)
 		if err != nil {
 			skipDNS = true
-			fmt.Println("err = ", err)
 		}
-		fmt.Println("clientIP = ", clientIP)
 		if !skipDNS {
 			clientDNS := ips[0]
-			fmt.Println("clientDns = ", clientDNS)
 			dnsParts := strings.Split(clientDNS, ".")
 			hostname = dnsParts[0]
 			hostname = strings.ToLower(hostname)

--- a/util/containers/deploy_test_k8_pod.sh
+++ b/util/containers/deploy_test_k8_pod.sh
@@ -24,6 +24,11 @@ if [[ ! -n "${RELEASE_DIR}" ]]; then
    RELEASE_DIR=${REPO_TOP}/bazel-bin/release
 fi
 
+# Remove the deployment directory if it exists.
+if [ -d "${OPENTITAN_VAR_DIR}" ]; then
+    rm -rf ${OPENTITAN_VAR_DIR}
+fi
+
 mkdir -p ${OPENTITAN_VAR_DIR}/release
 mv ${RELEASE_DIR}/release_bundle.tar.xz ${OPENTITAN_VAR_DIR}
 mv ${RELEASE_DIR}/fakeregistry_containers.tar ${OPENTITAN_VAR_DIR}/release


### PR DESCRIPTION
The following changes are included in this pull request:

- Implement `tbsgen` package to generate Device Under Test (DUT) To-Be-Signed (TBS) certificates. The TBS results in correct certificate chain verification after signed by the SPM. 
- Implement certificate verification inside `EndorseCerts`. The certs are not returned to the caller unless valid.
- Update test cases to cover new functionality.