### PR TITLE
[spm] Export ICA SubjectKeyId

### DIFF
--- a/config/spm/sku_auth.yml.tmpl
+++ b/config/spm/sku_auth.yml.tmpl
@@ -6,16 +6,16 @@ skuAuthCfgList:
   "sival":
     # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
     skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
-    methods: ["DeriveTokens", "GetCaSerialNumbers", "EndorseCerts", "RegisterDevice"]
+    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "RegisterDevice"]
   "cr01":
     # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
     skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
-    methods: ["DeriveTokens", "GetCaSerialNumbers", "EndorseCerts", "RegisterDevice"]
+    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "RegisterDevice"]
   "pi01":
     # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
     skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
-    methods: ["DeriveTokens", "GetCaSerialNumbers", "EndorseCerts", "RegisterDevice"]
+    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "RegisterDevice"]
   "ti01":
     # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
     skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
-    methods: ["DeriveTokens", "GetCaSerialNumbers", "EndorseCerts", "RegisterDevice"]
+    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "RegisterDevice"]

--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -36,8 +36,8 @@ enum {
    */
   kWrappedSeedMaxSize = 384,
 
-  /** CA serial number size in bytes. This is equivalent to 160 bits. */
-  kCaSerialNumberSize = 20,
+  /** CA subject key size in bytes. This is equivalent to 160 bits. */
+  kCaSubjectKeySize = 20,
 
   /** Maximum size of SPI frame supported by the DUT. */
   kDutSpiFrameHeaderSize = 4,
@@ -359,11 +359,11 @@ typedef struct wrapped_seed {
 } wrapped_seed_t;
 
 /**
- * CA serial number.
+ * CA subject key.
  */
-typedef struct ca_serial_number {
-  uint8_t data[kCaSerialNumberSize];
-} ca_serial_number_t;
+typedef struct ca_subject_key {
+  uint8_t data[kCaSubjectKeySize];
+} ca_subject_key_t;
 
 /**
  * DeviceLifeCycle encodes the state of the device as it is being manufactured
@@ -456,21 +456,21 @@ DLLEXPORT int GenerateTokens(ate_client_ptr client, const char* sku,
                              token_t* tokens, wrapped_seed_t* seeds);
 
 /**
- * Gets the CA serial numbers.
+ * Gets the CA subject keys.
  *
- * This function retrieves the CA serial numbers from the PA/SPM. The caller
- * should allocate enough memory to store the serial numbers.
+ * This function retrieves the CA subject keys from the PA/SPM. The caller
+ * should allocate enough memory to store the subject keys.
  *
  * @param client A client instance.
  * @param sku The SKU of the product to generate the keys for.
- * @param count The number of serial numbers to retrieve.
+ * @param count The number of subject keys to retrieve.
  * @param labels The lable strings of the certs to retrieve. Size `count`.
- * @param[out] serial_numbers The generated serial_numbers. Size `count`.
+ * @param[out] key_ids The generated key_ids. Size `count`.
  * @return The result of the operation.
  */
-DLLEXPORT int GetCaSerialNumbers(ate_client_ptr client, const char* sku,
-                                 size_t count, const char** labels,
-                                 ca_serial_number_t* serial_numbers);
+DLLEXPORT int GetCaSubjectKeys(ate_client_ptr client, const char* sku,
+                               size_t count, const char** labels,
+                               ca_subject_key_t* key_ids);
 
 /**
  * Endorse certificates.
@@ -543,16 +543,16 @@ DLLEXPORT int RmaTokenFromJson(const dut_spi_frame_t* frame,
                                token_t* rma_token);
 
 /**
- * Generate JSON command to inject the CA serial numbers.
+ * Generate JSON command to inject the CA subject keys.
  *
- * @param dice_ca_sn The DICE CA serial number.
- * @param aux_ca_sn The auxiliary CA serial number.
+ * @param dice_ca_sn The DICE CA subject key.
+ * @param aux_ca_sn The auxiliary CA subject key.
  * @param[out] result The generated JSON command.
  * @return The result of the operation.
  */
-DLLEXPORT int CaSerialNumbersToJson(const ca_serial_number_t* dice_ca_sn,
-                                    const ca_serial_number_t* aux_ca_sn,
-                                    dut_spi_frame_t* result);
+DLLEXPORT int CaSubjectKeysToJson(const ca_subject_key_t* dice_ca_sn,
+                                  const ca_subject_key_t* aux_ca_sn,
+                                  dut_spi_frame_t* result);
 
 /**
  * Generate JSON command to inject personalization blob.

--- a/src/ate/ate_api_json_commands.cc
+++ b/src/ate/ate_api_json_commands.cc
@@ -208,26 +208,26 @@ DLLEXPORT int RmaTokenFromJson(const dut_spi_frame_t *frame,
   return 0;
 }
 
-DLLEXPORT int CaSerialNumbersToJson(const ca_serial_number_t *dice_ca_sn,
-                                    const ca_serial_number_t *aux_ca_sn,
-                                    dut_spi_frame_t *result) {
+DLLEXPORT int CaSubjectKeysToJson(const ca_subject_key_t *dice_ca_sn,
+                                  const ca_subject_key_t *aux_ca_sn,
+                                  dut_spi_frame_t *result) {
   if (result == nullptr) {
     LOG(ERROR) << "Invalid result buffer";
     return -1;
   }
 
-  ot::dut_commands::CaSerialNumbersJSON ca_serial_numbers_cmd;
+  ot::dut_commands::CaSubjectKeysJSON ca_key_ids_cmd;
   if (dice_ca_sn == nullptr) {
-    LOG(ERROR) << "Invalid DICE CA serial number.";
+    LOG(ERROR) << "Invalid DICE CA subject key.";
     return -1;
   }
   if (aux_ca_sn == nullptr) {
-    LOG(ERROR) << "Invalid auxiliary CA serial number.";
+    LOG(ERROR) << "Invalid auxiliary CA subject key.";
     return -1;
   }
-  for (size_t i = 0; i < kCaSerialNumberSize; ++i) {
-    ca_serial_numbers_cmd.add_dice_auth_key_key_id(dice_ca_sn->data[i]);
-    ca_serial_numbers_cmd.add_ext_auth_key_key_id(aux_ca_sn->data[i]);
+  for (size_t i = 0; i < kCaSubjectKeySize; ++i) {
+    ca_key_ids_cmd.add_dice_auth_key_key_id(dice_ca_sn->data[i]);
+    ca_key_ids_cmd.add_ext_auth_key_key_id(aux_ca_sn->data[i]);
   }
 
   std::string command;
@@ -236,8 +236,8 @@ DLLEXPORT int CaSerialNumbersToJson(const ca_serial_number_t *dice_ca_sn,
   options.always_print_primitive_fields = true;
   options.preserve_proto_field_names = true;
   google::protobuf::util::Status status =
-      google::protobuf::util::MessageToJsonString(ca_serial_numbers_cmd,
-                                                  &command, options);
+      google::protobuf::util::MessageToJsonString(ca_key_ids_cmd, &command,
+                                                  options);
   if (!status.ok()) {
     LOG(ERROR) << "Failed to convert CA serial number command to JSON: "
                << status.ToString();

--- a/src/ate/ate_api_json_commands_test.cc
+++ b/src/ate/ate_api_json_commands_test.cc
@@ -129,30 +129,30 @@ TEST_F(AteJsonTest, RmaToken) {
   EXPECT_EQ(rma_token_got.size, sizeof(uint64_t) * 2);
 }
 
-TEST_F(AteJsonTest, CaSerialNumbers) {
-  ca_serial_number_t dice_ca_sn = {0};
-  ca_serial_number_t aux_ca_sn = {0};
-  dice_ca_sn.data[0] = 65;
-  dice_ca_sn.data[9] = 12;
-  aux_ca_sn.data[0] = 123;
-  aux_ca_sn.data[19] = 255;
+TEST_F(AteJsonTest, CaSubjectKeys) {
+  ca_subject_key_t dice_ca_key_id = {0};
+  ca_subject_key_t aux_ca_key_id = {0};
+  dice_ca_key_id.data[0] = 65;
+  dice_ca_key_id.data[9] = 12;
+  aux_ca_key_id.data[0] = 123;
+  aux_ca_key_id.data[19] = 255;
 
   dut_spi_frame_t frame;
-  EXPECT_EQ(CaSerialNumbersToJson(&dice_ca_sn, &aux_ca_sn, &frame), 0);
+  EXPECT_EQ(CaSubjectKeysToJson(&dice_ca_key_id, &aux_ca_key_id, &frame), 0);
 
   std::string json_string =
       std::string(reinterpret_cast<char*>(frame.payload), frame.cursor);
 
-  // Use the proto representation of CaSerialNumbersJSON to verify the JSON
+  // Use the proto representation of CaSubjectKeysJSON to verify the JSON
   // string.
-  ot::dut_commands::CaSerialNumbersJSON ca_serial_numbers_cmd;
+  ot::dut_commands::CaSubjectKeysJSON ca_key_ids_cmd;
   google::protobuf::util::JsonParseOptions options;
   options.ignore_unknown_fields = true;
   google::protobuf::util::Status status =
-      google::protobuf::util::JsonStringToMessage(
-          json_string, &ca_serial_numbers_cmd, options);
+      google::protobuf::util::JsonStringToMessage(json_string, &ca_key_ids_cmd,
+                                                  options);
   EXPECT_EQ(status.ok(), true);
-  EXPECT_THAT(ca_serial_numbers_cmd, EqualsProto(R"pb(
+  EXPECT_THAT(ca_key_ids_cmd, EqualsProto(R"pb(
                 dice_auth_key_key_id: 65
                 dice_auth_key_key_id: 0
                 dice_auth_key_key_id: 0

--- a/src/ate/ate_client.cc
+++ b/src/ate/ate_client.cc
@@ -29,8 +29,8 @@ using pa::DeriveTokensRequest;
 using pa::DeriveTokensResponse;
 using pa::EndorseCertsRequest;
 using pa::EndorseCertsResponse;
-using pa::GetCaSerialNumbersRequest;
-using pa::GetCaSerialNumbersResponse;
+using pa::GetCaSubjectKeysRequest;
+using pa::GetCaSubjectKeysResponse;
 using pa::InitSessionRequest;
 using pa::InitSessionResponse;
 using pa::ProvisioningApplianceService;
@@ -142,9 +142,9 @@ Status AteClient::DeriveTokens(DeriveTokensRequest& request,
   return stub_->DeriveTokens(&context, request, reply);
 }
 
-Status AteClient::GetCaSerialNumbers(GetCaSerialNumbersRequest& request,
-                                     GetCaSerialNumbersResponse* reply) {
-  LOG(INFO) << "AteClient::GetCaSerialNumbers";
+Status AteClient::GetCaSubjectKeys(GetCaSubjectKeysRequest& request,
+                                   GetCaSubjectKeysResponse* reply) {
+  LOG(INFO) << "AteClient::GetCaSubjectKeys";
 
   // Context for the client (It could be used to convey extra information to
   // the server and/or tweak certain RPC behaviors).
@@ -152,7 +152,7 @@ Status AteClient::GetCaSerialNumbers(GetCaSerialNumbersRequest& request,
   context.AddMetadata("authorization", sku_session_token_);
 
   // The actual RPC - call the server's DeriveTokens method.
-  return stub_->GetCaSerialNumbers(&context, request, reply);
+  return stub_->GetCaSubjectKeys(&context, request, reply);
 }
 
 Status AteClient::RegisterDevice(RegistrationRequest& request,

--- a/src/ate/ate_client.h
+++ b/src/ate/ate_client.h
@@ -70,9 +70,9 @@ class AteClient {
   grpc::Status DeriveTokens(pa::DeriveTokensRequest& request,
                             pa::DeriveTokensResponse* reply);
 
-  // Calls the server's GetCaSerialNumbers method and returns its reply.
-  grpc::Status GetCaSerialNumbers(pa::GetCaSerialNumbersRequest& request,
-                                  pa::GetCaSerialNumbersResponse* reply);
+  // Calls the server's GetCaSubjectKeys method and returns its reply.
+  grpc::Status GetCaSubjectKeys(pa::GetCaSubjectKeysRequest& request,
+                                pa::GetCaSubjectKeysResponse* reply);
 
   // Calls the server's RegisterDevice method and returns its reply.
   grpc::Status RegisterDevice(pa::RegistrationRequest& request,

--- a/src/ate/ate_dll.cc
+++ b/src/ate/ate_dll.cc
@@ -401,17 +401,16 @@ DLLEXPORT int GenerateTokens(ate_client_ptr client, const char *sku,
   return TokensCopy(count, resp, tokens, seeds);
 }
 
-DLLEXPORT int GetCaSerialNumbers(ate_client_ptr client, const char *sku,
-                                 size_t count, const char **labels,
-                                 ca_serial_number_t *serial_numbers) {
-  DLOG(INFO) << "GetCaSerialNumbers";
+DLLEXPORT int GetCaSubjectKeys(ate_client_ptr client, const char *sku,
+                               size_t count, const char **labels,
+                               ca_subject_key_t *key_ids) {
+  DLOG(INFO) << "GetCaSubjectKeys";
 
-  if (sku == nullptr || labels == nullptr || count == 0 ||
-      serial_numbers == nullptr) {
+  if (sku == nullptr || labels == nullptr || count == 0 || key_ids == nullptr) {
     return static_cast<int>(absl::StatusCode::kInvalidArgument);
   }
 
-  pa::GetCaSerialNumbersRequest req;
+  pa::GetCaSubjectKeysRequest req;
   req.set_sku(sku);
   for (size_t i = 0; i < count; ++i) {
     req.add_cert_labels(labels[i]);
@@ -419,17 +418,16 @@ DLLEXPORT int GetCaSerialNumbers(ate_client_ptr client, const char *sku,
 
   AteClient *ate = reinterpret_cast<AteClient *>(client);
 
-  pa::GetCaSerialNumbersResponse resp;
-  auto status = ate->GetCaSerialNumbers(req, &resp);
+  pa::GetCaSubjectKeysResponse resp;
+  auto status = ate->GetCaSubjectKeys(req, &resp);
   if (!status.ok()) {
-    LOG(ERROR) << "GetCaSerialNumbers failed with " << status.error_code()
-               << ": " << status.error_message();
+    LOG(ERROR) << "GetCaSubjectKeys failed with " << status.error_code() << ": "
+               << status.error_message();
     return static_cast<int>(status.error_code());
   }
 
   for (size_t i = 0; i < count; ++i) {
-    memcpy(serial_numbers[i].data, resp.serial_numbers(i).data(),
-           kCaSerialNumberSize);
+    memcpy(key_ids[i].data, resp.key_ids(i).data(), kCaSubjectKeySize);
   }
 
   return 0;

--- a/src/ate/proto/dut_commands.proto
+++ b/src/ate/proto/dut_commands.proto
@@ -47,7 +47,7 @@ message RmaTokenJSON {
 
 // Provides the manuf_certgen_inputs_t data structure used by provisioning
 // firmware.
-message CaSerialNumbersJSON {
+message CaSubjectKeysJSON {
   // dice_auth_key_key_id contains the DICE CA serial number. It must contain 20
   // bytes, to hold a SHA1 hash. Protobuf does not have a "uint8" type, such
   // that we can define a message field of "repeated uint8". Protobuf only has a

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -236,22 +236,20 @@ int main(int argc, char **argv) {
     return -1;
   }
 
-  // Generate CA serial numbers.
+  // Generate CA subject keys.
   constexpr size_t kNumIcas = 1;
   const char *kIcaCertLabels[] = {"SigningKey/Dice/v0"};
-  ca_serial_number_t serial_numbers[kNumIcas];
-  if (GetCaSerialNumbers(ate_client, absl::GetFlag(FLAGS_sku).c_str(),
-                         /*count=*/kNumIcas, kIcaCertLabels,
-                         serial_numbers) != 0) {
-    LOG(ERROR) << "GetCaSerialNumbers failed.";
+  ca_subject_key_t key_ids[kNumIcas];
+  if (GetCaSubjectKeys(ate_client, absl::GetFlag(FLAGS_sku).c_str(),
+                       /*count=*/kNumIcas, kIcaCertLabels, key_ids) != 0) {
+    LOG(ERROR) << "GetCaSubjectKeys failed.";
     return -1;
   }
-  const ca_serial_number_t *kDiceCaSn = &serial_numbers[0];
-  const ca_serial_number_t kExtCaSn = {0};
-  dut_spi_frame_t ca_serial_numbers_spi_frame;
-  if (CaSerialNumbersToJson(kDiceCaSn, &kExtCaSn,
-                            &ca_serial_numbers_spi_frame) != 0) {
-    LOG(ERROR) << "CaSerialNumbersToJson failed.";
+  const ca_subject_key_t *kDiceCaSk = &key_ids[0];
+  const ca_subject_key_t kExtCaSk = {0};
+  dut_spi_frame_t ca_key_ids_spi_frame;
+  if (CaSubjectKeysToJson(kDiceCaSk, &kExtCaSk, &ca_key_ids_spi_frame) != 0) {
+    LOG(ERROR) << "CaSubjectKeysToJson failed.";
     return -1;
   }
 
@@ -272,8 +270,7 @@ int main(int argc, char **argv) {
                     rma_token_spi_frame.payload, rma_token_spi_frame.cursor,
                     /*timeout_ms=*/1000);
   dut->DutConsoleTx("Waiting for certificate inputs ...",
-                    ca_serial_numbers_spi_frame.payload,
-                    ca_serial_numbers_spi_frame.cursor,
+                    ca_key_ids_spi_frame.payload, ca_key_ids_spi_frame.cursor,
                     /*timeout_ms=*/1000);
 
   // Receive the TBS certs and other provisioning data from the DUT.

--- a/src/pa/loadtest.go
+++ b/src/pa/loadtest.go
@@ -176,26 +176,26 @@ func testOTDeriveTokens(ctx context.Context, numCalls int, skuName string, c *cl
 	}
 }
 
-// Executes the GetCaSerialNumbers call for a `numCalls` total and
+// Executes the GetCaSubjectKeys call for a `numCalls` total and
 // produces a `callResult` which is sent to the `clientTask.results` channel.
-func testOTGetCaSerialNumbers(ctx context.Context, numCalls int, skuName string, c *clientTask) {
+func testOTGetCaSubjectKeys(ctx context.Context, numCalls int, skuName string, c *clientTask) {
 	// Prepare request and auth token.
 	md := metadata.Pairs("user_id", strconv.Itoa(c.id), "authorization", c.auth_token)
 	client_ctx := metadata.NewOutgoingContext(ctx, md)
 
-	request := &pbp.GetCaSerialNumbersRequest{
+	request := &pbp.GetCaSubjectKeysRequest{
 		Sku:        skuName,
 		CertLabels: []string{"SigningKey/Dice/v0"},
 	}
 
 	// Send request to PA.
 	for i := 0; i < numCalls; i++ {
-		r, err := c.client.GetCaSerialNumbers(client_ctx, request)
+		r, err := c.client.GetCaSubjectKeys(client_ctx, request)
 		if err != nil {
 			log.Printf("error: client id: %d, error: %v", c.id, err)
 		}
 		for j, label := range request.CertLabels {
-			log.Printf("CA %q serial number: 0x%s", label, hex.EncodeToString(r.SerialNumbers[j]))
+			log.Printf("CA %q subject key: 0x%s", label, hex.EncodeToString(r.KeyIds[j]))
 		}
 		c.results <- &callResult{id: c.id, err: err}
 		time.Sleep(c.delayPerCall)
@@ -433,8 +433,8 @@ func main() {
 				testFunc: testOTDeriveTokens,
 			},
 			{
-				testName: "OT:GetCaSerialNumbers",
-				testFunc: testOTGetCaSerialNumbers,
+				testName: "OT:GetCaSubjectKeys",
+				testFunc: testOTGetCaSubjectKeys,
 			},
 			{
 				testName: "OT:EndorseCerts",

--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -25,8 +25,8 @@ service ProvisioningApplianceService {
     returns (DeriveTokensResponse) {}
   rpc GetStoredTokens(GetStoredTokensRequest)
     returns (GetStoredTokensResponse) {}
-  rpc GetCaSerialNumbers(GetCaSerialNumbersRequest)
-    returns (GetCaSerialNumbersResponse) {}
+  rpc GetCaSubjectKeys(GetCaSubjectKeysRequest)
+    returns (GetCaSubjectKeysResponse) {}
   rpc RegisterDevice(RegistrationRequest)
     returns (RegistrationResponse) {}
 }
@@ -185,18 +185,18 @@ message InitSessionResponse {
 }
 
 // Get CA serial numbers request.
-message GetCaSerialNumbersRequest{
+message GetCaSubjectKeysRequest{
   // SKU identifier. Required.
   string sku = 1;
   // CA cert labels (to locate the key within the SPM). Required.
   repeated string cert_labels = 2;
 }
 
-// Get stored tokens response.
-message GetCaSerialNumbersResponse{
-  // Serial numbers. Size is fixed to 20 bytes (160-bits) per serial number as
+// Get CA subject keys response.
+message GetCaSubjectKeysResponse{
+  // Subject keys. Size is fixed to 20 bytes (160-bits) per subject key as
   // this is the size of the CA key IDs used by the OpenTitan project.
-  repeated bytes serial_numbers = 1;
+  repeated bytes key_ids = 1;
 }
 
 

--- a/src/pa/services/pa.go
+++ b/src/pa/services/pa.go
@@ -136,10 +136,10 @@ func (s *server) GetStoredTokens(ctx context.Context, request *pap.GetStoredToke
 	return r, nil
 }
 
-// GetCaSerialNumbers retrieves the CA serial numbers for a given SKU.
-func (s *server) GetCaSerialNumbers(ctx context.Context, request *pap.GetCaSerialNumbersRequest) (*pap.GetCaSerialNumbersResponse, error) {
-	log.Printf("In PA - Received GetCaSerialNumbers request")
-	r, err := s.spmClient.GetCaSerialNumbers(ctx, request)
+// GetCaSubjectKeys retrieves the CA serial numbers for a given SKU.
+func (s *server) GetCaSubjectKeys(ctx context.Context, request *pap.GetCaSubjectKeysRequest) (*pap.GetCaSubjectKeysResponse, error) {
+	log.Printf("In PA - Received GetCaSubjectKeys request")
+	r, err := s.spmClient.GetCaSubjectKeys(ctx, request)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "SPM returned error: %v", err)
 	}

--- a/src/pa/services/pa_test.go
+++ b/src/pa/services/pa_test.go
@@ -74,7 +74,7 @@ type fakeSpmClient struct {
 	initSession         initSessionResponse
 	deriveSymmetricKeys deriveSymmetricKeysResponse
 	getStoredTokens     getStoredTokensResponse
-	getCaSerialNumbers  getCaSerialNumbersResponse
+	getCaSubjectKeys    getCaSubjectKeysResponse
 	endorseCerts        endorseCertsResponse
 	endorseData         endorseDataResponse
 }
@@ -94,8 +94,8 @@ type getStoredTokensResponse struct {
 	err      error
 }
 
-type getCaSerialNumbersResponse struct {
-	response *pbp.GetCaSerialNumbersResponse
+type getCaSubjectKeysResponse struct {
+	response *pbp.GetCaSubjectKeysResponse
 	err      error
 }
 
@@ -121,8 +121,8 @@ func (c *fakeSpmClient) GetStoredTokens(ctx context.Context, request *pbp.GetSto
 	return c.getStoredTokens.response, c.getStoredTokens.err
 }
 
-func (c *fakeSpmClient) GetCaSerialNumbers(ctx context.Context, request *pbp.GetCaSerialNumbersRequest, opts ...grpc.CallOption) (*pbp.GetCaSerialNumbersResponse, error) {
-	return c.getCaSerialNumbers.response, c.getCaSerialNumbers.err
+func (c *fakeSpmClient) GetCaSubjectKeys(ctx context.Context, request *pbp.GetCaSubjectKeysRequest, opts ...grpc.CallOption) (*pbp.GetCaSubjectKeysResponse, error) {
+	return c.getCaSubjectKeys.response, c.getCaSubjectKeys.err
 }
 
 func (c *fakeSpmClient) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequest, opts ...grpc.CallOption) (*pbp.EndorseCertsResponse, error) {

--- a/src/spm/proto/spm.proto
+++ b/src/spm/proto/spm.proto
@@ -28,10 +28,10 @@ service SpmService {
   rpc DeriveTokens(pa.DeriveTokensRequest)
       returns (pa.DeriveTokensResponse) {}
 
-  // GetCaSerialNumbers retrieves the CA certificate(s) serial numbers for a
+  // GetCaSubjectKeys retrieves the CA certificate(s) subject keys for a
   // SKU.
-  rpc GetCaSerialNumbers(pa.GetCaSerialNumbersRequest)
-      returns (pa.GetCaSerialNumbersResponse) {}
+  rpc GetCaSubjectKeys(pa.GetCaSubjectKeysRequest)
+      returns (pa.GetCaSubjectKeysResponse) {}
 
   // GetStoredTokens retrieves a token preprovisioned on the SPM.
   rpc GetStoredTokens(pa.GetStoredTokensRequest)

--- a/src/spm/services/spm.go
+++ b/src/spm/services/spm.go
@@ -288,25 +288,25 @@ func ecdsaSignatureAlgorithmFromHashType(h pbcommon.HashType) x509.SignatureAlgo
 	}
 }
 
-// GetCaSerialNumbers retrieves the CA certificate(s) serial numbers for a SKU.
-func (s *server) GetCaSerialNumbers(ctx context.Context, request *pbp.GetCaSerialNumbersRequest) (*pbp.GetCaSerialNumbersResponse, error) {
+// GetCaSubjectKeys retrieves the CA certificate(s) subject keys for a SKU.
+func (s *server) GetCaSubjectKeys(ctx context.Context, request *pbp.GetCaSubjectKeysRequest) (*pbp.GetCaSubjectKeysResponse, error) {
 	sku, ok := s.skuManager.GetSku(request.Sku)
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "unable to find sku %q. Try calling InitSession first", request.Sku)
 	}
 
-	// Extract the serial number from each certificate.
-	var serialNumbers [][]byte
+	// Extract the subject key from each certificate.
+	var subjectKeys [][]byte
 	for _, label := range request.CertLabels {
 		cert, ok := sku.Certs[label]
 		if !ok {
 			return nil, status.Errorf(codes.Internal, "unable to find cert %q in SKU configuration", label)
 		}
-		serialNumbers = append(serialNumbers, cert.SerialNumber.Bytes())
+		subjectKeys = append(subjectKeys, cert.SubjectKeyId)
 	}
 
-	return &pbp.GetCaSerialNumbersResponse{
-		SerialNumbers: serialNumbers,
+	return &pbp.GetCaSubjectKeysResponse{
+		KeyIds: subjectKeys,
 	}, nil
 }
 


### PR DESCRIPTION
This replaces the `GetCaSerialNumbers` for `GetCaSubjecKeys`. This is to allow Intermediate CA (ICA) certificates to have a serial number set to a value different than its SubjectKeyId. openssl doesn't set the serial number to the SubjectKeyId by default.

The ICA SubjectKeyId is used by the DUT to populate the AuthorityKeyID. Below is a sample SPM log after applying the change in this commit:

```console
2025/06/08 20:43:14 DUT cert AuthorityKeyID: ff12c119c25880fefa2ff765551aef255c0c5622
2025/06/08 20:43:14 DUT cert Issuer: CN=Google Engineering ICA,OU=Engineering,O=Google,ST=CA,C=US
2025/06/08 20:43:14 ICA SubjectKeyID: ff12c119c25880fefa2ff765551aef255c0c5622
2025/06/08 20:43:14 ICA Subject: CN=Google Engineering ICA,OU=Engineering,O=Google,ST=CA,C=US
```