### PR TITLE
[dut_lib] enable console RX of several SPI frames

### DIFF
--- a/src/ate/test_programs/cp.cc
+++ b/src/ate/test_programs/cp.cc
@@ -222,8 +222,9 @@ int main(int argc, char **argv) {
                     spi_frame.cursor,
                     /*timeout_ms=*/1000);
   dut_spi_frame_t devid_spi_frame;
-  dut->DutConsoleRx("Exporting CP device ID ...", devid_spi_frame.payload,
-                    &devid_spi_frame.cursor,
+  size_t num_spi_frames = 1;
+  dut->DutConsoleRx("Exporting CP device ID ...", &devid_spi_frame,
+                    &num_spi_frames,
                     /*quiet=*/false,
                     /*timeout_ms=*/1000);
   device_id_bytes_t device_id_bytes = {.raw = {0}};

--- a/src/ate/test_programs/dut_lib/BUILD.bazel
+++ b/src/ate/test_programs/dut_lib/BUILD.bazel
@@ -19,6 +19,7 @@ cc_library(
     ],
     deps = [
         "//src/ate:ate_client",
+        "//src/ate:ate_lib",
         "//src/ate/proto:dut_commands_cc_proto",
         "//src/ate/test_programs/otlib_wrapper",
         "@com_google_absl//absl/log",

--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -11,6 +11,7 @@
 
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "src/ate/ate_api.h"
 #include "src/ate/proto/dut_commands.pb.h"
 
 namespace provisioning {
@@ -24,8 +25,9 @@ void OtLibLoadSramElf(void* transport, const char* openocd, const char* elf,
 void OtLibBootstrap(void* transport, const char* bin);
 void OtLibConsoleWaitForRx(void* transport, const char* msg,
                            uint64_t timeout_ms);
-void OtLibConsoleRx(void* transport, const char* sync_msg, uint8_t* spi_frame,
-                    size_t* spi_frame_size, bool quiet, uint64_t timeout_ms);
+void OtLibConsoleRx(void* transport, const char* sync_msg,
+                    dut_spi_frame_t* spi_frames, size_t* num_frames, bool quiet,
+                    uint64_t timeout_ms);
 void OtLibConsoleTx(void* transport, const char* sync_msg,
                     const uint8_t* spi_frame, size_t spi_frame_size,
                     uint64_t timeout_ms);
@@ -64,11 +66,11 @@ void DutLib::DutConsoleWaitForRx(const char* msg, uint64_t timeout_ms) {
   OtLibConsoleWaitForRx(transport_, msg, timeout_ms);
 }
 
-void DutLib::DutConsoleRx(const std::string& sync_msg, uint8_t* spi_frame,
-                          size_t* spi_frame_size, bool quiet,
-                          uint64_t timeout_ms) {
+void DutLib::DutConsoleRx(const std::string& sync_msg,
+                          dut_spi_frame_t* spi_frames, size_t* num_frames,
+                          bool quiet, uint64_t timeout_ms) {
   LOG(INFO) << "in DutLib::DutConsoleRx";
-  OtLibConsoleRx(transport_, sync_msg.c_str(), spi_frame, spi_frame_size, quiet,
+  OtLibConsoleRx(transport_, sync_msg.c_str(), spi_frames, num_frames, quiet,
                  timeout_ms);
 }
 

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -8,6 +8,8 @@
 #include <memory>
 #include <string>
 
+#include "src/ate/ate_api.h"
+
 namespace provisioning {
 namespace test_programs {
 
@@ -42,8 +44,8 @@ class DutLib {
   /**
    * Calls opentitanlib test util to receive a message over the SPI console.
    */
-  void DutConsoleRx(const std::string& sync_msg, uint8_t* spi_frame,
-                    size_t* spi_frame_size, bool quiet, uint64_t timeout_ms);
+  void DutConsoleRx(const std::string& sync_msg, dut_spi_frame_t* spi_frames,
+                    size_t* num_frames, bool quiet, uint64_t timeout_ms);
   /**
    * Calls opentitanlib test util to send a message over the SPI console.
    */


### PR DESCRIPTION
This refactors the console RX method to be able to RX several SPI console frames in a single call. This will be required to RX UJSON payloads like the perso blob which spans several SPI console frames.