### PR TITLE
[ate_dll,ft] add RegisterDevice function to ATE DLL

### DIFF
--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -364,8 +364,28 @@ int main(int argc, char **argv) {
     }
   }
 
-  // TODO(timothytrippel): Check the cert chains validate.
-  // TODO(timothytrippel): Register the device.
+  // Register the device.
+  // TODO(timothytrippel): add helper function to translate kDifLcCtrlStateProd
+  // to kDeviceLifeCycleProd
+  metadata_t dut_metadata = {
+      .year = 0,
+      .week = 10,
+      .lot_num = 123,
+      .wafer_id = 456,
+      .x = 25,
+      .y = 52,
+  };
+  // TODO(timothytrippel): extract the perso TLV data and perso FW hash
+  perso_tlv_data_t perso_tlv_data = {.size = 10, .data = {0}};
+  perso_fw_sha256_hash_t perso_fw_hash = {.raw = {0}};
+  if (RegisterDevice(ate_client, absl::GetFlag(FLAGS_sku).c_str(),
+                     reinterpret_cast<const device_id_t *>(&device_id),
+                     kDeviceLifeCycleProd, &dut_metadata,
+                     &wrapped_rma_token_seed, &perso_tlv_data,
+                     &perso_fw_hash) != 0) {
+    LOG(ERROR) << "RegisterDevice failed.";
+    return -1;
+  }
 
   // Close session with PA.
   if (CloseSession(ate_client) != 0) {

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -6,6 +6,7 @@
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -13,6 +14,11 @@ package(default_visibility = ["//visibility:public"])
 proto_library(
     name = "device_id_proto",
     srcs = ["device_id.proto"],
+)
+
+cc_proto_library(
+    name = "device_id_cc_proto",
+    deps = [":device_id_proto"],
 )
 
 go_proto_library(

--- a/src/proto/device_id.proto
+++ b/src/proto/device_id.proto
@@ -158,7 +158,10 @@ message DeviceData {
   DeviceLifeCycle device_life_cycle = 3;
   // Additional metadata contain device creation time and registration state.
   Metadata metadata = 4;
-  // Encrypted RMA unlock token.
+  // Encrypted RMA unlock token seed.
+  //
+  // This is the encrypted seed used to KDF the RMA unlock token, not the
+  // encrypted token itself.
   bytes wrapped_rma_unlock_token = 5;
   // Up to (8k) bytes of SKU specific personalization TLV data.
   //


### PR DESCRIPTION
This adds a RegisterDevice function to the ATE DLL, and calls it from the reference FT test program, to insert a provisioned device in to the device registry database.

Fixes #16.