### PR TITLE
[ate_dll] remove autogenerated proto header dep

### DIFF
--- a/src/ate/BUILD.bazel
+++ b/src/ate/BUILD.bazel
@@ -51,6 +51,7 @@ ATE_LIB_DEPS = [
     ":ate_client",
     "//src/ate/proto:dut_commands_cc_proto",
     "//src/pa/proto:pa_cc_grpc",
+    "//src/proto:device_id_cc_proto",
     "//src/proto/crypto:common_cc_proto",
     "//src/proto/crypto:ecdsa_cc_proto",
     "@com_google_absl//absl/log",

--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -10,8 +10,6 @@
 
 #include <string>
 
-#include "src/proto/device_id.pb.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -403,19 +401,16 @@ typedef struct perso_fw_sha256_hash {
  * DeviceLifeCycle encodes the state of the device as it is being manufactured
  * and provisioned for shipment.
  */
-typedef enum DeviceLifeCycle : uint32_t {
-  kDeviceLifeCycleUnspecified =
-      ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_UNSPECIFIED,
-  kDeviceLifeCycleRaw = ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_RAW,
-  kDeviceLifeCycleTestLocked =
-      ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_TEST_LOCKED,
-  kDeviceLifeCycleTestUnlocked =
-      ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_TEST_UNLOCKED,
-  kDeviceLifeCycleDev = ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_DEV,
-  kDeviceLifeCycleProd = ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_PROD,
-  kDeviceLifeCycleProdEnd = ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_PROD_END,
-  kDeviceLifeCycleRma = ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_RMA,
-  kDeviceLifeCycleScrap = ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_SCRAP,
+typedef enum device_life_cycle : uint32_t {
+  kDeviceLifeCycleUnspecified = 0,
+  kDeviceLifeCycleRaw = 1,
+  kDeviceLifeCycleTestLocked = 2,
+  kDeviceLifeCycleTestUnlocked = 3,
+  kDeviceLifeCycleDev = 4,
+  kDeviceLifeCycleProd = 5,
+  kDeviceLifeCycleProdEnd = 6,
+  kDeviceLifeCycleRma = 7,
+  kDeviceLifeCycleScrap = 8,
 } device_life_cycle_t;
 
 /**

--- a/src/ate/ate_dll.cc
+++ b/src/ate/ate_dll.cc
@@ -23,11 +23,53 @@
 #include "src/pa/proto/pa.grpc.pb.h"
 #include "src/proto/crypto/common.pb.h"
 #include "src/proto/crypto/ecdsa.pb.h"
+#include "src/proto/device_id.pb.h"
 
 namespace {
 using provisioning::ate::AteClient;
 using namespace provisioning::ate;
 }  // namespace
+
+/**
+ * Check the ate_api.h device_life_cycle_t enum values match those in the
+ * device_id.proto enum.
+ */
+static_assert(kDeviceLifeCycleUnspecified ==
+                  static_cast<uint32_t>(
+                      ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_UNSPECIFIED),
+              "LC state enum must match proto enum (Unspecified)");
+static_assert(
+    kDeviceLifeCycleRaw ==
+        static_cast<uint32_t>(ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_RAW),
+    "LC state enum must match proto enum (Raw)");
+static_assert(kDeviceLifeCycleTestLocked ==
+                  static_cast<uint32_t>(
+                      ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_TEST_LOCKED),
+              "LC state enum must match proto enum (TestLocked)");
+static_assert(kDeviceLifeCycleTestUnlocked ==
+                  static_cast<uint32_t>(
+                      ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_TEST_UNLOCKED),
+              "LC state enum must match proto enum (TestUnlocked)");
+static_assert(
+    kDeviceLifeCycleDev ==
+        static_cast<uint32_t>(ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_DEV),
+    "LC state enum must match proto enum (Dev)");
+static_assert(
+    kDeviceLifeCycleProd ==
+        static_cast<uint32_t>(ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_PROD),
+    "LC state enum must match proto enum (Prod)");
+static_assert(
+    kDeviceLifeCycleProdEnd ==
+        static_cast<uint32_t>(ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_PROD_END),
+    "LC state enum must match proto enum (ProdEnd)");
+static_assert(
+    kDeviceLifeCycleRma ==
+        static_cast<uint32_t>(ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_RMA),
+    "LC state enum must match proto enum (Rma)");
+static_assert(
+    kDeviceLifeCycleScrap ==
+        static_cast<uint32_t>(ot::DeviceLifeCycle::DEVICE_LIFE_CYCLE_SCRAP),
+    "LC state enum must match proto enum (Scrap)");
 
 std::string extractDNSNameFromCert(const char *certPath) {
   DLOG(INFO) << "extractDNSNameFromCert";
@@ -212,7 +254,6 @@ DLLEXPORT int CloseSession(ate_client_ptr client) {
 }
 
 namespace {
-
 // Convert `token_seed_t` to `TokenSeed`.
 int TokenSetSeedConfig(token_seed_t seed_kind, pa::TokenParams *param) {
   switch (seed_kind) {


### PR DESCRIPTION
This removes the include of an autogenerate protobuf header file from the ate_api.h header file.