### PR TITLE
[proto,ate] add A2 silicon product ID and add compiler configurations

### DIFF
--- a/src/ate/BUILD.bazel
+++ b/src/ate/BUILD.bazel
@@ -17,6 +17,7 @@ cc_library(
     name = "ate_client",
     srcs = ["ate_client.cc"],
     hdrs = ["ate_client.h"],
+    copts = ["-Wno-switch-default"],
     defines = ["BAZEL_BUILD"],
     linkopts = select({
         "//:windows": WINDOWS_LIBS,
@@ -100,6 +101,7 @@ cc_binary(
         "ate_api.h",
         "ate_perso_blob.h",
     ] + ATE_LIB_SRCS,
+    copts = ["-Wno-switch-default"],
     linkopts = select({
         "//:windows": WINDOWS_LIBS,
         "//conditions:default": [],
@@ -114,6 +116,7 @@ cc_binary(
 pkg_win(
     name = "windows",
     srcs = [
+        "ate_api.h",
         ":ate",
     ],
     platform = "@crt//platforms/x86_32:win32",

--- a/src/proto/device_id.proto
+++ b/src/proto/device_id.proto
@@ -37,6 +37,8 @@ enum ProductId {
   PRODUCT_ID_EARLGREY_Z1 = 0x0001;
   // Earlgrey Production v1.0.0 (A1).
   PRODUCT_ID_EARLGREY_A1 = 0x0002;
+  // Earlgrey Production v1.0.0 (A2).
+  PRODUCT_ID_EARLGREY_A2 = 0x0003;
 }
 
 // OpenTitan Hardware Origin.


### PR DESCRIPTION
This has two commits that:
1. adds the Earlgrey A2 silicon product ID code, and
2. adds compiler configurations to the ATE libs.