### PR TITLE
[config,ca] add dedicated pi01 root CA

### DIFF
--- a/config/spm/sku/eg/common/BUILD.bazel
+++ b/config/spm/sku/eg/common/BUILD.bazel
@@ -33,8 +33,15 @@ hsm_sku_rma_key(
     name = "sku-eg-rsa-rma-v0",
 )
 
+# All SKUs except pi01 SKU use the same root CA.
 hsm_certificate_authority_root(
     name = "opentitan-ca-root-v0",
+    curve = HSMTOOL_CONST.ECC_CURVE.PRIME256V1,
+)
+
+# pi01 SKU has own root CA.
+hsm_certificate_authority_root(
+    name = "pi01-ca-root-v0",
     curve = HSMTOOL_CONST.ECC_CURVE.PRIME256V1,
 )
 
@@ -65,10 +72,18 @@ hsm_certgen(
     root_cert = True,
 )
 
+hsm_certgen(
+    name = "pi01_ca_root",
+    config = ":pi01_ca_root.conf",
+    key = ":pi01-ca-root-v0",
+    root_cert = True,
+)
+
 hsm_config_tar(
     name = "offline_init",
     hsmtool_sequence = {
         ":opentitan-ca-root-v0": "keygen",
+        ":pi01-ca-root-v0": "keygen",
         ":eg-aes-wrap-v0": "keygen",
         ":eg-kdf-hisec-v0": "keygen",
         ":eg-kdf-losec-v0": "keygen",
@@ -103,6 +118,7 @@ hsm_certgen_tar(
     name = "ca_root_certgen",
     certs = [
         ":ca_root",
+        ":pi01_ca_root",
     ],
 )
 
@@ -113,6 +129,7 @@ filegroup(
         ":ca_root_certgen",
         ":offline_export",
         ":offline_init",
+        ":pi01_ca_root.conf",
         ":spm_sku_init",
     ],
 )

--- a/config/spm/sku/eg/common/pi01_ca_root.conf
+++ b/config/spm/sku/eg/common/pi01_ca_root.conf
@@ -1,0 +1,17 @@
+[req]
+prompt = no
+default_md = sha256
+distinguished_name = dn
+x509_extensions = v3_ca
+
+[dn]
+C=IL
+O=Nuvoton Technology Corporation
+OU=Engineering
+CN=Nuvoton Technology OpenTitan Root CA
+
+[v3_ca]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+basicConstraints = critical,CA:true,pathlen:1
+keyUsage = keyCertSign

--- a/config/spm/sku/eg/pi/BUILD.bazel
+++ b/config/spm/sku/eg/pi/BUILD.bazel
@@ -28,14 +28,14 @@ hsm_certificate_authority_intermediate(
 
 hsm_certgen(
     name = "pi01_ca_int_dice",
-    ca_key = "//config/spm/sku/eg/common:opentitan-ca-root-v0",
+    ca_key = "//config/spm/sku/eg/common:pi01-ca-root-v0",
     config = ":ca_int_dice.conf",
     key = ":pi01-ica-dice-key-p256-v0",
 )
 
 hsm_certgen(
     name = "pi01_ca_int_ext",
-    ca_key = "//config/spm/sku/eg/common:opentitan-ca-root-v0",
+    ca_key = "//config/spm/sku/eg/common:pi01-ca-root-v0",
     config = ":ca_int_ext.conf",
     key = ":pi01-ica-ext-key-p256-v0",
 )

--- a/config/spm/sku_pi01.yml.tmpl
+++ b/config/spm/sku_pi01.yml.tmpl
@@ -10,7 +10,7 @@ symmetricKeys:
   - name: eg-kdf-losec-v0
 certs:
   - name: RootCA
-    path: sku/eg/common/ca/opentitan-ca-root-v0.priv.der
+    path: sku/eg/common/ca/pi01-ca-root-v0.priv.der
   - name: SigningKey/Dice/v0
     path: sku/eg/pi/ca/pi01-ica-dice-key-p256-v0.priv.der
   - name: SigningKey/Ext/v0


### PR DESCRIPTION
This adds a dedicated root CA for the pi01 SKU. All other SKUs share a common root CA, however the pi01 SKU required extra pathlen and keyUsage constraints.