### PR TITLE
[hsm] use backwards compatible key wrap mechanism

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,6 +20,7 @@ build --workspace_status_command=util/get_workspace_status.sh
 
 # Enable the rust nightly toolchain
 build --@rules_rust//rust/toolchain/channel=nightly
+build --@rules_rust//cargo/settings:use_default_shell_env=False
 
 # Import site-specific configuration.
 try-import .bazelrc-site

--- a/config/spm/sku/eg/common/BUILD.bazel
+++ b/config/spm/sku/eg/common/BUILD.bazel
@@ -43,7 +43,7 @@ hsm_generic_secret(
     wrapping_key = ":eg-aes-wrap-v0",
     wrapping_mechanism = select({
         "//:dev_env": "AesKeyWrap",
-        "//:prod_env": "VendorThalesAesKwp",
+        "//:prod_env": "VendorThalesAesKw",
         "//conditions:default": "AesKeyWrap",
     }),
 )
@@ -53,7 +53,7 @@ hsm_generic_secret(
     wrapping_key = ":eg-aes-wrap-v0",
     wrapping_mechanism = select({
         "//:dev_env": "AesKeyWrap",
-        "//:prod_env": "VendorThalesAesKwp",
+        "//:prod_env": "VendorThalesAesKw",
         "//conditions:default": "AesKeyWrap",
     }),
 )

--- a/rules/hsm.bzl
+++ b/rules/hsm.bzl
@@ -398,6 +398,7 @@ hsm_key_template = rule(
                 "AesKeyWrap",
                 "RsaPkcs",
                 "RsaPkcsOaep",
+                "VendorThalesAesKw",
                 "VendorThalesAesKwp",
             ],
         ),
@@ -924,22 +925,23 @@ def hsm_generic_secret(name, wrapping_key, wrapping_mechanism):
         wrapping_key: The key used to wrap the key.
         wrapping_mechanism: The mechanism used to wrap the key.
     """
+    _PK11_ATTRS = {
+        "CKA_DERIVE": True,
+        "CKA_SENSITIVE": True,
+        "CKA_SIGN": True,
+        "CKA_TOKEN": True,
+    }
+    if wrapping_mechanism == "VendorThalesAesKw":
+        _PK11_ATTRS["CKA_VALUE_LEN"] = 32
     hsm_key_template(
         name = name,
-        import_template = hsmtool_pk11_attrs({
-            "CKA_DERIVE": True,
-            "CKA_SENSITIVE": True,
-            "CKA_SIGN": True,
-            "CKA_TOKEN": True,
-            "CKA_EXTRACTABLE": False,
+        import_template = hsmtool_pk11_attrs(_PK11_ATTRS | {
+            "CKA_EXTRACTABLE": True,
         }),
         keygen_params = hsmtool_generic_keygen(
             label = name,
-            template = {
-                "CKA_DERIVE": True,
-                "CKA_SENSITIVE": True,
+            template = _PK11_ATTRS | {
                 "CKA_EXTRACTABLE": True,
-                "CKA_TOKEN": True,
             },
         ),
         type = "generic",

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -281,7 +281,7 @@ int main(int argc, char **argv) {
                     &num_pb_spi_frames,
                     /*skip_crc_check=*/true,
                     /*quiet=*/true,
-                    /*timeout_ms=*/5000);
+                    /*timeout_ms=*/10000);
   perso_blob_t perso_blob_from_dut = {0};
   if (PersoBlobFromJson(pb_spi_frames, num_pb_spi_frames,
                         &perso_blob_from_dut)) {

--- a/third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh
+++ b/third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh
@@ -19,7 +19,7 @@ fi
 
 OT_REPO_TOP=$1
 
-_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC8"
+_OT_REPO_BRANCH="Earlgrey-A2-Orchestrator-RC1"
 _PROVISIONING_REPO_TOP=$(pwd)
 _FPGAS=("hyper310" "cw340")
 _CP_SKUS=("emulation")

--- a/third_party/lowrisc/ot_bitstreams/cp_hyper310.bit
+++ b/third_party/lowrisc/ot_bitstreams/cp_hyper310.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ef1c870fefa1487f6cf7c3e4741eadc7e53491dafe5de910c5aab50e03ec9f7
+oid sha256:744cf7e2562ac5a430cdb1f4b96d9cfb4b133a8b590f5b5981bc94b808f15157
 size 15878032

--- a/third_party/lowrisc/ot_bitstreams/cp_hyper340.bit
+++ b/third_party/lowrisc/ot_bitstreams/cp_hyper340.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc7d2b66a1952c1d0d2011fe7d0a2269ba6661a77a8f5c6f2c87358ee2014d73
+oid sha256:7fc14b448d75f893935cefa8b0cab5648806cf9b282792fafc8ea775304ead15
 size 35843488

--- a/third_party/lowrisc/ot_fw/build-orch-zip.sh
+++ b/third_party/lowrisc/ot_fw/build-orch-zip.sh
@@ -19,7 +19,7 @@ fi
 
 OT_REPO_TOP=$1
 
-_OT_REPO_BRANCH="Earlgrey-A2-Provisioning-RC8"
+_OT_REPO_BRANCH="Earlgrey-A2-Orchestrator-RC1"
 _PROVISIONING_REPO_TOP=$(pwd)
 _ORCHESTRATOR_ZIP_PATH="bazel-bin/sw/host/provisioning/orchestrator/src/orchestrator.zip"
 

--- a/third_party/lowrisc/ot_fw/orchestrator.zip
+++ b/third_party/lowrisc/ot_fw/orchestrator.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0e457e4c56d08977dc692e9e82196a4d2242cf3f00db7eccdca98912eacbf226
-size 116537308
+oid sha256:f5420d905311b189449f00b6a14fdc787aa72a8dfd08186a22451a91f19e4aa2
+size 112425426

--- a/third_party/lowrisc/repos.bzl
+++ b/third_party/lowrisc/repos.bzl
@@ -7,12 +7,12 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 _MISC_LINTERS_VERSION = "20240820_01"
 _BAZEL_RELEASE_VERSION = "0.0.3"
-_BAZEL_SKYLIB_VERSION = "1.5.0"
+_BAZEL_SKYLIB_VERSION = "1.7.1"
 
 # When updating the lowrisc_opentitan repo, be sure to rebuild the builtstream
 # files too by following the instructions in
 # `third_party/lowrisc/README.md`.
-_OPENTITAN_VERSION = "Earlgrey-A2-Provisioning-RC8"
+_OPENTITAN_VERSION = "Earlgrey-A2-Orchestrator-RC1"
 
 def lowrisc_repos(misc_linters = None, bazel_release = None, bazel_skylib = None, opentitan = None):
     maybe(
@@ -35,7 +35,7 @@ def lowrisc_repos(misc_linters = None, bazel_release = None, bazel_skylib = None
         http_archive_or_local,
         name = "bazel_skylib",
         lcoal = bazel_skylib,
-        sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+        sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
         url = "https://github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(
             _BAZEL_SKYLIB_VERSION,
             _BAZEL_SKYLIB_VERSION,
@@ -45,7 +45,7 @@ def lowrisc_repos(misc_linters = None, bazel_release = None, bazel_skylib = None
         http_archive_or_local,
         local = opentitan,
         name = "lowrisc_opentitan",
-        sha256 = "bd5b804c39a04911f5408441747a9b1715a7a38c9ab7f18c01b4490771917d15",
+        sha256 = "7ea956946e7898cd85baadcf6ebb7263fb2ac82b65b3b6555a0bc3a1fdc311f4",
         strip_prefix = "opentitan-{}".format(_OPENTITAN_VERSION),
         url = "https://github.com/lowRISC/opentitan/archive/refs/tags/{}.tar.gz".format(_OPENTITAN_VERSION),
     )

--- a/util/airgapped_builds/prep-bazel-airgapped-build.sh
+++ b/util/airgapped_builds/prep-bazel-airgapped-build.sh
@@ -138,22 +138,20 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @remote_java_tools//... \
     @remote_java_tools_linux//... \
     @bindgen_clang_linux//... \
-    @rules_rust_bindgen__bindgen-0.65.1//... \
-    @rules_rust_bindgen__bindgen-cli-0.65.1//... \
-    @go_sdk//... \
-    @cmake-3.22.2-linux-x86_64//... \
+    @rules_rust_bindgen_deps__bindgen-0.71.1//... \
+    @rules_rust_bindgen__bindgen-cli-0.71.1//... \
     @gnumake_src//... \
     @go_sdk//... \
     @gcc_mxe_mingw32_files//... \
     @gcc_mxe_mingw64_files//... \
     @ninja_1.10.2_linux//... \
+    @cmake-3.22.2-linux-x86_64//... \
     @ot_python_wheels//... \
     @python3_toolchains//... \
     @remotejdk11_linux//... \
-    @rustfmt_nightly-2023-10-05__x86_64-unknown-linux-gnu_tools//... \
-    @rust_analyzer_1.71.1_tools//... \
-    @rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//... \
-    @rust_linux_x86_64__riscv32imc-unknown-none-elf__nightly_tools//...
+    @rustfmt_host_tools//... \
+    @rust_analyzer_host_tools//... \
+    @rust_host__x86_64-unknown-linux-gnu__nightly_tools//...
   cp -R "$(bazelisk info output_base)"/external/${BAZEL_PYTHON_WHEEL_REPO} \
     ${BAZEL_AIRGAPPED_DIR}/
   echo "Done."


### PR DESCRIPTION
There are two versions of the vendor-specific AES key wrapping mechanism:
    1. VendorThalesAesKw, and
    2. VendorThalesAesKwp.

The former is only capatible with keys that are multiples of 64-bits, while the latter is compatible across all key sizes ("p" stands for padded version). However, only the former (VendorThalesAesKw) is supported between specific version of the HSM we have deployed. Therefore we reconfigure the prod deployment to use this key wrapping/unwrapping mechanism.

Note, when using the VendorThalesAesKw mechanism, it is imparative the `CKA_VALUE_LEN` attribute is set when importing a wrapped secret into the HSM.

Note: this depends on #224; only review the last commit.