### PR TITLE
[spm] Add WASDisable config attribute

### DIFF
--- a/config/spm/sku_cr01.yml.tmpl
+++ b/config/spm/sku_cr01.yml.tmpl
@@ -25,6 +25,7 @@ attributes:
     SeedSecHi: eg-kdf-hisec-v0
     SeedSecLo: eg-kdf-losec-v0
     WASKeyLabel: eg-kdf-hisec-v0
+    WASDisable: false
     WrappingMechanism: ${OTPROV_WrappingMechanism}
     WrappingKeyLabel: sku-eg-rsa-rma-v0.pub
     SigningKey/Dice/v0: cr01-ica-dice-key-p256-v0.priv

--- a/config/spm/sku_pi01.yml.tmpl
+++ b/config/spm/sku_pi01.yml.tmpl
@@ -25,6 +25,7 @@ attributes:
     SeedSecHi: eg-kdf-hisec-v0
     SeedSecLo: eg-kdf-losec-v0
     WASKeyLabel: eg-kdf-hisec-v0
+    WASDisable: false
     WrappingMechanism: ${OTPROV_WrappingMechanism}
     WrappingKeyLabel: sku-eg-rsa-rma-v0.pub
     SigningKey/Dice/v0: pi01-ica-dice-key-p256-v0.priv

--- a/config/spm/sku_sival.yml.tmpl
+++ b/config/spm/sku_sival.yml.tmpl
@@ -22,6 +22,7 @@ attributes:
     SeedSecHi: eg-kdf-hisec-v0
     SeedSecLo: eg-kdf-losec-v0
     WASKeyLabel: eg-kdf-hisec-v0
+    WASDisable: false
     WrappingMechanism: ${OTPROV_WrappingMechanism}
     WrappingKeyLabel: sku-eg-rsa-rma-v0.pub
     SigningKey/Dice/v0: sival-dice-key-p256-v0.priv

--- a/config/spm/sku_ti01.yml.tmpl
+++ b/config/spm/sku_ti01.yml.tmpl
@@ -22,6 +22,7 @@ attributes:
     SeedSecHi: eg-kdf-hisec-v0
     SeedSecLo: eg-kdf-losec-v0
     WASKeyLabel: eg-kdf-hisec-v0
+    WASDisable: false
     WrappingMechanism: ${OTPROV_WrappingMechanism}
     WrappingKeyLabel: sku-eg-rsa-rma-v0.pub
     SigningKey/Dice/v0: ti01-ica-dice-key-p256-v0.priv

--- a/src/spm/services/se.go
+++ b/src/spm/services/se.go
@@ -93,6 +93,7 @@ type VerifyWASParams struct {
 	Sku         string
 	Seed        string
 	Signature   []byte
+	LogOnly     bool
 }
 
 // SE is an interface representing a secure element, which may be implemented

--- a/src/spm/services/se_pk11.go
+++ b/src/spm/services/se_pk11.go
@@ -568,6 +568,10 @@ func (h *HSM) VerifyWASSignature(params VerifyWASParams) error {
 
 	if !hmac.Equal(sig, params.Signature) {
 		log.Printf("SE.VerifyWASSignature: WAS signature check failed")
+		if params.LogOnly {
+			log.Printf("SE.VerifyWASSignature: WAS signature check failed (expected/got): \n%x,\n%x", params.Signature, sig)
+			return nil
+		}
 		return fmt.Errorf("failed to verify signature (expected/got): \n%x,\n%x", params.Signature, sig)
 	}
 	return nil

--- a/src/spm/services/skucfg.go
+++ b/src/spm/services/skucfg.go
@@ -18,6 +18,7 @@ const (
 	AttrNameWrappingKeyLabel           = "WrappingKeyLabel"
 	AttrNameWrappingMechanism          = "WrappingMechanism"
 	AttrNameWASKeyLabel                = "WASKeyLabel"
+	AttrNameWASDisable                 = "WASDisable"
 )
 
 // WrappingMechanism provides the wrapping method for symmetric keys.

--- a/src/spm/services/spm.go
+++ b/src/spm/services/spm.go
@@ -338,12 +338,19 @@ func (s *server) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequ
 		return nil, status.Errorf(codes.Internal, "could not get WAS key label: %s", err)
 	}
 
+	// The WASDisable attribute will be removed in a future version of the spm.
+	wasDisable, err := sku.Config.GetAttribute(skucfg.AttrNameWASDisable)
+	if err != nil {
+		wasDisable = "false"
+	}
+
 	err = sku.SeHandle.VerifyWASSignature(se.VerifyWASParams{
 		Signature:   request.Signature,
 		Data:        wasData,
 		Diversifier: request.Diversifier,
 		Sku:         request.Sku,
 		Seed:        wasLabel,
+		LogOnly:     wasDisable == "true",
 	})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "could not verify WAS signature: %s", err)


### PR DESCRIPTION
The `WASDisable` attribute can be set to `true` at the SKU configuration level to disable WAS checks. This is useful when running FT on DUTs that were not initialized with a WAS during CP stage.

This configuration option will be removed in a future release of the SPM.