### PR TITLE
[ate] Check ate_client pointer in DestroyClient call.

### DIFF
--- a/src/ate/ate_dll.cc
+++ b/src/ate/ate_dll.cc
@@ -217,10 +217,12 @@ DLLEXPORT void CreateClient(
 
 DLLEXPORT void DestroyClient(ate_client_ptr client) {
   DLOG(INFO) << "DestroyClient";
-  if (ate_client != nullptr) {
+  if (client != nullptr && client == ate_client) {
     AteClient *ate = reinterpret_cast<AteClient *>(client);
     delete ate;
     ate_client = nullptr;
+  } else {
+    LOG(ERROR) << "DestroyClient called with invalid client pointer";
   }
 }
 


### PR DESCRIPTION
Explicitly check the `ate_client` static pointer inside the ate_dll.cc module before casting and destroying the obfuscated pointer passed by the caller.