### PR TITLE
[hsm] Add show cli option to print asset attributes

### DIFF
--- a/rules/hsmtool.bzl
+++ b/rules/hsmtool.bzl
@@ -270,3 +270,15 @@ def hsmtool_object_destroy(label):
         "command": "object-destroy",
         "label": label,
     })
+
+def hsmtool_object_show(label):
+    """Creates a command to show an object in the HSM.
+
+    Args:
+        label: The label for the object.
+    """
+    return json.encode_indent({
+        "command": "object-show",
+        "label": label,
+        "redact": True,
+    })

--- a/rules/scripts/hsmtool_runner.template.sh
+++ b/rules/scripts/hsmtool_runner.template.sh
@@ -14,6 +14,7 @@ usage () {
   echo "  --hsm_pin <pin>              PIN for the token."
   echo "  --input_tar <input.tar.gz>   Path to the input tarball."
   echo "  --wipe                       Execute destroy commands before initializing the assets."
+  echo "  --show                       Execute show commands to dump the asset attributes."
   echo "  --output_tar <output.tar.gz> Path to the output tarball. Optional."
   echo "  --help                       Show this help message."
   exit 1
@@ -24,6 +25,7 @@ readonly OUTDIR_PUB="pub"
 
 readonly INIT_HJSON=@@INIT_HJSON@@
 readonly DESTROY_HJSON=@@DESTROY_HJSON@@
+readonly SHOW_HJSON=@@SHOW_HJSON@@
 readonly HSMTOOL_BIN_DEFAULT=@@HSMTOOL_BIN@@
 
 HSMTOOL_BIN="${HSMTOOL_BIN:-./${HSMTOOL_BIN_DEFAULT}}"
@@ -35,9 +37,9 @@ FLAGS_HSMTOOL_PIN=""
 FLAGS_IN_TAR=""
 FLAGS_OUT_TAR=""
 FLAGS_WIPE=false
-FLAGS_CA_CERTGEN_ONLY=false
+FLAGS_SHOW=false
 
-LONGOPTS="hsm_module:,token:,softhsm_config:,hsm_pin:,input_tar:,output_tar:,wipe,help"
+LONGOPTS="hsm_module:,token:,softhsm_config:,hsm_pin:,input_tar:,output_tar:,wipe,show,help"
 OPTS=$(getopt -o "" --long "${LONGOPTS}" -n "$0" -- "$@")
 
 if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
@@ -72,6 +74,10 @@ while true; do
       ;;
     --wipe)
       FLAGS_WIPE=true
+      shift
+      ;;
+    --show)
+      FLAGS_SHOW=true
       shift
       ;;
     --help)
@@ -157,6 +163,13 @@ hsmtool_args=(
   "${HSMTOOL_BIN}"
   --logging=info
 )
+
+# If the --show flag is set, run the show command and exit.
+if [[ "${FLAGS_SHOW}" == true ]]; then
+  echo "Running hsmtool show (--show) operation."
+  env "${hsmtool_vars[@]}" "${hsmtool_args[@]}" exec "${SHOW_HJSON}"
+  exit 0
+fi
 
 if [[ "${FLAGS_WIPE}" == true ]]; then
   echo "Running hsmtool destroy (--wipe) operation."

--- a/util/containers/deploy_test_k8_pod.sh
+++ b/util/containers/deploy_test_k8_pod.sh
@@ -62,7 +62,12 @@ if [ -f "${TOKEN_INIT_SCRIPT}" ]; then
     echo " -- Step 6: Generate the root certificate."
     ${TOKEN_INIT_SCRIPT} --action "offline-ca-root-certgen"
     echo " -- Step 7: Endorse the CSRs for all SKUs."
-    ${TOKEN_INIT_SCRIPT} --action "offline-sku-certgen" --sku sival --sku cr01 --sku pi01 --sku ti01 
+    ${TOKEN_INIT_SCRIPT} --action "offline-sku-certgen" --sku sival --sku cr01 --sku pi01 --sku ti01
+
+    echo "Print object attributes ..."
+    ${TOKEN_INIT_SCRIPT} --action "spm-init" --show
+    ${TOKEN_INIT_SCRIPT} --action "offline-common-init" --show
+    ${TOKEN_INIT_SCRIPT} --action "spm-sku-init" --sku sival --sku cr01 --sku pi01 --sku ti01 --show
 fi
 
 echo "Provisioning services launched."


### PR DESCRIPTION
This commit introduces a `--show` command-line option to the `config/token_init.sh` script. This feature provides operators with a mechanism to audit the attributes of cryptographic assets generated or imported into both the Offline and SPM HSMs.

The main changes are:
- Refactored `config/token_init.sh` to improve maintainability by modularizing actions into separate functions and using a `case` statement for control flow.
- Updated `docs/hsm.md` with a new "Auditing HSM State" section, providing detailed instructions and examples for operators on how to use the `--show` flag to verify key attributes.
- Modified `util/containers/deploy_test_k8_pod.sh` to include calls to the new audit commands, demonstrating their usage and verifying the token initialization process in the test environment.