### PR TITLE
[ate] Explicitly create PA stub.

### DIFF
--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -469,8 +469,9 @@ typedef struct register_device_request {
  *
  * @param client A pointer (an `ate_client_ptr`) to the created client instance.
  * @param options The secure channel attributes.
+ * @return The result of the operation.
  */
-DLLEXPORT void CreateClient(ate_client_ptr* client, client_options_t* options);
+DLLEXPORT int CreateClient(ate_client_ptr* client, client_options_t* options);
 
 /**
  * Destroys an AteClient instance.

--- a/src/ate/ate_client.cc
+++ b/src/ate/ate_client.cc
@@ -93,7 +93,8 @@ std::unique_ptr<AteClient> AteClient::Create(AteClient::Options options) {
   }
   // 2. create the grpc channel between the client and the targeted server
   auto channel = grpc::CreateChannel(options.pa_socket, credentials);
-  auto ate = absl::make_unique<AteClient>(channel);
+  auto ate = absl::make_unique<AteClient>(
+      ProvisioningApplianceService::NewStub(channel));
 
   return ate;
 }

--- a/src/ate/ate_dll.cc
+++ b/src/ate/ate_dll.cc
@@ -169,7 +169,7 @@ absl::Status LoadPEMResources(AteClient::Options *options,
 
 static ate_client_ptr ate_client = nullptr;
 
-DLLEXPORT void CreateClient(
+DLLEXPORT int CreateClient(
     ate_client_ptr *client,    // Out: the created client instance
     client_options_t *options  // In: secure channel attributes
 ) {
@@ -186,6 +186,7 @@ DLLEXPORT void CreateClient(
                          options->pem_root_certs);
     if (!s.ok()) {
       LOG(ERROR) << "Failed to load needed PEM resources";
+      return static_cast<int>(s.code());
     }
   }
 
@@ -212,6 +213,7 @@ DLLEXPORT void CreateClient(
   *client = ate_client;
 
   LOG(INFO) << "debug info: returned from CreateClient with ate = " << *client;
+  return 0;
 }
 
 DLLEXPORT void DestroyClient(ate_client_ptr client) {

--- a/src/ate/test_programs/cp.cc
+++ b/src/ate/test_programs/cp.cc
@@ -87,8 +87,7 @@ absl::StatusOr<ate_client_ptr> AteClientNew(void) {
   }
 
   ate_client_ptr ate_client;
-  CreateClient(&ate_client, &options);
-  if (ate_client == nullptr) {
+  if (CreateClient(&ate_client, &options) != 0) {
     return absl::InternalError("Failed to create ATE client.");
   }
   return ate_client;

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -90,7 +90,9 @@ absl::StatusOr<ate_client_ptr> AteClientNew(void) {
   }
 
   ate_client_ptr ate_client;
-  CreateClient(&ate_client, &options);
+  if (CreateClient(&ate_client, &options) != 0) {
+    return absl::InternalError("Failed to create ATE client.");
+  }
   if (ate_client == nullptr) {
     return absl::InternalError("Failed to create ATE client.");
   }


### PR DESCRIPTION
- Explicitly call PA stub constructor in `AteClient::Create` call.
- Add return error code to ATE DLL `CreateClient` API to improve error handling.