### PR TITLE
[spm] Introduce UDS/EXT aliases for certificate key labels

### DIFF
--- a/src/ate/ate_dll.cc
+++ b/src/ate/ate_dll.cc
@@ -515,11 +515,7 @@ DLLEXPORT int EndorseCerts(ate_client_ptr client, const char *sku,
       return static_cast<int>(absl::StatusCode::kInvalidArgument);
     }
     std::string cert_label(req_params.key_label, req_params.key_label_size);
-    if (cert_label == "UDS") {
-      signing_params->set_key_label("SigningKey/Dice/v0");
-    } else {
-      signing_params->set_key_label("SigningKey/Ext/v0");
-    }
+    signing_params->set_key_label(cert_label);
 
     // Only ECDSA keys are supported at this time.
     auto key = signing_params->mutable_ecdsa_params();

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -239,8 +239,11 @@ int main(int argc, char **argv) {
   }
 
   // Generate CA subject keys.
-  constexpr size_t kNumIcas = 1;
-  const char *kIcaCertLabels[] = {"SigningKey/Dice/v0"};
+  constexpr size_t kNumIcas = 2;
+  const char *kIcaCertLabels[] = {
+      "UDS",
+      "EXT",
+  };
   ca_subject_key_t key_ids[kNumIcas];
   if (GetCaSubjectKeys(ate_client, absl::GetFlag(FLAGS_sku).c_str(),
                        /*count=*/kNumIcas, kIcaCertLabels, key_ids) != 0) {
@@ -248,9 +251,9 @@ int main(int argc, char **argv) {
     return -1;
   }
   const ca_subject_key_t *kDiceCaSk = &key_ids[0];
-  const ca_subject_key_t kExtCaSk = {0};
+  const ca_subject_key_t *kExtCaSk = &key_ids[1];
   dut_spi_frame_t ca_key_ids_spi_frame;
-  if (CaSubjectKeysToJson(kDiceCaSk, &kExtCaSk, &ca_key_ids_spi_frame) != 0) {
+  if (CaSubjectKeysToJson(kDiceCaSk, kExtCaSk, &ca_key_ids_spi_frame) != 0) {
     LOG(ERROR) << "CaSubjectKeysToJson failed.";
     return -1;
   }

--- a/src/pa/loadtest.go
+++ b/src/pa/loadtest.go
@@ -185,7 +185,7 @@ func testOTGetCaSubjectKeys(ctx context.Context, numCalls int, skuName string, c
 
 	request := &pbp.GetCaSubjectKeysRequest{
 		Sku:        skuName,
-		CertLabels: []string{"SigningKey/Dice/v0"},
+		CertLabels: []string{"UDS"},
 	}
 
 	// Send request to PA.
@@ -214,7 +214,7 @@ func testOTEndorseCerts(ctx context.Context, numCalls int, skuName string, c *cl
 		Bundles: []*pbp.EndorseCertBundle{
 			{
 				KeyParams: &pbc.SigningKeyParams{
-					KeyLabel: "SigningKey/Dice/v0",
+					KeyLabel: "UDS",
 					Key: &pbc.SigningKeyParams_EcdsaParams{
 						EcdsaParams: &pbe.EcdsaParams{
 							HashType: pbcommon.HashType_HASH_TYPE_SHA256,
@@ -425,7 +425,7 @@ func main() {
 			ConfigDir:    *configDir,
 			HSMSOLibPath: *hsmSOLibPath,
 		}
-		certLabels := []string{"SigningKey/Dice/v0"}
+		certLabels := []string{"UDS"}
 		tbsCerts, _, err := tbsgen.BuildTestTBSCerts(opts, skuName, certLabels)
 		if err != nil {
 			log.Fatalf("failed to generate TBS certificates for SKU %q: %v", skuName, err)
@@ -446,7 +446,7 @@ func main() {
 			},
 			{
 				testName: "OT:EndorseCerts",
-				testFunc: NewEndorseCertTest(tbsCerts["SigningKey/Dice/v0"]),
+				testFunc: NewEndorseCertTest(tbsCerts["UDS"]),
 			},
 			{
 				testName: "OT:RegisterDevice",

--- a/src/spm/services/testutils/tbsgen.go
+++ b/src/spm/services/testutils/tbsgen.go
@@ -110,7 +110,13 @@ func BuildTestTBSCerts(opts skumgr.Options, skuName string, certLabels []string)
 
 	tbsCerts := make(map[string][]byte)
 	pubKeys := make(map[string]crypto.PublicKey)
-	for _, label := range certLabels {
+	for _, kl := range certLabels {
+		var label string
+		if kl == "UDS" {
+			label = "SigningKey/Dice/v0"
+		} else {
+			label = "SigningKey/Ext/v0"
+		}
 		issuerCert, ok := sku.Certs[label]
 		if !ok {
 			return nil, nil, fmt.Errorf("issuer certificate %q not found for SKU %q", label, skuName)
@@ -125,8 +131,8 @@ func BuildTestTBSCerts(opts skumgr.Options, skuName string, certLabels []string)
 			if err != nil {
 				return err
 			}
-			tbsCerts[label] = tbs
-			pubKeys[label] = pub
+			tbsCerts[kl] = tbs
+			pubKeys[kl] = pub
 			return nil
 		}); err != nil {
 			return nil, nil, fmt.Errorf("failed to generate TBS certificate: %w", err)


### PR DESCRIPTION
This change introduces shorter, more stable aliases for certificate key labels used in the provisioning process. The aliases "UDS" (Unique Device Secret) and "EXT" (Extension) are now used by client applications.

The SPM service is responsible for mapping these aliases to the underlying key labels ("SigningKey/Dice/v0" and "SigningKey/Ext/v0"). This provides a layer of abstraction, making the client-side implementation cleaner and less coupled to the internal naming scheme.

Key changes:
- `spm`: Translates "UDS" and "EXT" labels to their full counterparts during key retrieval and certificate endorsement. It now gracefully handles missing certificates by returning an empty subject key.
- `ate`: The client library now accepts the key label directly from the caller instead of hardcoding a mapping.
- `pa/loadtest`, `ate/test_programs/ft`: Updated to use the new "UDS" and "EXT" aliases.