### PR TITLE
[ate] extract personalization FW hash from perso blob

### DIFF
--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -685,7 +685,8 @@ DLLEXPORT int PersoBlobFromJson(const dut_spi_frame_t* frames,
  *
  * @param blob The personalization blob to unpack.
  * @param[out] device_id The extracted device ID.
- * @param[out] hmac The HMAC over the TBS certificates.
+ * @param[out] signature The HMAC signature over the TBS certificates.
+ * @param[out] perso_fw_hash The hash of the personalization firmware.
  * @param[out] x509_tbs_certs Array of X.509 TBS certs.
  * @param[out] tbs_cert_count The number of TBS certs found. Initialized
  * to the size of `x509_tbs_certs`.
@@ -699,9 +700,10 @@ DLLEXPORT int PersoBlobFromJson(const dut_spi_frame_t* frames,
  */
 DLLEXPORT int UnpackPersoBlob(
     const perso_blob_t* blob, device_id_bytes_t* device_id,
-    endorse_cert_signature_t* signature, endorse_cert_request_t* x509_tbs_certs,
-    size_t* tbs_cert_count, endorse_cert_response_t* x509_certs,
-    size_t* cert_count, seed_t* seeds, size_t* seed_count);
+    endorse_cert_signature_t* signature, perso_fw_sha256_hash_t* perso_fw_hash,
+    endorse_cert_request_t* x509_tbs_certs, size_t* tbs_cert_count,
+    endorse_cert_response_t* x509_certs, size_t* cert_count, seed_t* seeds,
+    size_t* seed_count);
 
 /**
  * Pack a personalization blob from the endorsed certificates.

--- a/src/ate/ate_perso_blob.cc
+++ b/src/ate/ate_perso_blob.cc
@@ -273,13 +273,14 @@ int PackSeedTlvObject(const seed_t* seed, perso_blob_t* blob) {
 
 DLLEXPORT int UnpackPersoBlob(
     const perso_blob_t* blob, device_id_bytes_t* device_id,
-    endorse_cert_signature_t* signature, endorse_cert_request_t* x509_tbs_certs,
-    size_t* tbs_cert_count, endorse_cert_response_t* x509_certs,
-    size_t* cert_count, seed_t* seeds, size_t* seed_count) {
+    endorse_cert_signature_t* signature, perso_fw_sha256_hash_t* perso_fw_hash,
+    endorse_cert_request_t* x509_tbs_certs, size_t* tbs_cert_count,
+    endorse_cert_response_t* x509_certs, size_t* cert_count, seed_t* seeds,
+    size_t* seed_count) {
   if (device_id == nullptr || signature == nullptr ||
-      x509_tbs_certs == nullptr || tbs_cert_count == nullptr ||
-      x509_certs == nullptr || cert_count == nullptr || seeds == nullptr ||
-      seed_count == nullptr) {
+      perso_fw_hash == nullptr || x509_tbs_certs == nullptr ||
+      tbs_cert_count == nullptr || x509_certs == nullptr ||
+      cert_count == nullptr || seeds == nullptr || seed_count == nullptr) {
     LOG(ERROR) << "Invalid output parameters";
     return -1;
   }
@@ -290,7 +291,8 @@ DLLEXPORT int UnpackPersoBlob(
   }
 
   memset(device_id->raw, 0, sizeof(device_id_bytes_t));
-  memset(signature->raw, 0, sizeof(signature->raw));
+  memset(signature->raw, 0, sizeof(endorse_cert_signature_t));
+  memset(perso_fw_hash->raw, 0, sizeof(perso_fw_sha256_hash_t));
 
   size_t max_tbs_cert_count = *tbs_cert_count;
   *tbs_cert_count = 0;
@@ -404,6 +406,20 @@ DLLEXPORT int UnpackPersoBlob(
         memcpy(seeds[*seed_count].raw, buf + sizeof(perso_tlv_object_header_t),
                seeds[*seed_count].size);
         (*seed_count)++;
+        break;
+      }
+
+      case kPersoObjectTypePersoSha256Hash: {
+        if (obj_size != sizeof(perso_fw_sha256_hash_t) +
+                            sizeof(perso_tlv_object_header_t)) {
+          LOG(ERROR) << "Invalid size for perso firmware hash object: "
+                     << obj_size << ", expected: "
+                     << (sizeof(perso_fw_sha256_hash_t) +
+                         sizeof(perso_tlv_object_header_t));
+          return -1;
+        }
+        memcpy(perso_fw_hash->raw, buf + sizeof(perso_tlv_object_header_t),
+               sizeof(perso_fw_hash->raw));
         break;
       }
     }

--- a/src/ate/ate_perso_blob.h
+++ b/src/ate/ate_perso_blob.h
@@ -24,6 +24,7 @@ typedef enum perso_tlv_object_type {
   kPersoObjectTypeWasTbsHmac = 4,
   kPersoObjectTypeDeviceId = 5,
   kPersoObjectTypeGenericSeed = 6,
+  kPersoObjectTypePersoSha256Hash = 7,
 } perso_tlv_object_type_t;
 
 // Header types

--- a/src/ate/ate_perso_blob_test.cc
+++ b/src/ate/ate_perso_blob_test.cc
@@ -114,6 +114,7 @@ TEST_F(AtePersoBlobTest, UnpackPersoBlobSuccess) {
 
   device_id_bytes_t device_id;
   endorse_cert_signature_t signature;
+  perso_fw_sha256_hash_t perso_fw_hash = {.raw = {0}};
   size_t tbs_cert_count = 10;
   size_t cert_count = 10;
   endorse_cert_request_t x509_tbs_certs[10];
@@ -121,9 +122,9 @@ TEST_F(AtePersoBlobTest, UnpackPersoBlobSuccess) {
   seed_t seeds[10];
   size_t seed_count = 10;
 
-  EXPECT_EQ(UnpackPersoBlob(&test_blob, &device_id, &signature, x509_tbs_certs,
-                            &tbs_cert_count, x509_certs, &cert_count, seeds,
-                            &seed_count),
+  EXPECT_EQ(UnpackPersoBlob(&test_blob, &device_id, &signature, &perso_fw_hash,
+                            x509_tbs_certs, &tbs_cert_count, x509_certs,
+                            &cert_count, seeds, &seed_count),
             0);
 
   EXPECT_EQ(tbs_cert_count, 1);
@@ -146,6 +147,7 @@ TEST_F(AtePersoBlobTest, UnpackPersoBlobNullInputs) {
 
   device_id_bytes_t device_id;
   endorse_cert_signature_t signature;
+  perso_fw_sha256_hash_t perso_fw_hash = {.raw = {0}};
   size_t tbs_cert_count = 10;
   size_t cert_count = 10;
   endorse_cert_request_t x509_tbs_certs[10];
@@ -154,19 +156,19 @@ TEST_F(AtePersoBlobTest, UnpackPersoBlobNullInputs) {
   size_t seed_count = 10;
 
   // Test null blob
-  EXPECT_EQ(UnpackPersoBlob(nullptr, &device_id, &signature, x509_tbs_certs,
-                            &tbs_cert_count, x509_certs, &cert_count, seeds,
-                            &seed_count),
+  EXPECT_EQ(UnpackPersoBlob(nullptr, &device_id, &signature, &perso_fw_hash,
+                            x509_tbs_certs, &tbs_cert_count, x509_certs,
+                            &cert_count, seeds, &seed_count),
             -1);
 
   // Test null output parameters
-  EXPECT_EQ(UnpackPersoBlob(&test_blob, nullptr, &signature, x509_tbs_certs,
-                            &tbs_cert_count, x509_certs, &cert_count, seeds,
-                            &seed_count),
+  EXPECT_EQ(UnpackPersoBlob(&test_blob, nullptr, &signature, &perso_fw_hash,
+                            x509_tbs_certs, &tbs_cert_count, x509_certs,
+                            &cert_count, seeds, &seed_count),
             -1);
-  EXPECT_EQ(UnpackPersoBlob(&test_blob, &device_id, nullptr, x509_tbs_certs,
-                            &tbs_cert_count, x509_certs, &cert_count, seeds,
-                            &seed_count),
+  EXPECT_EQ(UnpackPersoBlob(&test_blob, &device_id, nullptr, &perso_fw_hash,
+                            x509_tbs_certs, &tbs_cert_count, x509_certs,
+                            &cert_count, seeds, &seed_count),
             -1);
 }
 

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -299,6 +299,7 @@ int main(int argc, char **argv) {
   // the perso blob.
   device_id_bytes_t device_id;
   endorse_cert_signature_t tbs_was_hmac = {.raw = {0}};
+  perso_fw_sha256_hash_t perso_fw_hash = {.raw = {0}};
   constexpr size_t kMaxNumCerts = 10;
   size_t num_tbs_certs = kMaxNumCerts;
   endorse_cert_request_t x509_tbs_certs[kMaxNumCerts];
@@ -308,8 +309,8 @@ int main(int argc, char **argv) {
   seed_t seeds[kMaxSeeds];
   size_t num_seeds = kMaxSeeds;
   if (UnpackPersoBlob(&perso_blob_from_dut, &device_id, &tbs_was_hmac,
-                      x509_tbs_certs, &num_tbs_certs, x509_certs, &num_certs,
-                      seeds, &num_seeds) != 0) {
+                      &perso_fw_hash, x509_tbs_certs, &num_tbs_certs,
+                      x509_certs, &num_certs, seeds, &num_seeds) != 0) {
     LOG(ERROR) << "Failed to unpack the perso blob from the DUT.";
     return -1;
   }
@@ -386,8 +387,6 @@ int main(int argc, char **argv) {
     LOG(ERROR) << "PackRegistryPersoTlvData failed.";
     return -1;
   }
-  // TODO(timothytrippel): extract the perso FW hash
-  perso_fw_sha256_hash_t perso_fw_hash = {.raw = {0}};
   // TODO(timothytrippel): add helper function to translate kDifLcCtrlStateProd
   // to kDeviceLifeCycleProd
   if (RegisterDevice(ate_client, absl::GetFlag(FLAGS_sku).c_str(),


### PR DESCRIPTION
The personalization firmware includes the hash of itself in the perso blob it sends to the host. We update the ATE DLL to parse this data and write it to the registry along with the other DUT data.

Note: this depends on #237; only review the last commit.