### PR TITLE
[ate]: Remove client singleton and support multiple instances

### DIFF
--- a/config/containers/provapp.yml.tmpl
+++ b/config/containers/provapp.yml.tmpl
@@ -12,7 +12,7 @@ spec:
   hostNetwork: true
   containers:
   # Configuration for the `paserver` container.
-  - name: paserver
+  - name: paserver-1
     args:
     - --enable_tls=true
     - --service_key=/var/lib/opentitan/config/certs/out/pa-service-key.pem
@@ -27,6 +27,54 @@ spec:
     resources: {}
     ports:
       - containerPort: ${OTPROV_PORT_PA}
+    securityContext:
+      capabilities:
+        drop:
+        - CAP_MKNOD
+        - CAP_NET_RAW
+        - CAP_AUDIT_WRITE
+    volumeMounts:
+    - mountPath: /var/lib/opentitan/config
+      name: var-lib-opentitan-spm-config-0
+  - name: paserver-2
+    args:
+    - --enable_tls=true
+    - --service_key=/var/lib/opentitan/config/certs/out/pa-service-key.pem
+    - --service_cert=/var/lib/opentitan/config/certs/out/pa-service-cert.pem
+    - --ca_root_certs=/var/lib/opentitan/config/certs/out/ca-cert.pem
+    - --port=${OTPROV_PORT_PA_2}
+    - --spm_address=${OTPROV_DNS_SPM}:${OTPROV_PORT_SPM}
+    - --enable_registry
+    - --registry_address=${OTPROV_DNS_PB}:${OTPROV_PORT_PB}
+    # TODO: Update label to point to specific release version.
+    image: localhost/pa_server:latest
+    resources: {}
+    ports:
+      - containerPort: ${OTPROV_PORT_PA_2}
+    securityContext:
+      capabilities:
+        drop:
+        - CAP_MKNOD
+        - CAP_NET_RAW
+        - CAP_AUDIT_WRITE
+    volumeMounts:
+    - mountPath: /var/lib/opentitan/config
+      name: var-lib-opentitan-spm-config-0
+  - name: paserver-3
+    args:
+    - --enable_tls=true
+    - --service_key=/var/lib/opentitan/config/certs/out/pa-service-key.pem
+    - --service_cert=/var/lib/opentitan/config/certs/out/pa-service-cert.pem
+    - --ca_root_certs=/var/lib/opentitan/config/certs/out/ca-cert.pem
+    - --port=5005
+    - --spm_address=${OTPROV_DNS_SPM}:${OTPROV_PORT_SPM}
+    - --enable_registry
+    - --registry_address=${OTPROV_DNS_PB}:${OTPROV_PORT_PB}
+    # TODO: Update label to point to specific release version.
+    image: localhost/pa_server:latest
+    resources: {}
+    ports:
+      - containerPort: 5005
     securityContext:
       capabilities:
         drop:

--- a/config/env/dev/spm.env
+++ b/config/env/dev/spm.env
@@ -18,9 +18,11 @@ export OTPROV_IP_ATE="${OTPROV_IP_ATE:-127.0.0.1}"
 export OTPROV_IP_REG="${OTPROV_IP_REG:-127.0.0.1}"
 
 export OTPROV_PORT_SPM="${OTPROV_PORT_SPM:-5000}"
-export OTPROV_PORT_PA="${OTPROV_PORT_PA:-5001}"
-export OTPROV_PORT_PB="${OTPROV_PORT_PB:-5002}"
-export OTPROV_PORT_REG="${OTPROV_PORT_REG:-5003}"
+export OTPROV_PORT_PB="${OTPROV_PORT_PB:-5001}"
+export OTPROV_PORT_REG="${OTPROV_PORT_REG:-5002}"
+
+export OTPROV_PORT_PA="${OTPROV_PORT_PA:-5003}"
+export OTPROV_PORT_PA_2="${OTPROV_PORT_PA_2:-5004}"
 
 # The following variables are used for test purposes and are synchronized with
 # the ${REPO_TOP}/config/softhsm/init.sh script.

--- a/config/env/prod/spm.env
+++ b/config/env/prod/spm.env
@@ -16,8 +16,10 @@ export OTPROV_IP_PB="${OTPROV_IP_PB:-127.0.0.1}"
 export OTPROV_IP_ATE="${OTPROV_IP_ATE:-127.0.0.1}"
 
 export OTPROV_PORT_SPM="${OTPROV_PORT_SPM:-5000}"
-export OTPROV_PORT_PA="${OTPROV_PORT_PA:-5001}"
-export OTPROV_PORT_PB="${OTPROV_PORT_PB:-5002}"
+export OTPROV_PORT_PB="${OTPROV_PORT_PB:-5001}"
+
+export OTPROV_PORT_PA="${OTPROV_PORT_PA:-5003}"
+export OTPROV_PORT_PA_2="${OTPROV_PORT_PA_2:-5004}"
 
 # The following variables are used for test purposes.
 export SPM_HSM_PIN_ADMIN="${SPM_HSM_PIN_ADMIN:-cryptoki}"

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -82,7 +82,7 @@ for OTSKU in "${FPGA_SKUS[@]}"; do
     --client_cert="${DEPLOYMENT_DIR}/certs/out/ate-client-cert.pem" \
     --client_key="${DEPLOYMENT_DIR}/certs/out/ate-client-key.pem" \
     --ca_root_certs=${DEPLOYMENT_DIR}/certs/out/ca-cert.pem \
-    --pa_target="ipv4:${OTPROV_IP_PA}:${OTPROV_PORT_PA}" \
+    --pa_target="ipv4:${OTPROV_IP_PA}:${OTPROV_PORT_PA_2}" \
     --sku="${OTSKU}" \
     --sku_auth_pw="test_password" \
     --fpga="${FPGA}" \

--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -474,8 +474,8 @@ typedef struct register_device_request {
 /**
  * Creates an AteClient instance.
  *
- * The client instance should be created once and reused many times over a
- * long running session.
+ * Each call to this function creates a new client instance. The caller is
+ * responsible for destroying the client instance by calling `DestroyClient`.
  *
  * @param client A pointer (an `ate_client_ptr`) to the created client instance.
  * @param options The secure channel attributes.

--- a/src/ate/ate_client.cc
+++ b/src/ate/ate_client.cc
@@ -98,8 +98,7 @@ std::unique_ptr<AteClient> AteClient::Create(AteClient::Options options) {
   }
   auto channel =
       grpc::CreateCustomChannel(options.pa_target, credentials, args);
-  auto ate = absl::make_unique<AteClient>(
-      ProvisioningApplianceService::NewStub(channel));
+  auto ate = absl::make_unique<AteClient>(channel);
 
   return ate;
 }


### PR DESCRIPTION
This commit refactors the ATE client library to remove the singleton pattern to enable downstream users to manage multiple client instances.

Previously, `CreateClient` would always return the same client instance, making it impossible to connect to multiple, distinct provisioning servers from a single application. The singleton implementation also had a potential race condition in the `CreateClient` call.

This change introduces the following:

- The `ate_dll.cc` no longer uses a static client. Each call to `CreateClient` now returns a new, independent client instance.
- Callers are now responsible for managing the lifecycle of each client and must call `DestroyClient` for every instance created.
- The documentation in `ate_api.h` and `ate.md` has been updated to reflect the new factory pattern, and a guide has been added for managing multiple client instances.