### PR TITLE
[spm]: Update EndorseData public key format

### DIFF
--- a/src/pa/services/pa.go
+++ b/src/pa/services/pa.go
@@ -170,8 +170,8 @@ func (s *server) RegisterDevice(ctx context.Context, request *pap.RegistrationRe
 			KeyLabel: "SigningKey/Identity/v0",
 			Key: &certpb.SigningKeyParams_EcdsaParams{
 				EcdsaParams: &ecdsapb.EcdsaParams{
-					HashType: commonpb.HashType_HASH_TYPE_SHA384,
-					Curve:    commonpb.EllipticCurveType_ELLIPTIC_CURVE_TYPE_NIST_P384,
+					HashType: commonpb.HashType_HASH_TYPE_SHA256,
+					Curve:    commonpb.EllipticCurveType_ELLIPTIC_CURVE_TYPE_NIST_P256,
 					Encoding: ecdsapb.EcdsaSignatureEncoding_ECDSA_SIGNATURE_ENCODING_DER,
 				},
 			},

--- a/src/spm/services/se_pk11.go
+++ b/src/spm/services/se_pk11.go
@@ -7,7 +7,6 @@ package se
 
 import (
 	"crypto"
-	"crypto/ecdsa"
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/x509"
@@ -498,11 +497,7 @@ func (h *HSM) EndorseData(data []byte, params EndorseCertParams) ([]byte, []byte
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to export public key from SE: %v", err)
 	}
-	var ecdsaPubKey struct{ X, Y *big.Int }
-	ecdsaPubKey.X, ecdsaPubKey.Y = new(big.Int), new(big.Int)
-	ecdsaPubKey.X.Set(publicKey.(*ecdsa.PublicKey).X)
-	ecdsaPubKey.Y.Set(publicKey.(*ecdsa.PublicKey).Y)
-	asn1EcdsaPublicKey, err := asn1.Marshal(ecdsaPubKey)
+	asn1EcdsaPublicKey, err := x509.MarshalPKIXPublicKey(publicKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal public key: %v", err)
 	}

--- a/src/spm/services/se_pk11_test.go
+++ b/src/spm/services/se_pk11_test.go
@@ -334,16 +334,16 @@ func TestEndorseData(t *testing.T) {
 	})
 	ts.Check(t, err)
 
-	// Check public keys match.
-	var pubKey struct{ X, Y *big.Int }
-	_, err = asn1.Unmarshal(asn1PubKey, &pubKey)
+	// Check public key.
+	pub, err := x509.ParsePKIXPublicKey(asn1PubKey)
+	ts.Check(t, err)
+	pubKey := pub.(*ecdsa.PublicKey)
 	if pubKey.X.Cmp(idPublicKey.X) != 0 {
 		t.Fatal("pubkey (X) exported does not match one in HSM")
 	}
 	if pubKey.Y.Cmp(idPublicKey.Y) != 0 {
 		t.Fatal("pubkey (Y) exported does not match one in HSM")
 	}
-
 	// Verify signatures.
 	log.Printf("Verifying data signature")
 	dataHash := sha256.Sum256(data)


### PR DESCRIPTION
The `se_pk11` package was returning a raw ECDSA public key, which caused parsing failures in the SPM. This change updates the implementation to return the public key in the standard `SubjectPublicKeyInfo` format by using `x509.MarshalPKIXPublicKey`.

This fixes ASN.1 parsing errors and ensures interoperability. The updated key format is now correctly handled when endorsing data and generating certificates.

This change also updates the EndorseData parameters to use P256-SHA256 instead of P384-SHA384. This is to match the SPM identity key configuration used in the HSMs.