### PR TITLE
[spm]: Add device data verification during registration

### DIFF
--- a/config/spm/sku_cr01.yml.tmpl
+++ b/config/spm/sku_cr01.yml.tmpl
@@ -31,3 +31,4 @@ attributes:
     SigningKey/Dice/v0: cr01-ica-dice-key-p256-v0.priv
     SigningKey/Ext/v0: cr01-ica-ext-key-p256-v0.priv
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
+    CertChainDiceLeaf: CDI_1

--- a/config/spm/sku_pi01.yml.tmpl
+++ b/config/spm/sku_pi01.yml.tmpl
@@ -31,3 +31,4 @@ attributes:
     SigningKey/Dice/v0: pi01-ica-dice-key-p256-v0.priv
     SigningKey/Ext/v0: pi01-ica-ext-key-p256-v0.priv
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
+    CertChainDiceLeaf: UDS

--- a/config/spm/sku_sival.yml.tmpl
+++ b/config/spm/sku_sival.yml.tmpl
@@ -27,3 +27,4 @@ attributes:
     WrappingKeyLabel: sku-eg-rsa-rma-v0.pub
     SigningKey/Dice/v0: sival-dice-key-p256-v0.priv
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
+    CertChainDiceLeaf: CDI_1

--- a/config/spm/sku_ti01.yml.tmpl
+++ b/config/spm/sku_ti01.yml.tmpl
@@ -27,3 +27,4 @@ attributes:
     WrappingKeyLabel: sku-eg-rsa-rma-v0.pub
     SigningKey/Dice/v0: ti01-ica-dice-key-p256-v0.priv
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
+    CertChainDiceLeaf: CDI_1

--- a/src/ate/BUILD.bazel
+++ b/src/ate/BUILD.bazel
@@ -118,6 +118,7 @@ pkg_win(
     name = "windows",
     srcs = [
         "ate_api.h",
+        "ate_perso_blob.h",
         ":ate",
     ],
     platform = "@crt//platforms/x86_32:win32",

--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -8,7 +8,6 @@ syntax = "proto3";
 package pa;
 
 import "src/proto/crypto/cert.proto";
-import "src/proto/crypto/wrap.proto";
 import "src/proto/device_id.proto";
 
 option go_package = "pa_go_pb";

--- a/src/pa/services/pa.go
+++ b/src/pa/services/pa.go
@@ -163,6 +163,13 @@ func (s *server) RegisterDevice(ctx context.Context, request *pap.RegistrationRe
 		return nil, fmt.Errorf("failed to marshal device data: %v", err)
 	}
 
+	// Verify the device data.
+	if _, err := s.spmClient.VerifyDeviceData(ctx, &pbs.VerifyDeviceDataRequest{
+		DeviceData: request.DeviceData,
+	}); err != nil {
+		return nil, status.Errorf(codes.Internal, "SPM-VerifyDeviceData returned error: %v", err)
+	}
+	
 	// Endorse data payload.
 	edRequest := &pbs.EndorseDataRequest{
 		Sku: request.DeviceData.Sku,

--- a/src/pa/services/pa_test.go
+++ b/src/pa/services/pa_test.go
@@ -77,6 +77,7 @@ type fakeSpmClient struct {
 	getCaSubjectKeys    getCaSubjectKeysResponse
 	endorseCerts        endorseCertsResponse
 	endorseData         endorseDataResponse
+	verifyDeviceData    verifyDeviceDataResponse
 }
 
 type initSessionResponse struct {
@@ -109,6 +110,11 @@ type endorseDataResponse struct {
 	err      error
 }
 
+type verifyDeviceDataResponse struct {
+	response *pbs.VerifyDeviceDataResponse
+	err      error
+}
+
 func (c *fakeSpmClient) InitSession(ctx context.Context, request *pbp.InitSessionRequest, opts ...grpc.CallOption) (*pbp.InitSessionResponse, error) {
 	return c.initSession.response, c.initSession.err
 }
@@ -131,6 +137,10 @@ func (c *fakeSpmClient) EndorseCerts(ctx context.Context, request *pbp.EndorseCe
 
 func (c *fakeSpmClient) EndorseData(ctx context.Context, request *pbs.EndorseDataRequest, opts ...grpc.CallOption) (*pbs.EndorseDataResponse, error) {
 	return c.endorseData.response, c.endorseData.err
+}
+
+func (c *fakeSpmClient) VerifyDeviceData(ctx context.Context, request *pbs.VerifyDeviceDataRequest, opts ...grpc.CallOption) (*pbs.VerifyDeviceDataResponse, error) {
+	return c.verifyDeviceData.response, c.verifyDeviceData.err
 }
 
 func TestDeriveSymmetricKey(t *testing.T) {

--- a/src/proto/device_id.proto
+++ b/src/proto/device_id.proto
@@ -23,6 +23,8 @@ enum SiliconCreatorId {
   SILICON_CREATOR_ID_OPENSOURCE = 0x0001;
   // Nuvoton
   SILICON_CREATOR_ID_NUVOTON = 0x4001;
+  // FPGA
+  SILICON_CREATOR_ID_FPGA = 0xffff;
 }
 
 // OpenTitan Product ID.
@@ -39,6 +41,8 @@ enum ProductId {
   PRODUCT_ID_EARLGREY_A1 = 0x0002;
   // Earlgrey Production v1.0.0 (A2).
   PRODUCT_ID_EARLGREY_A2 = 0x0003;
+  // FPGA
+  PRODUCT_ID_FPGA = 0xffff;
 }
 
 // OpenTitan Hardware Origin.

--- a/src/proto/validators.go
+++ b/src/proto/validators.go
@@ -39,6 +39,8 @@ func ValidateSiliconCreatorId(sc dpb.SiliconCreatorId) error {
 	case dpb.SiliconCreatorId_SILICON_CREATOR_ID_OPENSOURCE:
 		fallthrough
 	case dpb.SiliconCreatorId_SILICON_CREATOR_ID_NUVOTON:
+		fallthrough
+	case dpb.SiliconCreatorId_SILICON_CREATOR_ID_FPGA:
 		return nil
 	}
 	return fmt.Errorf("Invalid SiliconCreatorId: %v", sc)
@@ -53,6 +55,8 @@ func ValidateProductId(pi dpb.ProductId) error {
 	case dpb.ProductId_PRODUCT_ID_EARLGREY_Z1:
 		fallthrough
 	case dpb.ProductId_PRODUCT_ID_EARLGREY_A1:
+		fallthrough
+	case dpb.ProductId_PRODUCT_ID_FPGA:
 		return nil
 	}
 	return fmt.Errorf("Invalid ProductId: %v", pi)

--- a/src/proto/validators_test.go
+++ b/src/proto/validators_test.go
@@ -103,8 +103,9 @@ func TestValidateProductId(t *testing.T) {
 			ok:   true,
 		},
 		{
-			name: "invalid: 0xffff",
-			pi:   dpb.ProductId(0xffff),
+			name: "fpga",
+			pi:   dpb.ProductId_PRODUCT_ID_FPGA,
+			ok:   true,
 		},
 	}
 

--- a/src/spm/proto/BUILD.bazel
+++ b/src/spm/proto/BUILD.bazel
@@ -12,6 +12,7 @@ proto_library(
     srcs = ["spm.proto"],
     deps = [
         "//src/pa/proto:pa_proto",
+        "//src/proto:device_id_proto",
         "//src/proto/crypto:cert_proto",
     ],
 )
@@ -23,6 +24,7 @@ go_proto_library(
     proto = ":spm_proto",
     deps = [
         "//src/pa/proto:pa_go_pb",
+        "//src/proto:device_id_go_pb",
         "//src/proto/crypto:cert_go_pb",
     ],
 )

--- a/src/spm/proto/spm.proto
+++ b/src/spm/proto/spm.proto
@@ -9,6 +9,7 @@ package spm;
 
 import "src/pa/proto/pa.proto";
 import "src/proto/crypto/cert.proto";
+import "src/proto/device_id.proto";
 
 option go_package = "spm_go_bp";
 
@@ -46,6 +47,10 @@ service SpmService {
   // hashed and signed with a private key stored in the SPM.
   rpc EndorseData(EndorseDataRequest)
       returns (EndorseDataResponse) {}
+
+  // VerifyDeviceData verifies the device data for a given SKU.
+  rpc VerifyDeviceData(VerifyDeviceDataRequest)
+      returns (VerifyDeviceDataResponse) {}
 }
 
 // Endorse data request.
@@ -64,4 +69,15 @@ message EndorseDataResponse {
   bytes pubkey = 1;
   // ASN.1 DER signature of data payload.
   bytes signature = 2;
+}
+
+// Verify device data request.
+message VerifyDeviceDataRequest {
+  // Device data to verify. Required.
+  ot.DeviceData device_data = 1;
+}
+
+// Verify device data response.
+message VerifyDeviceDataResponse {
+  // Empty message.
 }

--- a/src/spm/services/BUILD.bazel
+++ b/src/spm/services/BUILD.bazel
@@ -20,9 +20,11 @@ go_library(
     deps = [
         ":se",
         ":skucfg",
+        "//src/ate:ate_go_lib",
         "//src/pa/proto:pa_go_pb",
         "//src/pk11",
         "//src/proto:device_id_go_pb",
+        "//src/proto:validators",
         "//src/proto/crypto:cert_go_pb",
         "//src/proto/crypto:common_go_pb",
         "//src/spm/proto:spm_go_pb",

--- a/src/spm/services/skucfg.go
+++ b/src/spm/services/skucfg.go
@@ -19,6 +19,7 @@ const (
 	AttrNameWrappingMechanism          = "WrappingMechanism"
 	AttrNameWASKeyLabel                = "WASKeyLabel"
 	AttrNameWASDisable                 = "WASDisable"
+	AttrNameCertChainDiceLeaf          = "CertChainDiceLeaf"
 )
 
 // WrappingMechanism provides the wrapping method for symmetric keys.


### PR DESCRIPTION
This change introduces a verification step for device data during the
device registration process in the Provisioning Appliance (PA).

The SPM now exposes a `VerifyDeviceData` RPC that the PA calls.
This RPC validates the device's certificate chain, which is passed in a
personalization TLV blob.

The verification logic in the SPM supports multiple DICE certificate
chain configurations, controlled by a new `CertChainDiceLeaf` SKU
attribute. This allows for flexible certificate hierarchies, such as:

- Root CA -> UDS ICA -> UDS (leaf)
- Root CA -> UDS ICA -> UDS -> CDI_0 (leaf)
- Root CA -> UDS ICA -> UDS -> CDI_0 -> CDI_1 (leaf)

The `dututils` in the ATE framework have been updated to emulate the
generation of these certificate chains on the DUT for testing purposes.
The load test now utilizes this functionality to test the end-to-end
flow.

Additionally, FPGA-specific identifiers have been added to the
device ID proto definitions.