### PR TITLE
[ate] unpack CWT certs to push to registry

### DIFF
--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -297,10 +297,24 @@ typedef struct endorse_cert_request {
 } endorse_cert_request_t;
 
 /**
+ * Certificate type: X509 or CWT.
+ */
+typedef enum cert_type {
+  kCertTypeX509 = 0,
+  kCertTypeCwt = 1,
+} cert_type_t;
+
+/**
  * Response parameters for endorsing certificates.
  */
 typedef struct endorse_cert_response {
-  /** Size of the key label. */
+  /**
+   * Certificate type.
+   */
+  cert_type_t type;
+  /**
+   * Size of the key label.
+   */
   size_t key_label_size;
   /**
    * The key label is used to identify the key used to sign the certificate.
@@ -706,12 +720,12 @@ DLLEXPORT int PersoBlobFromJson(const dut_spi_frame_t* frames,
  * @param[out] device_id The extracted device ID.
  * @param[out] signature The HMAC signature over the TBS certificates.
  * @param[out] perso_fw_hash The hash of the personalization firmware.
- * @param[out] x509_tbs_certs Array of X.509 TBS certs.
+ * @param[out] tbs_certs Array of TBS certs (only X.509 supported at this time).
  * @param[out] tbs_cert_count The number of TBS certs found. Initialized
- * to the size of `x509_tbs_certs`.
- * @param[out] x509_certs Array of (fully formed) X.509 certs.
+ * to the size of `tbs_certs`.
+ * @param[out] certs Array of (fully formed) X.509 or CWT certs.
  * @param[out] cert_count The number of certs found. Initialized to the size of
- * `x509_certs`.
+ * `certs `.
  * @param[out] seeds The extracted seeds.
  * @param[out] seed_count The number of seeds found. Initialized to the size of
  * `seeds`.
@@ -720,8 +734,8 @@ DLLEXPORT int PersoBlobFromJson(const dut_spi_frame_t* frames,
 DLLEXPORT int UnpackPersoBlob(
     const perso_blob_t* blob, device_id_bytes_t* device_id,
     endorse_cert_signature_t* signature, perso_fw_sha256_hash_t* perso_fw_hash,
-    endorse_cert_request_t* x509_tbs_certs, size_t* tbs_cert_count,
-    endorse_cert_response_t* x509_certs, size_t* cert_count, seed_t* seeds,
+    endorse_cert_request_t* tbs_certs, size_t* tbs_cert_count,
+    endorse_cert_response_t* certs, size_t* cert_count, seed_t* seeds,
     size_t* seed_count);
 
 /**

--- a/src/ate/ate_dll.cc
+++ b/src/ate/ate_dll.cc
@@ -579,6 +579,11 @@ DLLEXPORT int EndorseCerts(ate_client_ptr client, const char *sku,
       return static_cast<int>(absl::StatusCode::kInternal);
     }
 
+    // Set the cert type.
+    // Only signing of X.509 certificates is supported at this time.
+    resp_cert.type = kCertTypeX509;
+
+    // Set the cert size.
     resp_cert.cert_size = c.cert().blob().size();
     memcpy(resp_cert.cert, c.cert().blob().data(), c.cert().blob().size());
 


### PR DESCRIPTION
The personalization firmware can produce DUT-endorsed X.509 or CWT certificates depending on the SKU. This updates the ATE DLL to unpack CWT certs, in addition to the X.509 certs, so they will be included in the TLV data structure written to the device registry.