### PR TITLE
[ate] Add Dut Commands Go Proto Library.

### DIFF
--- a/src/ate/proto/BUILD
+++ b/src/ate/proto/BUILD
@@ -4,6 +4,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -15,4 +16,10 @@ proto_library(
 cc_proto_library(
     name = "dut_commands_cc_proto",
     deps = [":dut_commands_proto"],
+)
+
+go_proto_library(
+    name = "dut_commands_go_proto",
+    importpath = "github.com/lowRISC/opentitan-provisioning/src/ate/proto/dut_commands_go_pb",
+    proto = ":dut_commands_proto",
 )


### PR DESCRIPTION
The `//src/ate/proto:dut_commands_go_proto` is based on `//src/ate/proto:dut_commands_proto`.