### PR TITLE
[ate,pa,spm,dut_lib] add ROM_EXT and owner FW boot check

### DIFF
--- a/config/spm/sku_auth.yml.tmpl
+++ b/config/spm/sku_auth.yml.tmpl
@@ -6,16 +6,16 @@ skuAuthCfgList:
   "sival":
     # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
     skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
-    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "RegisterDevice"]
+    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "GetOwnerFwBootMessage", "RegisterDevice"]
   "cr01":
     # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
     skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
-    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "RegisterDevice"]
+    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "GetOwnerFwBootMessage", "RegisterDevice"]
   "pi01":
     # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
     skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
-    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "RegisterDevice"]
+    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "GetOwnerFwBootMessage", "RegisterDevice"]
   "ti01":
     # bcrypt hash of "test_password" (used by .../pa/loadtest.go)
     skuAuth: "$2a$10$7ZjR5zTQpig.aomnunzte.Ve1eW4GT2ACx1iy4fxtfzysprfrNMfG"
-    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "RegisterDevice"]
+    methods: ["DeriveTokens", "GetCaSubjectKeys", "EndorseCerts", "GetOwnerFwBootMessage", "RegisterDevice"]

--- a/config/spm/sku_cr01.yml.tmpl
+++ b/config/spm/sku_cr01.yml.tmpl
@@ -32,3 +32,4 @@ attributes:
     SigningKey/Ext/v0: cr01-ica-ext-key-p256-v0.priv
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
     CertChainDiceLeaf: CDI_1
+    OwnerFirmwareBootMessage: "Key ladder state: Prod"

--- a/config/spm/sku_pi01.yml.tmpl
+++ b/config/spm/sku_pi01.yml.tmpl
@@ -32,3 +32,4 @@ attributes:
     SigningKey/Ext/v0: pi01-ica-ext-key-p256-v0.priv
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
     CertChainDiceLeaf: UDS
+    OwnerFirmwareBootMessage: "...sleeping..."

--- a/config/spm/sku_sival.yml.tmpl
+++ b/config/spm/sku_sival.yml.tmpl
@@ -28,3 +28,4 @@ attributes:
     SigningKey/Dice/v0: sival-dice-key-p256-v0.priv
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
     CertChainDiceLeaf: CDI_1
+    OwnerFirmwareBootMessage: "ownership: OWND"

--- a/config/spm/sku_ti01.yml.tmpl
+++ b/config/spm/sku_ti01.yml.tmpl
@@ -28,3 +28,4 @@ attributes:
     SigningKey/Dice/v0: ti01-ica-dice-key-p256-v0.priv
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
     CertChainDiceLeaf: CDI_1
+    OwnerFirmwareBootMessage: "pie_rot_earlgrey_mfg"

--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -614,6 +614,21 @@ DLLEXPORT int EndorseCerts(ate_client_ptr client, const char* sku,
                            endorse_cert_response_t* certs);
 
 /**
+ * Gets the owner firmware boot success message for a given SKU.
+ *
+ * This function retrieves the owner firmware boot success message from the
+ * PA/SPM. The caller should allocate enough memory to store the string.
+ *
+ * @param client A client instance.
+ * @param sku The SKU of the product to generate the keys for.
+ * @param[out] boot_msg The boot message string.
+ * @param boot_msg_size The maximum size of the boot message.
+ * @return The result of the operation.
+ */
+DLLEXPORT int GetOwnerFwBootMessage(ate_client_ptr client, const char* sku,
+                                    char* boot_msg, size_t boot_msg_size);
+
+/**
  * Register a device.
  *
  * The function registers a provisioned device in the device registry.

--- a/src/ate/ate_client.cc
+++ b/src/ate/ate_client.cc
@@ -31,6 +31,8 @@ using pa::EndorseCertsRequest;
 using pa::EndorseCertsResponse;
 using pa::GetCaSubjectKeysRequest;
 using pa::GetCaSubjectKeysResponse;
+using pa::GetOwnerFwBootMessageRequest;
+using pa::GetOwnerFwBootMessageResponse;
 using pa::InitSessionRequest;
 using pa::InitSessionResponse;
 using pa::ProvisioningApplianceService;
@@ -175,6 +177,14 @@ Status AteClient::GetCaSubjectKeys(GetCaSubjectKeysRequest& request,
 
   // The actual RPC - call the server's DeriveTokens method.
   return stub_->GetCaSubjectKeys(&context, request, reply);
+}
+
+Status AteClient::GetOwnerFwBootMessage(GetOwnerFwBootMessageRequest& request,
+                                        GetOwnerFwBootMessageResponse* reply) {
+  LOG(INFO) << "AteClient::GetOwnerFwBootMessage";
+  ClientContext context;
+  context.AddMetadata("authorization", sku_session_token_);
+  return stub_->GetOwnerFwBootMessage(&context, request, reply);
 }
 
 Status AteClient::RegisterDevice(RegistrationRequest& request,

--- a/src/ate/ate_client.h
+++ b/src/ate/ate_client.h
@@ -91,6 +91,10 @@ class AteClient {
   grpc::Status GetCaSubjectKeys(pa::GetCaSubjectKeysRequest& request,
                                 pa::GetCaSubjectKeysResponse* reply);
 
+  // Calls the server's GetOwnerFwBootMessage method and returns its reply.
+  grpc::Status GetOwnerFwBootMessage(pa::GetOwnerFwBootMessageRequest& request,
+                                     pa::GetOwnerFwBootMessageResponse* reply);
+
   // Calls the server's RegisterDevice method and returns its reply.
   grpc::Status RegisterDevice(pa::RegistrationRequest& request,
                               pa::RegistrationResponse* reply);

--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -35,6 +35,8 @@ void OtLibResetAndLock(void* transport, const char* openocd);
 void OtLibLcTransition(void* transport, const char* openocd,
                        const uint8_t* token, size_t token_size,
                        uint32_t target_lc_state);
+void OtLibCheckTransportImgBoot(void* transport, const char* owner_fw_boot_msg,
+                                uint64_t timeout_ms);
 }
 
 std::unique_ptr<DutLib> DutLib::Create(const std::string& fpga) {
@@ -90,6 +92,12 @@ void DutLib::DutLcTransition(const std::string& openocd, const uint8_t* token,
   LOG(INFO) << "in DutLib::DutLcTransition";
   OtLibLcTransition(transport_, openocd.c_str(), token, token_size,
                     target_lc_state);
+}
+
+void DutLib::DutCheckTransportImgBoot(const char* owner_fw_boot_msg,
+                                      uint64_t timeout_ms) {
+  LOG(INFO) << "in DutLib::DutCheckTransportImgBoot";
+  OtLibCheckTransportImgBoot(transport_, owner_fw_boot_msg, timeout_ms);
 }
 
 }  // namespace test_programs

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -63,6 +63,13 @@ class DutLib {
    */
   void DutLcTransition(const std::string& openocd, const uint8_t* token,
                        size_t token_size, uint32_t target_lc_state);
+  /**
+   * Calls opentitanlib test utils to reset the DUT and wait for a ROM_EXT and
+   * owner firmware boot message to appear over the console to indicate the DUT
+   * has been provisioned successfully.
+   */
+  void DutCheckTransportImgBoot(const char* owner_fw_boot_msg,
+                                uint64_t timeout_ms);
 
  private:
   // Must be 2x the opentitanlib UartConsole buffer size defined here:

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -411,6 +411,20 @@ int main(int argc, char **argv) {
     return -1;
   }
 
+  // TODO(timothytrippel): check the hash of all certificates written to flash.
+
+  // Wait for the DUT to boot the transport image successfully (i.e., the
+  // ROM_EXT + Owner FW payload).
+  dut->DutConsoleWaitForRx("Personalization done.\n", /*timeout_ms=*/1000);
+  constexpr size_t kMaxBootMessageStringSize = 50;
+  char boot_msg_cstr[kMaxBootMessageStringSize] = {0};
+  if (GetOwnerFwBootMessage(ate_client, absl::GetFlag(FLAGS_sku).c_str(),
+                            boot_msg_cstr, kMaxBootMessageStringSize) != 0) {
+    LOG(ERROR) << "GetOwnerFwBootMessage failed.";
+    return -1;
+  }
+  dut->DutCheckTransportImgBoot(boot_msg_cstr, /*timeout_ms=*/5000);
+
   // Close session with PA.
   if (CloseSession(ate_client) != 0) {
     LOG(ERROR) << "CloseSession with PA failed.";

--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -26,6 +26,8 @@ service ProvisioningApplianceService {
     returns (GetStoredTokensResponse) {}
   rpc GetCaSubjectKeys(GetCaSubjectKeysRequest)
     returns (GetCaSubjectKeysResponse) {}
+  rpc GetOwnerFwBootMessage(GetOwnerFwBootMessageRequest)
+    returns (GetOwnerFwBootMessageResponse) {}
   rpc RegisterDevice(RegistrationRequest)
     returns (RegistrationResponse) {}
 }
@@ -198,6 +200,17 @@ message GetCaSubjectKeysResponse{
   repeated bytes key_ids = 1;
 }
 
+// Get owner firmware boot message request.
+message GetOwnerFwBootMessageRequest{
+  // SKU identifier. Required.
+  string sku = 1;
+}
+
+// Get owner firmware boot message response.
+message GetOwnerFwBootMessageResponse{
+  // Boot message string.
+  string boot_message = 1;
+}
 
 // Close SKU session request.
 message CloseSessionRequest {

--- a/src/pa/services/pa.go
+++ b/src/pa/services/pa.go
@@ -150,6 +150,16 @@ func (s *server) GetCaSubjectKeys(ctx context.Context, request *pap.GetCaSubject
 	return r, nil
 }
 
+// GetOwnerFwBootMessage retrieves the owner firmware boot message for a given SKU.
+func (s *server) GetOwnerFwBootMessage(ctx context.Context, request *pap.GetOwnerFwBootMessageRequest) (*pap.GetOwnerFwBootMessageResponse, error) {
+	log.Printf("In PA - Received GetOwnerFwBootMessage request")
+	r, err := s.spmClient.GetOwnerFwBootMessage(ctx, request)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "SPM returned error: %v", err)
+	}
+	return r, nil
+}
+
 // RegisterDevice registers a new device record in the registry database.
 //
 // The registry database is accessed through the ProxyBuffer or any downstream

--- a/src/pa/services/pa_test.go
+++ b/src/pa/services/pa_test.go
@@ -71,13 +71,14 @@ func (c *fakePbClient) BatchRegisterDevice(ctx context.Context, request *pbr.Bat
 // fakeSpmClient provides a fake client interface to the SPM server. Test
 // cases can set the fake responses as part of the test setup.
 type fakeSpmClient struct {
-	initSession         initSessionResponse
-	deriveSymmetricKeys deriveSymmetricKeysResponse
-	getStoredTokens     getStoredTokensResponse
-	getCaSubjectKeys    getCaSubjectKeysResponse
-	endorseCerts        endorseCertsResponse
-	endorseData         endorseDataResponse
-	verifyDeviceData    verifyDeviceDataResponse
+	initSession           initSessionResponse
+	deriveSymmetricKeys   deriveSymmetricKeysResponse
+	getStoredTokens       getStoredTokensResponse
+	getCaSubjectKeys      getCaSubjectKeysResponse
+	endorseCerts          endorseCertsResponse
+	endorseData           endorseDataResponse
+	verifyDeviceData      verifyDeviceDataResponse
+	getOwnerFwBootMessage getOwnerFwBootMessageResponse
 }
 
 type initSessionResponse struct {
@@ -115,6 +116,11 @@ type verifyDeviceDataResponse struct {
 	err      error
 }
 
+type getOwnerFwBootMessageResponse struct {
+	response *pbp.GetOwnerFwBootMessageResponse
+	err      error
+}
+
 func (c *fakeSpmClient) InitSession(ctx context.Context, request *pbp.InitSessionRequest, opts ...grpc.CallOption) (*pbp.InitSessionResponse, error) {
 	return c.initSession.response, c.initSession.err
 }
@@ -141,6 +147,10 @@ func (c *fakeSpmClient) EndorseData(ctx context.Context, request *pbs.EndorseDat
 
 func (c *fakeSpmClient) VerifyDeviceData(ctx context.Context, request *pbs.VerifyDeviceDataRequest, opts ...grpc.CallOption) (*pbs.VerifyDeviceDataResponse, error) {
 	return c.verifyDeviceData.response, c.verifyDeviceData.err
+}
+
+func (c *fakeSpmClient) GetOwnerFwBootMessage(ctx context.Context, request *pbp.GetOwnerFwBootMessageRequest, opts ...grpc.CallOption) (*pbp.GetOwnerFwBootMessageResponse, error) {
+	return c.getOwnerFwBootMessage.response, c.getOwnerFwBootMessage.err
 }
 
 func TestDeriveSymmetricKey(t *testing.T) {

--- a/src/spm/proto/spm.proto
+++ b/src/spm/proto/spm.proto
@@ -51,6 +51,10 @@ service SpmService {
   // VerifyDeviceData verifies the device data for a given SKU.
   rpc VerifyDeviceData(VerifyDeviceDataRequest)
       returns (VerifyDeviceDataResponse) {}
+
+  // GetOwnerFwBootMessage retrieves the owner firmware boot message for a SKU.
+  rpc GetOwnerFwBootMessage(pa.GetOwnerFwBootMessageRequest)
+      returns (pa.GetOwnerFwBootMessageResponse) {}
 }
 
 // Endorse data request.

--- a/src/spm/services/skucfg.go
+++ b/src/spm/services/skucfg.go
@@ -13,13 +13,14 @@ import (
 type AttrName string
 
 const (
-	AttrNameSeedSecHi         AttrName = "SeedSecHi"
-	AttrNameSeedSecLo                  = "SeedSecLo"
-	AttrNameWrappingKeyLabel           = "WrappingKeyLabel"
-	AttrNameWrappingMechanism          = "WrappingMechanism"
-	AttrNameWASKeyLabel                = "WASKeyLabel"
-	AttrNameWASDisable                 = "WASDisable"
-	AttrNameCertChainDiceLeaf          = "CertChainDiceLeaf"
+	AttrNameSeedSecHi                AttrName = "SeedSecHi"
+	AttrNameSeedSecLo                         = "SeedSecLo"
+	AttrNameWrappingKeyLabel                  = "WrappingKeyLabel"
+	AttrNameWrappingMechanism                 = "WrappingMechanism"
+	AttrNameWASKeyLabel                       = "WASKeyLabel"
+	AttrNameWASDisable                        = "WASDisable"
+	AttrNameCertChainDiceLeaf                 = "CertChainDiceLeaf"
+	AttrNameOwnerFirmwareBootMessage          = "OwnerFirmwareBootMessage"
 )
 
 // WrappingMechanism provides the wrapping method for symmetric keys.

--- a/src/spm/services/spm.go
+++ b/src/spm/services/spm.go
@@ -605,3 +605,20 @@ func (s *server) VerifyDeviceData(ctx context.Context, request *pbs.VerifyDevice
 
 	return &pbs.VerifyDeviceDataResponse{}, nil
 }
+
+// GetOwnerFwBootMessage retrieves the owner firmware boot message for a SKU.
+func (s *server) GetOwnerFwBootMessage(ctx context.Context, request *pbp.GetOwnerFwBootMessageRequest) (*pbp.GetOwnerFwBootMessageResponse, error) {
+	sku, ok := s.skuManager.GetSku(request.Sku)
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "unable to find sku %q. Try calling InitSession first", request.Sku)
+	}
+
+	msg, err := sku.Config.GetAttribute(skucfg.AttrNameOwnerFirmwareBootMessage)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "could not fetch owner firmware boot message: %v", err)
+	}
+
+	return &pbp.GetOwnerFwBootMessageResponse{
+		BootMessage: msg,
+	}, nil
+}


### PR DESCRIPTION
After personalization completes, to confirm everything completed successfully, we reset the DUT and wait for the ROM_EXT and Owner firmware to boot, by waiting for a message to appear over the UART.