### PR TITLE
[ate] add separate SPI frame buffers for DUT TX and RX directions

### DIFF
--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -46,7 +46,7 @@ enum {
   kCaSubjectKeySize = 20,
 
   /**
-   * Maximum size of SPI frame supported by the DUT.
+   * Maximum size of a SPI frame transmitted to the ATE by the DUT.
    *
    * The max size is defined in the OpenTitan repository in:
    * sw/device/lib/testing/test_framework/ottf_console_internal.h
@@ -58,6 +58,13 @@ enum {
   kDutTxSpiFrameHeaderSizeInBytes = 12,
   kDutTxMaxSpiFrameSizeInBytes =
       2048 - (2 * kDutTxSpiFrameHeaderSizeInBytes) - 4,
+
+  /**
+   * Maximum size of a SPI frame recevied by the DUT from  the ATE.
+   *
+   * The max size is defined as the page program size in the SPI flash mode.
+   */
+  kDutRxMaxSpiFrameSizeInBytes = 256,
 
   /**
    * Dev seed size in bytes; Must be equal to the value defined in
@@ -97,7 +104,7 @@ enum {
  * ate_client_ptr is an opaque pointer to an AteClient instance.
  */
 typedef struct {
-}* ate_client_ptr;
+} * ate_client_ptr;
 
 typedef struct {
   // Endpoint address in gRPC name-syntax format, including port number. For
@@ -151,6 +158,22 @@ typedef struct dut_tx_spi_frame {
    */
   size_t size;
 } dut_tx_spi_frame_t;
+
+/**
+ * A SPI console frame RXed by the DUT from the host (ATE).
+ */
+typedef struct dut_rx_spi_frame {
+  /**
+   * The data payload to be sent out from the DUT to the ATE.
+   *
+   * The maximum size of a payload is kDutRxMaxSpiFrameSizeInBytes.
+   */
+  uint8_t payload[kDutRxMaxSpiFrameSizeInBytes];
+  /**
+   * The number bytes contained in the payload above.
+   */
+  size_t size;
+} dut_rx_spi_frame_t;
 
 /**
  * The perso blob is a structure used to store the personalization data.
@@ -658,7 +681,7 @@ DLLEXPORT int RegisterDevice(
 DLLEXPORT int TokensToJson(const token_t* wafer_auth_secret,
                            const token_t* test_unlock_token,
                            const token_t* test_exit_token,
-                           dut_tx_spi_frame_t* result);
+                           dut_rx_spi_frame_t* result);
 
 /**
  * Parse JSON command to extract device ID from the SPI frame.
@@ -679,7 +702,7 @@ DLLEXPORT int DeviceIdFromJson(const dut_tx_spi_frame_t* frame,
  * @return The result of the operation.
  */
 DLLEXPORT int RmaTokenToJson(const token_t* rma_token,
-                             dut_tx_spi_frame_t* result, bool skip_crc);
+                             dut_rx_spi_frame_t* result, bool skip_crc);
 
 /**
  * Parse JSON command to extract the RMA token from the SPI frame.
@@ -701,7 +724,7 @@ DLLEXPORT int RmaTokenFromJson(const dut_tx_spi_frame_t* frame,
  */
 DLLEXPORT int CaSubjectKeysToJson(const ca_subject_key_t* dice_ca_sn,
                                   const ca_subject_key_t* aux_ca_sn,
-                                  dut_tx_spi_frame_t* result);
+                                  dut_rx_spi_frame_t* result);
 
 /**
  * Generate JSON command to inject personalization blob.
@@ -712,7 +735,7 @@ DLLEXPORT int CaSubjectKeysToJson(const ca_subject_key_t* dice_ca_sn,
  * @return The result of the operation.
  */
 DLLEXPORT int PersoBlobToJson(const perso_blob_t* blob,
-                              dut_tx_spi_frame_t* result, size_t* num_frames);
+                              dut_rx_spi_frame_t* result, size_t* num_frames);
 
 /**
  * Parse JSON command to extract personalization blob from the SPI frame.

--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -64,7 +64,7 @@ enum {
    *
    * The max size is defined as the page program size in the SPI flash mode.
    */
-  kDutRxMaxSpiFrameSizeInBytes = 256,
+  kDutRxSpiFrameSizeInBytes = 256,
 
   /**
    * Dev seed size in bytes; Must be equal to the value defined in
@@ -166,13 +166,9 @@ typedef struct dut_rx_spi_frame {
   /**
    * The data payload to be sent out from the DUT to the ATE.
    *
-   * The maximum size of a payload is kDutRxMaxSpiFrameSizeInBytes.
+   * Each payload is padded to a fixed size of kDutRxSpiFrameSizeInBytes .
    */
-  uint8_t payload[kDutRxMaxSpiFrameSizeInBytes];
-  /**
-   * The number bytes contained in the payload above.
-   */
-  size_t size;
+  uint8_t payload[kDutRxSpiFrameSizeInBytes];
 } dut_rx_spi_frame_t;
 
 /**

--- a/src/ate/ate_api_json_commands.cc
+++ b/src/ate/ate_api_json_commands.cc
@@ -12,7 +12,7 @@
 #include "src/ate/proto/dut_commands.pb.h"
 
 namespace {
-int SpiFrameSet(dut_tx_spi_frame_t *frame, const std::string &payload) {
+int RxSpiFrameSet(dut_rx_spi_frame_t *frame, const std::string &payload) {
   if (frame == nullptr) {
     LOG(ERROR) << "Invalid result buffer";
     return -1;
@@ -137,7 +137,7 @@ std::string TrimJsonString(const std::string &json_str) {
 DLLEXPORT int TokensToJson(const token_t *wafer_auth_secret,
                            const token_t *test_unlock_token,
                            const token_t *test_exit_token,
-                           dut_tx_spi_frame_t *result) {
+                           dut_rx_spi_frame_t *result) {
   if (result == nullptr) {
     LOG(ERROR) << "Invalid result buffer";
     return -1;
@@ -191,7 +191,7 @@ DLLEXPORT int TokensToJson(const token_t *wafer_auth_secret,
     return -1;
   }
 
-  return SpiFrameSet(result, command);
+  return RxSpiFrameSet(result, command);
 }
 
 DLLEXPORT int DeviceIdFromJson(const dut_tx_spi_frame_t *frame,
@@ -225,7 +225,7 @@ DLLEXPORT int DeviceIdFromJson(const dut_tx_spi_frame_t *frame,
 }
 
 DLLEXPORT int RmaTokenToJson(const token_t *rma_token,
-                             dut_tx_spi_frame_t *result, bool skip_crc) {
+                             dut_rx_spi_frame_t *result, bool skip_crc) {
   if (result == nullptr) {
     LOG(ERROR) << "Invalid result buffer";
     return -1;
@@ -261,7 +261,7 @@ DLLEXPORT int RmaTokenToJson(const token_t *rma_token,
     return -1;
   }
 
-  return SpiFrameSet(result, command);
+  return RxSpiFrameSet(result, command);
 }
 
 DLLEXPORT int RmaTokenFromJson(const dut_tx_spi_frame_t *frame,
@@ -309,7 +309,7 @@ DLLEXPORT int RmaTokenFromJson(const dut_tx_spi_frame_t *frame,
 
 DLLEXPORT int CaSubjectKeysToJson(const ca_subject_key_t *dice_ca_sn,
                                   const ca_subject_key_t *aux_ca_sn,
-                                  dut_tx_spi_frame_t *result) {
+                                  dut_rx_spi_frame_t *result) {
   if (result == nullptr) {
     LOG(ERROR) << "Invalid result buffer";
     return -1;
@@ -343,11 +343,11 @@ DLLEXPORT int CaSubjectKeysToJson(const ca_subject_key_t *dice_ca_sn,
     return -1;
   }
 
-  return SpiFrameSet(result, command);
+  return RxSpiFrameSet(result, command);
 }
 
 DLLEXPORT int PersoBlobToJson(const perso_blob_t *blob,
-                              dut_tx_spi_frame_t *result, size_t *num_frames) {
+                              dut_rx_spi_frame_t *result, size_t *num_frames) {
   if (result == nullptr) {
     LOG(ERROR) << "Invalid result buffer";
     return -1;
@@ -386,9 +386,8 @@ DLLEXPORT int PersoBlobToJson(const perso_blob_t *blob,
   }
 
   const size_t kNumFramesExpected =
-      (command.size() + kDutTxMaxSpiFrameSizeInBytes - 1) /
-      kDutTxMaxSpiFrameSizeInBytes;
-  const size_t kDutTxMaxSpiFrameSizeInBytes = sizeof(result[0].payload);
+      (command.size() + kDutRxMaxSpiFrameSizeInBytes - 1) /
+      kDutRxMaxSpiFrameSizeInBytes;
 
   if (*num_frames < kNumFramesExpected) {
     LOG(ERROR) << "Output buffer size is too small"
@@ -398,9 +397,9 @@ DLLEXPORT int PersoBlobToJson(const perso_blob_t *blob,
   }
 
   for (size_t i = 0; i < kNumFramesExpected; ++i) {
-    size_t offset = i * kDutTxMaxSpiFrameSizeInBytes;
+    size_t offset = i * kDutRxMaxSpiFrameSizeInBytes;
     size_t size =
-        std::min(kDutTxMaxSpiFrameSizeInBytes, command.size() - offset);
+        std::min((size_t)kDutRxMaxSpiFrameSizeInBytes, command.size() - offset);
     if (size == 0) {
       break;
     }

--- a/src/ate/test_programs/cp.cc
+++ b/src/ate/test_programs/cp.cc
@@ -217,7 +217,7 @@ int main(int argc, char **argv) {
   }
 
   // Convert the tokens to a JSON payload to inject during CP.
-  dut_tx_spi_frame_t spi_frame;
+  dut_rx_spi_frame_t spi_frame;
   if (TokensToJson(&tokens[0], &tokens[1], &tokens[2], &spi_frame) != 0) {
     LOG(ERROR) << "TokensToJson failed.";
     return -1;

--- a/src/ate/test_programs/cp.cc
+++ b/src/ate/test_programs/cp.cc
@@ -229,7 +229,7 @@ int main(int argc, char **argv) {
   dut->DutLoadSramElf(openocd_path, sram_elf_path, /*wait_for_done=*/false,
                       /*timeout_ms=*/1000);
   dut->DutConsoleTx("Waiting for CP provisioning data ...", spi_frame.payload,
-                    spi_frame.size,
+                    kDutRxSpiFrameSizeInBytes,
                     /*timeout_ms=*/1000);
   dut_tx_spi_frame_t devid_spi_frame = {0};
   size_t num_spi_frames = 1;

--- a/src/ate/test_programs/cp.cc
+++ b/src/ate/test_programs/cp.cc
@@ -217,7 +217,7 @@ int main(int argc, char **argv) {
   }
 
   // Convert the tokens to a JSON payload to inject during CP.
-  dut_spi_frame_t spi_frame;
+  dut_tx_spi_frame_t spi_frame;
   if (TokensToJson(&tokens[0], &tokens[1], &tokens[2], &spi_frame) != 0) {
     LOG(ERROR) << "TokensToJson failed.";
     return -1;
@@ -229,9 +229,9 @@ int main(int argc, char **argv) {
   dut->DutLoadSramElf(openocd_path, sram_elf_path, /*wait_for_done=*/false,
                       /*timeout_ms=*/1000);
   dut->DutConsoleTx("Waiting for CP provisioning data ...", spi_frame.payload,
-                    spi_frame.cursor,
+                    spi_frame.size,
                     /*timeout_ms=*/1000);
-  dut_spi_frame_t devid_spi_frame = {0};
+  dut_tx_spi_frame_t devid_spi_frame = {0};
   size_t num_spi_frames = 1;
   dut->DutConsoleRx("Exporting CP device ID ...", &devid_spi_frame,
                     &num_spi_frames,

--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -26,7 +26,7 @@ void OtLibBootstrap(void* transport, const char* bin);
 void OtLibConsoleWaitForRx(void* transport, const char* msg,
                            uint64_t timeout_ms);
 void OtLibConsoleRx(void* transport, const char* sync_msg,
-                    dut_spi_frame_t* spi_frames, size_t* num_frames,
+                    dut_tx_spi_frame_t* spi_frames, size_t* num_frames,
                     bool skip_crc_check, bool quiet, uint64_t timeout_ms);
 void OtLibConsoleTx(void* transport, const char* sync_msg,
                     const uint8_t* spi_frame, size_t spi_frame_size,
@@ -67,7 +67,7 @@ void DutLib::DutConsoleWaitForRx(const char* msg, uint64_t timeout_ms) {
 }
 
 void DutLib::DutConsoleRx(const std::string& sync_msg,
-                          dut_spi_frame_t* spi_frames, size_t* num_frames,
+                          dut_tx_spi_frame_t* spi_frames, size_t* num_frames,
                           bool skip_crc_check, bool quiet,
                           uint64_t timeout_ms) {
   LOG(INFO) << "in DutLib::DutConsoleRx";

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -44,7 +44,7 @@ class DutLib {
   /**
    * Calls opentitanlib test util to receive a message over the SPI console.
    */
-  void DutConsoleRx(const std::string& sync_msg, dut_spi_frame_t* spi_frames,
+  void DutConsoleRx(const std::string& sync_msg, dut_tx_spi_frame_t* spi_frames,
                     size_t* num_frames, bool skip_crc_check, bool quiet,
                     uint64_t timeout_ms);
   /**

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
     LOG(ERROR) << "GenerateTokens failed.";
     return -1;
   }
-  dut_tx_spi_frame_t rma_token_spi_frame;
+  dut_rx_spi_frame_t rma_token_spi_frame;
   if (RmaTokenToJson(&rma_token, &rma_token_spi_frame, /*skip_crc=*/false) !=
       0) {
     LOG(ERROR) << "RmaTokenToJson failed.";
@@ -264,7 +264,7 @@ int main(int argc, char **argv) {
   }
   const ca_subject_key_t *kDiceCaSk = &key_ids[0];
   const ca_subject_key_t *kExtCaSk = &key_ids[1];
-  dut_tx_spi_frame_t ca_key_ids_spi_frame;
+  dut_rx_spi_frame_t ca_key_ids_spi_frame;
   if (CaSubjectKeysToJson(kDiceCaSk, kExtCaSk, &ca_key_ids_spi_frame) != 0) {
     LOG(ERROR) << "CaSubjectKeysToJson failed.";
     return -1;
@@ -355,8 +355,8 @@ int main(int argc, char **argv) {
 
   // Send the endorsed certs back to the device.
   perso_blob_t perso_blob_from_ate = {0};
-  constexpr size_t kNumPersoBlobMaxNumSpiFrames = 10;
-  dut_tx_spi_frame_t
+  constexpr size_t kNumPersoBlobMaxNumSpiFrames = 50;
+  dut_rx_spi_frame_t
       perso_blob_from_ate_spi_frames[kNumPersoBlobMaxNumSpiFrames];
   size_t num_perso_blob_spi_frames = kNumPersoBlobMaxNumSpiFrames;
   if (PackPersoBlob(num_tbs_certs, pa_endorsed_certs, &perso_blob_from_ate) !=

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -284,10 +284,10 @@ int main(int argc, char **argv) {
   dut->DutConsoleWaitForRx("Bootstrap requested.", /*timeout_ms=*/1000);
   dut->DutBootstrap(ft_fw_bundle_path);
   dut->DutConsoleTx("Waiting For RMA Unlock Token Hash ...",
-                    rma_token_spi_frame.payload, rma_token_spi_frame.size,
+                    rma_token_spi_frame.payload, kDutRxSpiFrameSizeInBytes,
                     /*timeout_ms=*/1000);
   dut->DutConsoleTx("Waiting for certificate inputs ...",
-                    ca_key_ids_spi_frame.payload, ca_key_ids_spi_frame.size,
+                    ca_key_ids_spi_frame.payload, kDutRxSpiFrameSizeInBytes,
                     /*timeout_ms=*/1000);
 
   // Receive the TBS certs and other provisioning data from the DUT.
@@ -375,12 +375,12 @@ int main(int argc, char **argv) {
     if (i == 0) {
       dut->DutConsoleTx(perso_blob_sync_msg,
                         perso_blob_from_ate_spi_frames[i].payload,
-                        perso_blob_from_ate_spi_frames[i].size,
+                        kDutRxSpiFrameSizeInBytes,
                         /*timeout_ms=*/1000);
     } else {
       dut->DutConsoleTx(empty_sync_msg,
                         perso_blob_from_ate_spi_frames[i].payload,
-                        perso_blob_from_ate_spi_frames[i].size,
+                        kDutRxSpiFrameSizeInBytes,
                         /*timeout_ms=*/1000);
     }
   }

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
     LOG(ERROR) << "GenerateTokens failed.";
     return -1;
   }
-  dut_spi_frame_t rma_token_spi_frame;
+  dut_tx_spi_frame_t rma_token_spi_frame;
   if (RmaTokenToJson(&rma_token, &rma_token_spi_frame, /*skip_crc=*/false) !=
       0) {
     LOG(ERROR) << "RmaTokenToJson failed.";
@@ -264,7 +264,7 @@ int main(int argc, char **argv) {
   }
   const ca_subject_key_t *kDiceCaSk = &key_ids[0];
   const ca_subject_key_t *kExtCaSk = &key_ids[1];
-  dut_spi_frame_t ca_key_ids_spi_frame;
+  dut_tx_spi_frame_t ca_key_ids_spi_frame;
   if (CaSubjectKeysToJson(kDiceCaSk, kExtCaSk, &ca_key_ids_spi_frame) != 0) {
     LOG(ERROR) << "CaSubjectKeysToJson failed.";
     return -1;
@@ -284,15 +284,15 @@ int main(int argc, char **argv) {
   dut->DutConsoleWaitForRx("Bootstrap requested.", /*timeout_ms=*/1000);
   dut->DutBootstrap(ft_fw_bundle_path);
   dut->DutConsoleTx("Waiting For RMA Unlock Token Hash ...",
-                    rma_token_spi_frame.payload, rma_token_spi_frame.cursor,
+                    rma_token_spi_frame.payload, rma_token_spi_frame.size,
                     /*timeout_ms=*/1000);
   dut->DutConsoleTx("Waiting for certificate inputs ...",
-                    ca_key_ids_spi_frame.payload, ca_key_ids_spi_frame.cursor,
+                    ca_key_ids_spi_frame.payload, ca_key_ids_spi_frame.size,
                     /*timeout_ms=*/1000);
 
   // Receive the TBS certs and other provisioning data from the DUT.
   constexpr size_t kMaxNumPbSpiFrames = 10;
-  dut_spi_frame_t pb_spi_frames[kMaxNumPbSpiFrames];
+  dut_tx_spi_frame_t pb_spi_frames[kMaxNumPbSpiFrames];
   size_t num_pb_spi_frames = kMaxNumPbSpiFrames;
   dut->DutConsoleRx("Exporting TBS certificates ...", pb_spi_frames,
                     &num_pb_spi_frames,
@@ -356,7 +356,8 @@ int main(int argc, char **argv) {
   // Send the endorsed certs back to the device.
   perso_blob_t perso_blob_from_ate = {0};
   constexpr size_t kNumPersoBlobMaxNumSpiFrames = 10;
-  dut_spi_frame_t perso_blob_from_ate_spi_frames[kNumPersoBlobMaxNumSpiFrames];
+  dut_tx_spi_frame_t
+      perso_blob_from_ate_spi_frames[kNumPersoBlobMaxNumSpiFrames];
   size_t num_perso_blob_spi_frames = kNumPersoBlobMaxNumSpiFrames;
   if (PackPersoBlob(num_tbs_certs, pa_endorsed_certs, &perso_blob_from_ate) !=
       0) {
@@ -374,12 +375,12 @@ int main(int argc, char **argv) {
     if (i == 0) {
       dut->DutConsoleTx(perso_blob_sync_msg,
                         perso_blob_from_ate_spi_frames[i].payload,
-                        perso_blob_from_ate_spi_frames[i].cursor,
+                        perso_blob_from_ate_spi_frames[i].size,
                         /*timeout_ms=*/1000);
     } else {
       dut->DutConsoleTx(empty_sync_msg,
                         perso_blob_from_ate_spi_frames[i].payload,
-                        perso_blob_from_ate_spi_frames[i].cursor,
+                        perso_blob_from_ate_spi_frames[i].size,
                         /*timeout_ms=*/1000);
     }
   }


### PR DESCRIPTION
Previously, we used one struct type for sending data to / from the DUT over the SPI console. However, the size of a SPI console data frame that is TXed by the DUT to the ATE is a maximum size of 2020 bytes, while the size of a SPI console data frame that is RXed by the DUT from the ATE is a maximum size of 256 bytes.

Therefore, we add a struct to represent a SPI console frame that is RXed by the DUT too to facilitate ATE integrations.

Thanks @BenBenderOT for pointing this out!