### PR TITLE
[pa/spm] Improve SPM and PA error handling and logging

### DIFF
--- a/src/pa/services/pa.go
+++ b/src/pa/services/pa.go
@@ -7,7 +7,6 @@ package pa
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"sync"
 
@@ -45,10 +44,13 @@ func NewProvisioningApplianceServer(spmClient pbs.SpmServiceClient) pap.Provisio
 // InitSession sends a SKU initialization request to the SPM and returns a
 // session token and associated PA endpoint.
 func (s *server) InitSession(ctx context.Context, request *pap.InitSessionRequest) (*pap.InitSessionResponse, error) {
+	log.Printf("PA.InitSession SKU: %q", request.Sku)
+
 	// Generate a session token with the SPM.
 	r, err := s.spmClient.InitSession(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "SPM returned error: %v", err)
+		st := status.Convert(err)
+		return nil, status.Errorf(st.Code(), "SPM.InitSession returned error: %s", st.Message())
 	}
 
 	// Get authorization controller for the PA.
@@ -67,33 +69,28 @@ func (s *server) InitSession(ctx context.Context, request *pap.InitSessionReques
 
 	// Get userID and set session token.
 	userID := auth_service.GetUserID(ctx, md)
-	log.Printf("In PA InitSession: Add User: name = %s, token = %s, sku = %s", userID, r.SkuSessionToken, request.Sku)
+	log.Printf("InitSession: Add User: name: %s, token: %s, sku: %s", userID, r.SkuSessionToken, request.Sku)
 	_, err = auth_controller.AddUser(userID, r.SkuSessionToken, request.Sku, r.AuthMethods)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to add user: %v", err)
 	}
-
-	r.PaEndpoint = "TODO: SET_PA_ENDPOINT"
-
 	return r, nil
 }
 
 // CloseSession sends a SKU initialization request to the SPM and returns a
 // session token and associated PA endpoint.
 func (s *server) CloseSession(ctx context.Context, request *pap.CloseSessionRequest) (*pap.CloseSessionResponse, error) {
-	log.Printf("In PA CloseSession")
+	log.Printf("PA.CloseSession")
 
 	// Get authorization controller for the PA.
 	auth_controller, err := auth_service.GetInstance()
 	if err != nil {
-		log.Printf("internal error, try to reset pa server")
-		return nil, err
+		return nil, status.Errorf(codes.Internal, "failed to get auth controller: %v", err)
 	}
 
 	// Get context metadata.
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		log.Printf("metadata is not provided")
 		return nil, status.Errorf(codes.Unauthenticated, "metadata is not provided")
 	}
 
@@ -101,20 +98,21 @@ func (s *server) CloseSession(ctx context.Context, request *pap.CloseSessionRequ
 	userID := auth_service.GetUserID(ctx, md)
 	user, err := auth_controller.RemoveUser(userID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to remove user: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to remove user %q: %v", userID, err)
 	}
-	fmt.Println("Remove User: ", user)
+	log.Printf("Remove User: %q", user)
 
 	return &pap.CloseSessionResponse{}, nil
 }
 
 // EndorseCerts endorses a set of TBS certificates and returns them.
 func (s *server) EndorseCerts(ctx context.Context, request *pap.EndorseCertsRequest) (*pap.EndorseCertsResponse, error) {
-	log.Printf("In PA - Received EndorseCerts request with Sku=%s", request.Sku)
+	log.Printf("PA.EndorseCerts Sku: %q", request.Sku)
 
 	r, err := s.spmClient.EndorseCerts(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "SPM returned error: %v", err)
+		st := status.Convert(err)
+		return nil, status.Errorf(st.Code(), "SPM.EndorseCerts returned error: %s", st.Message())
 	}
 	return r, nil
 }
@@ -122,40 +120,44 @@ func (s *server) EndorseCerts(ctx context.Context, request *pap.EndorseCertsRequ
 // DeriveTokens generates a symmetric key from a seed (pre-provisioned in
 // the SPM/HSM) and diversifier string.
 func (s *server) DeriveTokens(ctx context.Context, request *pap.DeriveTokensRequest) (*pap.DeriveTokensResponse, error) {
-	log.Printf("In PA - Received DeriveTokens request")
+	log.Printf("PA.DeriveTokens Sku: %q", request.Sku)
 	r, err := s.spmClient.DeriveTokens(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "SPM returned error: %v", err)
+		st := status.Convert(err)
+		return nil, status.Errorf(st.Code(), "SPM.DeriveTokens returned error: %s", st.Message())
 	}
 	return r, nil
 }
 
 // GetStoredTokens retrieves a token stored within the SPM.
 func (s *server) GetStoredTokens(ctx context.Context, request *pap.GetStoredTokensRequest) (*pap.GetStoredTokensResponse, error) {
-	log.Printf("In PA - Received GetStoredTokens request")
+	log.Printf("PA.GetStoredTokens Sku: %q", request.Sku)
 	r, err := s.spmClient.GetStoredTokens(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "SPM returned error: %v", err)
+		st := status.Convert(err)
+		return nil, status.Errorf(st.Code(), "SPM.GetStoredTokens returned error: %s", st.Message())
 	}
 	return r, nil
 }
 
 // GetCaSubjectKeys retrieves the CA serial numbers for a given SKU.
 func (s *server) GetCaSubjectKeys(ctx context.Context, request *pap.GetCaSubjectKeysRequest) (*pap.GetCaSubjectKeysResponse, error) {
-	log.Printf("In PA - Received GetCaSubjectKeys request")
+	log.Printf("PA.GetCaSubjectKeys Sku: %q", request.Sku)
 	r, err := s.spmClient.GetCaSubjectKeys(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "SPM returned error: %v", err)
+		st := status.Convert(err)
+		return nil, status.Errorf(st.Code(), "SPM.GetCaSubjectKeys returned error: %s", st.Message())
 	}
 	return r, nil
 }
 
 // GetOwnerFwBootMessage retrieves the owner firmware boot message for a given SKU.
 func (s *server) GetOwnerFwBootMessage(ctx context.Context, request *pap.GetOwnerFwBootMessageRequest) (*pap.GetOwnerFwBootMessageResponse, error) {
-	log.Printf("In PA - Received GetOwnerFwBootMessage request")
+	log.Printf("PA.GetOwnerFwBootMessage Sku: %q", request.Sku)
 	r, err := s.spmClient.GetOwnerFwBootMessage(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "SPM returned error: %v", err)
+		st := status.Convert(err)
+		return nil, status.Errorf(st.Code(), "SPM.GetOwnerFwBootMessage returned error: %s", st.Message())
 	}
 	return r, nil
 }
@@ -167,19 +169,22 @@ func (s *server) GetOwnerFwBootMessage(ctx context.Context, request *pap.GetOwne
 // interface with their registry service(s), an overrideable shim layer is used
 // to implement this RPC.
 func (s *server) RegisterDevice(ctx context.Context, request *pap.RegistrationRequest) (*pap.RegistrationResponse, error) {
-	// Extract ot.DeviceData to a raw byte buffer.
+	log.Printf("PA.RegisterDevice Sku: %q", request.DeviceData.Sku)
+
+	// Extract ot.DeviceData to a raw byte buffer. 
 	deviceDataBytes, err := proto.Marshal(request.DeviceData)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal device data: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to marshal device data: %v err: %v", err, request.DeviceData)
 	}
 
 	// Verify the device data.
 	if _, err := s.spmClient.VerifyDeviceData(ctx, &pbs.VerifyDeviceDataRequest{
 		DeviceData: request.DeviceData,
 	}); err != nil {
-		return nil, status.Errorf(codes.Internal, "SPM-VerifyDeviceData returned error: %v", err)
+		st := status.Convert(err)
+		return nil, status.Errorf(st.Code(), "SPM.VerifyDeviceData returned error: %s", st.Message())
 	}
-	
+
 	// Endorse data payload.
 	edRequest := &pbs.EndorseDataRequest{
 		Sku: request.DeviceData.Sku,
@@ -197,7 +202,8 @@ func (s *server) RegisterDevice(ctx context.Context, request *pap.RegistrationRe
 	}
 	edResponse, err := s.spmClient.EndorseData(ctx, edRequest)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "SPM-EndorseData returned error: %v", err)
+		st := status.Convert(err)
+		return nil, status.Errorf(st.Code(), "SPM.EndorseData returned error: %s", st.Message())
 	}
 
 	return rs.RegisterDevice(ctx, request, edResponse)

--- a/src/pa/services/pa_test.go
+++ b/src/pa/services/pa_test.go
@@ -184,7 +184,7 @@ func TestDeriveSymmetricKey(t *testing.T) {
 		{
 			// SPM errors are converted to code.Internal.
 			name:        "spm_error",
-			expCode:     codes.Internal,
+			expCode:     codes.InvalidArgument,
 			request:     &pbp.DeriveTokensRequest{},
 			spmResponse: &pbp.DeriveTokensResponse{},
 			spmError:    status.Errorf(codes.InvalidArgument, "invalid argument"),
@@ -244,7 +244,7 @@ func TestEndorseCerts(t *testing.T) {
 		{
 			// SPM errors are converted to code.Internal.
 			name:        "spm_error",
-			expCode:     codes.Internal,
+			expCode:     codes.InvalidArgument,
 			request:     &pbp.EndorseCertsRequest{},
 			spmResponse: &pbp.EndorseCertsResponse{},
 			spmError:    status.Errorf(codes.InvalidArgument, "invalid argument"),


### PR DESCRIPTION
This commit introduces several improvements to error handling and logging in the SPM and PA services.

In the Provisioning Appliance (PA):
- Replaced generic internal error statuses with the specific status codes returned by the SPM. This provides more meaningful error information to the client.
- Enhanced log messages to include the SKU, which aids in debugging and tracing requests for specific device types.

In the Secure Provisioning Module (SPM):
- Corrected gRPC status codes to more accurately reflect the nature of the error. For example, using `NotFound` for unknown SKUs and `Unauthenticated` for failed authentication instead of `Internal`.
- Made error messages more descriptive by including contextual information such as the SKU, which helps in diagnosing issues.
- Changed several `Internal` errors to `InvalidArgument` where the failure is due to invalid data from the client, such as during certificate validation.
- Added more details to cryptographic-related error messages to assist in debugging signature and parsing failures.