### PR TITLE
[ate] consolidate `dut_*_spi_frame_t` types

### DIFF
--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -140,36 +140,31 @@ typedef struct {
 } client_options_t;
 
 /**
- * A SPI console frame TXed from the DUT to the host (ATE).
+ * A SPI console frame sent/received to/from the DUT.
  *
- * In practice, each SPI frame is prepended with a 12-byte header that indicates
- * how big the data frame is. This headed is ommitted in this struct. The ATE
- * test framework is expected to handle the header and the payload separately.
+ * For frames sent to the DUT (from the ATE), each must prepended with a 12-byte
+ * header that indicates how big the data frame is. This header is ommitted in
+ * this struct. The ATE test framework is expected to handle the header and the
+ * payload separately.
+ *
+ * Note: the header does NOT apply to frames received from the DUT.
  */
-typedef struct dut_tx_spi_frame {
+typedef struct dut_spi_frame {
   /**
    * The data payload to be sent out from the DUT to the ATE.
    *
-   * The maximum size of a payload is kDutTxMaxSpiFrameSizeInBytes.
+   * The maximum size of a payload is kDutTxMaxSpiFrameSizeInBytes (which is
+   * larger than kDutRxSpiFrameSizeInBytes).
    */
   uint8_t payload[kDutTxMaxSpiFrameSizeInBytes];
   /**
    * The number bytes contained in the payload above.
+   *
+   * This value is fixed to kDutRxSpiFrameSizeInBytes for SPI frames sent from
+   * the ATE to the DUT.
    */
   size_t size;
-} dut_tx_spi_frame_t;
-
-/**
- * A SPI console frame RXed by the DUT from the host (ATE).
- */
-typedef struct dut_rx_spi_frame {
-  /**
-   * The data payload to be sent out from the DUT to the ATE.
-   *
-   * Each payload is padded to a fixed size of kDutRxSpiFrameSizeInBytes .
-   */
-  uint8_t payload[kDutRxSpiFrameSizeInBytes];
-} dut_rx_spi_frame_t;
+} dut_spi_frame_t;
 
 /**
  * The perso blob is a structure used to store the personalization data.
@@ -677,7 +672,7 @@ DLLEXPORT int RegisterDevice(
 DLLEXPORT int TokensToJson(const token_t* wafer_auth_secret,
                            const token_t* test_unlock_token,
                            const token_t* test_exit_token,
-                           dut_rx_spi_frame_t* result);
+                           dut_spi_frame_t* result);
 
 /**
  * Parse JSON command to extract device ID from the SPI frame.
@@ -686,7 +681,7 @@ DLLEXPORT int TokensToJson(const token_t* wafer_auth_secret,
  * @param[out] device_id The extracted device ID.
  * @return The result of the operation.
  */
-DLLEXPORT int DeviceIdFromJson(const dut_tx_spi_frame_t* frame,
+DLLEXPORT int DeviceIdFromJson(const dut_spi_frame_t* frame,
                                device_id_bytes_t* device_id);
 
 /**
@@ -697,8 +692,8 @@ DLLEXPORT int DeviceIdFromJson(const dut_tx_spi_frame_t* frame,
  * @param skip_crc Whether or not to skip attaching of the CRC.
  * @return The result of the operation.
  */
-DLLEXPORT int RmaTokenToJson(const token_t* rma_token,
-                             dut_rx_spi_frame_t* result, bool skip_crc);
+DLLEXPORT int RmaTokenToJson(const token_t* rma_token, dut_spi_frame_t* result,
+                             bool skip_crc);
 
 /**
  * Parse JSON command to extract the RMA token from the SPI frame.
@@ -707,7 +702,7 @@ DLLEXPORT int RmaTokenToJson(const token_t* rma_token,
  * @param[out] rma_token The extracted RMA token.
  * @return The result of the operation.
  */
-DLLEXPORT int RmaTokenFromJson(const dut_tx_spi_frame_t* frame,
+DLLEXPORT int RmaTokenFromJson(const dut_spi_frame_t* frame,
                                token_t* rma_token);
 
 /**
@@ -720,7 +715,7 @@ DLLEXPORT int RmaTokenFromJson(const dut_tx_spi_frame_t* frame,
  */
 DLLEXPORT int CaSubjectKeysToJson(const ca_subject_key_t* dice_ca_sn,
                                   const ca_subject_key_t* aux_ca_sn,
-                                  dut_rx_spi_frame_t* result);
+                                  dut_spi_frame_t* result);
 
 /**
  * Generate JSON command to inject personalization blob.
@@ -730,8 +725,8 @@ DLLEXPORT int CaSubjectKeysToJson(const ca_subject_key_t* dice_ca_sn,
  * @param[out] num_frames The number of SPI frames generated.
  * @return The result of the operation.
  */
-DLLEXPORT int PersoBlobToJson(const perso_blob_t* blob,
-                              dut_rx_spi_frame_t* result, size_t* num_frames);
+DLLEXPORT int PersoBlobToJson(const perso_blob_t* blob, dut_spi_frame_t* result,
+                              size_t* num_frames);
 
 /**
  * Parse JSON command to extract personalization blob from the SPI frame.
@@ -741,7 +736,7 @@ DLLEXPORT int PersoBlobToJson(const perso_blob_t* blob,
  * @param[out] blob The extracted personalization blob.
  * @return The result of the operation.
  */
-DLLEXPORT int PersoBlobFromJson(const dut_tx_spi_frame_t* frames,
+DLLEXPORT int PersoBlobFromJson(const dut_spi_frame_t* frames,
                                 size_t num_frames, perso_blob_t* blob);
 
 /**

--- a/src/ate/ate_api_json_commands_test.cc
+++ b/src/ate/ate_api_json_commands_test.cc
@@ -23,7 +23,7 @@ using testing::EqualsProto;
 class AteJsonTest : public ::testing::Test {};
 
 TEST_F(AteJsonTest, TokensToJson) {
-  dut_rx_spi_frame_t frame;
+  dut_spi_frame_t frame;
   token_t wafer_auth_secret = {0};
   token_t test_unlock_token = {0};
   token_t test_exit_token = {0};
@@ -83,7 +83,7 @@ TEST_F(AteJsonTest, DeviceIdFromJson) {
                                                   options);
   EXPECT_EQ(status.ok(), true);
 
-  dut_tx_spi_frame_t frame = {0};
+  dut_spi_frame_t frame = {0};
   memcpy(frame.payload, command.data(), command.size());
   frame.size = command.size();
 
@@ -103,18 +103,13 @@ TEST_F(AteJsonTest, RmaTokenWithoutCrc) {
   rma_token.data[0] = 0x11;
   rma_token.data[1] = 0x22;
 
-  dut_rx_spi_frame_t ate_to_dut_frame;
+  dut_spi_frame_t ate_to_dut_frame;
   EXPECT_EQ(RmaTokenToJson(&rma_token, &ate_to_dut_frame, /*skip_crc=*/true),
             0);
 
   std::string json_string =
       std::string(reinterpret_cast<char*>(ate_to_dut_frame.payload),
                   kDutRxSpiFrameSizeInBytes);
-  // const std::string kWhitespace = " ";
-  // size_t last_non_whitespace = json_string.find_last_not_of(kWhitespace);
-  // if (std::string::npos != last_non_whitespace) {
-  // json_string.erase(last_non_whitespace + 1);
-  //}
 
   // Use the proto representation of RmaTokenJSON to verify the JSON string.
   ot::dut_commands::RmaTokenJSON rma_hash_cmd;
@@ -128,8 +123,8 @@ TEST_F(AteJsonTest, RmaTokenWithoutCrc) {
                 hash: 8721 hash: 0
               )pb"));
 
-  dut_tx_spi_frame_t dut_to_ate_frame = {.payload = {0},
-                                         .size = kDutTxMaxSpiFrameSizeInBytes};
+  dut_spi_frame_t dut_to_ate_frame = {.payload = {0},
+                                      .size = kDutTxMaxSpiFrameSizeInBytes};
   memcpy(dut_to_ate_frame.payload, ate_to_dut_frame.payload,
          kDutRxSpiFrameSizeInBytes);
   token_t rma_token_got = {0};
@@ -145,9 +140,9 @@ TEST_F(AteJsonTest, RmaTokenWithCrc) {
   rma_token.data[0] = 0x11;
   rma_token.data[1] = 0x22;
 
-  dut_rx_spi_frame_t frame_with_crc;
+  dut_spi_frame_t frame_with_crc;
   EXPECT_EQ(RmaTokenToJson(&rma_token, &frame_with_crc, /*skip_crc=*/false), 0);
-  dut_rx_spi_frame_t frame_without_crc;
+  dut_spi_frame_t frame_without_crc;
   EXPECT_EQ(RmaTokenToJson(&rma_token, &frame_without_crc, /*skip_crc=*/true),
             0);
 
@@ -170,7 +165,7 @@ TEST_F(AteJsonTest, RmaTokenWithCrc) {
                 hash: 8721 hash: 0
               )pb"));
 
-  dut_tx_spi_frame_t dut_to_ate_frame_with_crc = {
+  dut_spi_frame_t dut_to_ate_frame_with_crc = {
       .payload = {0}, .size = kDutTxMaxSpiFrameSizeInBytes};
   memcpy(dut_to_ate_frame_with_crc.payload, frame_with_crc.payload,
          kDutRxSpiFrameSizeInBytes);
@@ -189,7 +184,7 @@ TEST_F(AteJsonTest, CaSubjectKeys) {
   aux_ca_key_id.data[0] = 123;
   aux_ca_key_id.data[19] = 255;
 
-  dut_rx_spi_frame_t frame;
+  dut_spi_frame_t frame;
   EXPECT_EQ(CaSubjectKeysToJson(&dice_ca_key_id, &aux_ca_key_id, &frame), 0);
 
   std::string json_string = std::string(reinterpret_cast<char*>(frame.payload),
@@ -259,7 +254,7 @@ TEST_F(AteJsonTest, PersoBlob) {
   blob.next_free = sizeof(blob.body);
 
   constexpr size_t kNum256ByteFrames = 150;
-  dut_rx_spi_frame_t ate_to_dut_frames[kNum256ByteFrames] = {0};
+  dut_spi_frame_t ate_to_dut_frames[kNum256ByteFrames] = {0};
   size_t num_frames = kNum256ByteFrames;
   EXPECT_EQ(PersoBlobToJson(&blob, ate_to_dut_frames, &num_frames), 0);
   EXPECT_EQ(num_frames, 129);
@@ -267,12 +262,13 @@ TEST_F(AteJsonTest, PersoBlob) {
   // Translate the RX buffer into a TX buffer.
   const size_t kNum2020ByteFrames =
       ((kNum256ByteFrames * kDutRxSpiFrameSizeInBytes) + 2020 - 1) / 2020;
-  dut_tx_spi_frame_t dut_to_ate_frames[kNum2020ByteFrames] = {0};
+  dut_spi_frame_t dut_to_ate_frames[kNum2020ByteFrames] = {0};
   uint8_t tmp[kNum2020ByteFrames * 2020] = {0};
   memset(tmp, sizeof(tmp), ' ');
   for (size_t i = 0; i < kNum256ByteFrames; ++i) {
     memcpy(&tmp[i * kDutRxSpiFrameSizeInBytes], ate_to_dut_frames[i].payload,
            kDutRxSpiFrameSizeInBytes);
+    ate_to_dut_frames[i].size = kDutRxSpiFrameSizeInBytes;
   }
   for (size_t i = 0; i < kNum2020ByteFrames; ++i) {
     memcpy(dut_to_ate_frames[i].payload, &tmp[i * 2020], 2020);

--- a/src/ate/test_programs/cp.cc
+++ b/src/ate/test_programs/cp.cc
@@ -217,7 +217,7 @@ int main(int argc, char **argv) {
   }
 
   // Convert the tokens to a JSON payload to inject during CP.
-  dut_rx_spi_frame_t spi_frame;
+  dut_spi_frame_t spi_frame;
   if (TokensToJson(&tokens[0], &tokens[1], &tokens[2], &spi_frame) != 0) {
     LOG(ERROR) << "TokensToJson failed.";
     return -1;
@@ -231,7 +231,7 @@ int main(int argc, char **argv) {
   dut->DutConsoleTx("Waiting for CP provisioning data ...", spi_frame.payload,
                     kDutRxSpiFrameSizeInBytes,
                     /*timeout_ms=*/1000);
-  dut_tx_spi_frame_t devid_spi_frame = {0};
+  dut_spi_frame_t devid_spi_frame = {0};
   size_t num_spi_frames = 1;
   dut->DutConsoleRx("Exporting CP device ID ...", &devid_spi_frame,
                     &num_spi_frames,

--- a/src/ate/test_programs/dut_lib/dut_lib.cc
+++ b/src/ate/test_programs/dut_lib/dut_lib.cc
@@ -26,7 +26,7 @@ void OtLibBootstrap(void* transport, const char* bin);
 void OtLibConsoleWaitForRx(void* transport, const char* msg,
                            uint64_t timeout_ms);
 void OtLibConsoleRx(void* transport, const char* sync_msg,
-                    dut_tx_spi_frame_t* spi_frames, size_t* num_frames,
+                    dut_spi_frame_t* spi_frames, size_t* num_frames,
                     bool skip_crc_check, bool quiet, uint64_t timeout_ms);
 void OtLibConsoleTx(void* transport, const char* sync_msg,
                     const uint8_t* spi_frame, size_t spi_frame_size,
@@ -67,7 +67,7 @@ void DutLib::DutConsoleWaitForRx(const char* msg, uint64_t timeout_ms) {
 }
 
 void DutLib::DutConsoleRx(const std::string& sync_msg,
-                          dut_tx_spi_frame_t* spi_frames, size_t* num_frames,
+                          dut_spi_frame_t* spi_frames, size_t* num_frames,
                           bool skip_crc_check, bool quiet,
                           uint64_t timeout_ms) {
   LOG(INFO) << "in DutLib::DutConsoleRx";

--- a/src/ate/test_programs/dut_lib/dut_lib.h
+++ b/src/ate/test_programs/dut_lib/dut_lib.h
@@ -44,7 +44,7 @@ class DutLib {
   /**
    * Calls opentitanlib test util to receive a message over the SPI console.
    */
-  void DutConsoleRx(const std::string& sync_msg, dut_tx_spi_frame_t* spi_frames,
+  void DutConsoleRx(const std::string& sync_msg, dut_spi_frame_t* spi_frames,
                     size_t* num_frames, bool skip_crc_check, bool quiet,
                     uint64_t timeout_ms);
   /**

--- a/src/ate/test_programs/ft.cc
+++ b/src/ate/test_programs/ft.cc
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
     LOG(ERROR) << "GenerateTokens failed.";
     return -1;
   }
-  dut_rx_spi_frame_t rma_token_spi_frame;
+  dut_spi_frame_t rma_token_spi_frame;
   if (RmaTokenToJson(&rma_token, &rma_token_spi_frame, /*skip_crc=*/false) !=
       0) {
     LOG(ERROR) << "RmaTokenToJson failed.";
@@ -264,7 +264,7 @@ int main(int argc, char **argv) {
   }
   const ca_subject_key_t *kDiceCaSk = &key_ids[0];
   const ca_subject_key_t *kExtCaSk = &key_ids[1];
-  dut_rx_spi_frame_t ca_key_ids_spi_frame;
+  dut_spi_frame_t ca_key_ids_spi_frame;
   if (CaSubjectKeysToJson(kDiceCaSk, kExtCaSk, &ca_key_ids_spi_frame) != 0) {
     LOG(ERROR) << "CaSubjectKeysToJson failed.";
     return -1;
@@ -292,7 +292,7 @@ int main(int argc, char **argv) {
 
   // Receive the TBS certs and other provisioning data from the DUT.
   constexpr size_t kMaxNumPbSpiFrames = 10;
-  dut_tx_spi_frame_t pb_spi_frames[kMaxNumPbSpiFrames];
+  dut_spi_frame_t pb_spi_frames[kMaxNumPbSpiFrames];
   size_t num_pb_spi_frames = kMaxNumPbSpiFrames;
   dut->DutConsoleRx("Exporting TBS certificates ...", pb_spi_frames,
                     &num_pb_spi_frames,
@@ -356,8 +356,7 @@ int main(int argc, char **argv) {
   // Send the endorsed certs back to the device.
   perso_blob_t perso_blob_from_ate = {0};
   constexpr size_t kNumPersoBlobMaxNumSpiFrames = 50;
-  dut_rx_spi_frame_t
-      perso_blob_from_ate_spi_frames[kNumPersoBlobMaxNumSpiFrames];
+  dut_spi_frame_t perso_blob_from_ate_spi_frames[kNumPersoBlobMaxNumSpiFrames];
   size_t num_perso_blob_spi_frames = kNumPersoBlobMaxNumSpiFrames;
   if (PackPersoBlob(num_tbs_certs, pa_endorsed_certs, &perso_blob_from_ate) !=
       0) {

--- a/src/ate/test_programs/otlib_wrapper/src/lib.rs
+++ b/src/ate/test_programs/otlib_wrapper/src/lib.rs
@@ -41,13 +41,13 @@ use opentitanlib::uart::console::{ExitStatus, UartConsole};
 
 // NOTE: must match kDutTxMaxSpiFrameSizeInBytes defined in src/ate/ate_api.h
 // TODO(timothytrippel): look into using bindgen here to keep in sync
-const DUT_TX_BUFFER_SIZE: usize = 2020;
+const CONSOLE_BUFFER_MAX_SIZE: usize = 2020;
 
-// NOTE: must match definition of dut_tx_spi_frame_t defined in src/ate/ate_api.h
+// NOTE: must match definition of dut_spi_frame_t defined in src/ate/ate_api.h
 // TODO(timothytrippel): look into using bindgen here to keep in sync
 #[repr(C)]
-pub struct DutTxSpiFrame {
-    pub payload: [u8; DUT_TX_BUFFER_SIZE],
+pub struct DutSpiFrame {
+    pub payload: [u8; CONSOLE_BUFFER_MAX_SIZE],
     pub size: usize,
 }
 
@@ -274,7 +274,7 @@ fn check_console_crc(json_str: &str, crc_str: &str) -> Result<()> {
 pub extern "C" fn OtLibConsoleRx(
     transport: *const TransportWrapper,
     sync_msg: *mut c_char,
-    spi_frames: *mut DutTxSpiFrame,
+    spi_frames: *mut DutSpiFrame,
     num_frames: *mut usize,
     skip_crc_check: bool,
     quiet: bool,
@@ -343,19 +343,19 @@ pub extern "C" fn OtLibConsoleRx(
                 check_console_crc(json_str, crc_str).expect("CRC check failed.");
             }
             let num_frames_required =
-                (json_str.len() + DUT_TX_BUFFER_SIZE - 1) / DUT_TX_BUFFER_SIZE;
+                (json_str.len() + CONSOLE_BUFFER_MAX_SIZE - 1) / CONSOLE_BUFFER_MAX_SIZE;
             if *num_frames < num_frames_required {
                 panic!(
                         "Not enough frames ({} frames of size {} bytes) allocated to receive JSON string of length {}",
                         *num_frames,
-                        DUT_TX_BUFFER_SIZE,
+                        CONSOLE_BUFFER_MAX_SIZE,
                         json_str.len()
                     )
             }
             for (i, spi_frame) in spi_frames.iter_mut().enumerate() {
                 if i < num_frames_required {
-                    let start = i * DUT_TX_BUFFER_SIZE;
-                    let end = (start + DUT_TX_BUFFER_SIZE).min(json_str.len());
+                    let start = i * CONSOLE_BUFFER_MAX_SIZE;
+                    let end = (start + CONSOLE_BUFFER_MAX_SIZE).min(json_str.len());
                     let chunk = &json_str.as_bytes()[start..end];
                     let chunk_len = chunk.len();
                     spi_frame.payload[..chunk_len].copy_from_slice(chunk);


### PR DESCRIPTION
This consolidates the `dut_rx_spi_frame_t` and `dut_tx_spi_frame_t` types into a single `dut_spi_frame_t` type. While SPI frames received from the DUT may be different sizes, SPI frames sent to the DUT are fixed to a size of 256 bytes.