### PR TITLE
[pa,spm,ate] add scaffolding to verify hash of all certs

### DIFF
--- a/config/spm/sku_cr01.yml.tmpl
+++ b/config/spm/sku_cr01.yml.tmpl
@@ -35,3 +35,11 @@ attributes:
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
     CertChainDiceLeaf: CDI_1
     OwnerFirmwareBootMessage: "Key ladder state: Prod"
+x509CertHashOrder:
+    - UDS
+    - CDI_0
+    - CDI_1
+    - TPM EK
+    - TPM CEK
+    - TPM CIK
+    - CROS UDS

--- a/config/spm/sku_pi01.yml.tmpl
+++ b/config/spm/sku_pi01.yml.tmpl
@@ -35,3 +35,11 @@ attributes:
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
     CertChainDiceLeaf: UDS
     OwnerFirmwareBootMessage: "...sleeping..."
+cwtCertHashOrder:
+    - UDS
+    - CDI_0
+    - CDI_1
+x509CertHashOrder:
+    - UDS
+    - CEK_0
+    - CEK_1

--- a/config/spm/sku_sival.yml.tmpl
+++ b/config/spm/sku_sival.yml.tmpl
@@ -31,3 +31,7 @@ attributes:
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
     CertChainDiceLeaf: CDI_1
     OwnerFirmwareBootMessage: "ownership: OWND"
+x509CertHashOrder:
+    - UDS
+    - CDI_0
+    - CDI_1

--- a/config/spm/sku_ti01.yml.tmpl
+++ b/config/spm/sku_ti01.yml.tmpl
@@ -31,3 +31,7 @@ attributes:
     SigningKey/Identity/v0: spm-hsm-id-v0.priv
     CertChainDiceLeaf: CDI_1
     OwnerFirmwareBootMessage: "pie_rot_earlgrey_mfg"
+x509CertHashOrder:
+    - UDS
+    - CDI_0
+    - CDI_1

--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -437,9 +437,9 @@ typedef struct ca_subject_key {
 /**
  * Type used to wrap the personalization firmware hash raw bytes.
  */
-typedef struct perso_fw_sha256_hash {
+typedef struct sha256_hash {
   uint8_t raw[kSha256HashSize];
-} perso_fw_sha256_hash_t;
+} sha256_hash_t;
 
 /**
  * DeviceLifeCycle encodes the state of the device as it is being manufactured
@@ -651,6 +651,7 @@ DLLEXPORT int GetOwnerFwBootMessage(ate_client_ptr client, const char* sku,
  * @param wrapped_rma_unlock_token_seed The encrypted RMA unlock token seed.
  * @param perso_blob_for_registry The perso blob TLV data structure to store.
  * @param perso_fw_hash The hash of the perso firmware that was executed.
+ * @param hash_of_all_certs The hash of all certs installed on the DUT.
  * @return The result of the operation.
  */
 DLLEXPORT int RegisterDevice(
@@ -658,7 +659,7 @@ DLLEXPORT int RegisterDevice(
     device_life_cycle_t device_life_cycle, const metadata_t* metadata,
     const wrapped_seed_t* wrapped_rma_unlock_token_seed,
     const perso_blob_t* perso_blob_for_registry,
-    const perso_fw_sha256_hash_t* perso_fw_hash);
+    const sha256_hash_t* perso_fw_hash, const sha256_hash_t* hash_of_all_certs);
 
 /**
  * Generate JSON command to inject tokens.
@@ -740,6 +741,16 @@ DLLEXPORT int PersoBlobFromJson(const dut_spi_frame_t* frames,
                                 size_t num_frames, perso_blob_t* blob);
 
 /**
+ * Parse JSON command to extract SHA256 hash from a SPI frame.
+ *
+ * @param frame The SPI frame containing the JSON command.
+ * @param[out] hash The extracted SHA256 hash.
+ * @return The result of the operation.
+ */
+DLLEXPORT int Sha256HashFromJson(const dut_spi_frame_t* frame,
+                                 sha256_hash_t* hash);
+
+/**
  * Unpack a personalization blob into its components.
  *
  * @param blob The personalization blob to unpack.
@@ -759,7 +770,7 @@ DLLEXPORT int PersoBlobFromJson(const dut_spi_frame_t* frames,
  */
 DLLEXPORT int UnpackPersoBlob(
     const perso_blob_t* blob, device_id_bytes_t* device_id,
-    endorse_cert_signature_t* signature, perso_fw_sha256_hash_t* perso_fw_hash,
+    endorse_cert_signature_t* signature, sha256_hash_t* perso_fw_hash,
     endorse_cert_request_t* tbs_certs, size_t* tbs_cert_count,
     endorse_cert_response_t* certs, size_t* cert_count, seed_t* seeds,
     size_t* seed_count);

--- a/src/ate/ate_dll.cc
+++ b/src/ate/ate_dll.cc
@@ -644,7 +644,8 @@ DLLEXPORT int RegisterDevice(
     device_life_cycle_t device_life_cycle, const metadata_t *metadata,
     const wrapped_seed_t *wrapped_rma_unlock_token_seed,
     const perso_blob_t *perso_blob_for_registry,
-    const perso_fw_sha256_hash_t *perso_fw_hash) {
+    const sha256_hash_t *perso_fw_hash,
+    const sha256_hash_t *hash_of_all_certs) {
   DLOG(INFO) << "RegisterDevice";
 
   if (sku == nullptr || device_id == nullptr || metadata == nullptr ||
@@ -664,6 +665,11 @@ DLLEXPORT int RegisterDevice(
   // Build the RegisterDeviceRequest object.
   pa::RegistrationRequest req;
   auto device_data = req.mutable_device_data();
+
+  // Certs hash type and hash.
+  req.set_hash_type(crypto::common::HashType::HASH_TYPE_SHA256);
+  req.set_certs_hash(std::string(
+      reinterpret_cast<const char *>(hash_of_all_certs->raw), kSha256HashSize));
 
   // SKU.
   device_data->set_sku(sku);

--- a/src/ate/ate_perso_blob.cc
+++ b/src/ate/ate_perso_blob.cc
@@ -289,7 +289,7 @@ int PackSeedTlvObject(const seed_t* seed, perso_blob_t* blob) {
 
 DLLEXPORT int UnpackPersoBlob(
     const perso_blob_t* blob, device_id_bytes_t* device_id,
-    endorse_cert_signature_t* signature, perso_fw_sha256_hash_t* perso_fw_hash,
+    endorse_cert_signature_t* signature, sha256_hash_t* perso_fw_hash,
     endorse_cert_request_t* tbs_certs, size_t* tbs_cert_count,
     endorse_cert_response_t* certs, size_t* cert_count, seed_t* seeds,
     size_t* seed_count) {
@@ -308,7 +308,7 @@ DLLEXPORT int UnpackPersoBlob(
 
   memset(device_id->raw, 0, sizeof(device_id_bytes_t));
   memset(signature->raw, 0, sizeof(endorse_cert_signature_t));
-  memset(perso_fw_hash->raw, 0, sizeof(perso_fw_sha256_hash_t));
+  memset(perso_fw_hash->raw, 0, sizeof(sha256_hash_t));
 
   size_t max_tbs_cert_count = *tbs_cert_count;
   *tbs_cert_count = 0;
@@ -427,11 +427,11 @@ DLLEXPORT int UnpackPersoBlob(
       }
 
       case kPersoObjectTypePersoSha256Hash: {
-        if (obj_size != sizeof(perso_fw_sha256_hash_t) +
-                            sizeof(perso_tlv_object_header_t)) {
+        if (obj_size !=
+            sizeof(sha256_hash_t) + sizeof(perso_tlv_object_header_t)) {
           LOG(ERROR) << "Invalid size for perso firmware hash object: "
                      << obj_size << ", expected: "
-                     << (sizeof(perso_fw_sha256_hash_t) +
+                     << (sizeof(sha256_hash_t) +
                          sizeof(perso_tlv_object_header_t));
           return -1;
         }

--- a/src/ate/ate_perso_blob_test.cc
+++ b/src/ate/ate_perso_blob_test.cc
@@ -114,7 +114,7 @@ TEST_F(AtePersoBlobTest, UnpackPersoBlobSuccess) {
 
   device_id_bytes_t device_id;
   endorse_cert_signature_t signature;
-  perso_fw_sha256_hash_t perso_fw_hash = {.raw = {0}};
+  sha256_hash_t perso_fw_hash = {.raw = {0}};
   size_t tbs_cert_count = 10;
   size_t cert_count = 10;
   endorse_cert_request_t x509_tbs_certs[10];
@@ -147,7 +147,7 @@ TEST_F(AtePersoBlobTest, UnpackPersoBlobNullInputs) {
 
   device_id_bytes_t device_id;
   endorse_cert_signature_t signature;
-  perso_fw_sha256_hash_t perso_fw_hash = {.raw = {0}};
+  sha256_hash_t perso_fw_hash = {.raw = {0}};
   size_t tbs_cert_count = 10;
   size_t cert_count = 10;
   endorse_cert_request_t x509_tbs_certs[10];

--- a/src/ate/perso_blob.go
+++ b/src/ate/perso_blob.go
@@ -1,6 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+
 package ate
 
 import (

--- a/src/ate/proto/dut_commands.proto
+++ b/src/ate/proto/dut_commands.proto
@@ -81,3 +81,11 @@ message PersoBlobJSON {
   repeated uint32 body = 3;
 }
 
+// Provides the serdes_sha256_hash_t data structure used by provisioning
+// firmware.
+message Sha256JSON {
+  // SHA256 hash encoded as 8 uint32 values.
+  // Required.
+  // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
+  repeated uint32 data = 1;
+}

--- a/src/pa/loadtest.go
+++ b/src/pa/loadtest.go
@@ -349,6 +349,8 @@ func processDut(ctx context.Context, c *clientTask, skuName string, dut *dututil
 			PersoTlvData:       persoTlv,
 			NumPersoTlvObjects: numObjs,
 		},
+		HashType:  pbcommon.HashType_HASH_TYPE_SHA256,
+		CertsHash: make([]byte, 32),
 	}
 	if _, err := c.client.RegisterDevice(client_ctx, regReq); err != nil {
 		return fmt.Errorf("failed to register device: %w", err)

--- a/src/pa/proto/BUILD.bazel
+++ b/src/pa/proto/BUILD.bazel
@@ -15,6 +15,7 @@ proto_library(
     deps = [
         "//src/proto:device_id_proto",
         "//src/proto/crypto:cert_proto",
+        "//src/proto/crypto:common_proto",
         "//src/proto/crypto:wrap_proto",
     ],
 )
@@ -27,6 +28,7 @@ go_proto_library(
     deps = [
         "//src/proto:device_id_go_pb",
         "//src/proto/crypto:cert_go_pb",
+        "//src/proto/crypto:common_go_pb",
         "//src/proto/crypto:wrap_go_pb",
     ],
 )

--- a/src/pa/proto/pa.proto
+++ b/src/pa/proto/pa.proto
@@ -8,6 +8,7 @@ syntax = "proto3";
 package pa;
 
 import "src/proto/crypto/cert.proto";
+import "src/proto/crypto/common.proto";
 import "src/proto/device_id.proto";
 
 option go_package = "pa_go_pb";
@@ -225,6 +226,10 @@ message CloseSessionResponse {
 message RegistrationRequest {
   // Device record. Required.
   ot.DeviceData device_data = 1;
+  // Hash type of certificates (for integrity check). Required.
+  crypto.common.HashType hash_type = 2;
+  // Hash of certificates written to non-volatile storage on the DUT. Required.
+  bytes certs_hash = 3;
 }
 
 // Device Registration reponse.

--- a/src/pa/services/pa.go
+++ b/src/pa/services/pa.go
@@ -180,6 +180,8 @@ func (s *server) RegisterDevice(ctx context.Context, request *pap.RegistrationRe
 	// Verify the device data.
 	if _, err := s.spmClient.VerifyDeviceData(ctx, &pbs.VerifyDeviceDataRequest{
 		DeviceData: request.DeviceData,
+		HashType:   request.HashType,
+		CertsHash:  request.CertsHash,
 	}); err != nil {
 		st := status.Convert(err)
 		return nil, status.Errorf(st.Code(), "SPM.VerifyDeviceData returned error: %s", st.Message())

--- a/src/spm/proto/BUILD.bazel
+++ b/src/spm/proto/BUILD.bazel
@@ -14,6 +14,7 @@ proto_library(
         "//src/pa/proto:pa_proto",
         "//src/proto:device_id_proto",
         "//src/proto/crypto:cert_proto",
+        "//src/proto/crypto:common_proto",
     ],
 )
 
@@ -26,5 +27,6 @@ go_proto_library(
         "//src/pa/proto:pa_go_pb",
         "//src/proto:device_id_go_pb",
         "//src/proto/crypto:cert_go_pb",
+        "//src/proto/crypto:common_go_pb",
     ],
 )

--- a/src/spm/proto/spm.proto
+++ b/src/spm/proto/spm.proto
@@ -9,6 +9,7 @@ package spm;
 
 import "src/pa/proto/pa.proto";
 import "src/proto/crypto/cert.proto";
+import "src/proto/crypto/common.proto";
 import "src/proto/device_id.proto";
 
 option go_package = "spm_go_bp";
@@ -79,6 +80,10 @@ message EndorseDataResponse {
 message VerifyDeviceDataRequest {
   // Device data to verify. Required.
   ot.DeviceData device_data = 1;
+  // Hash type of certificates (for integrity check). Required.
+  crypto.common.HashType hash_type = 2;
+  // Hash of certificates written to non-volatile storage on the DUT. Required.
+  bytes certs_hash = 3;
 }
 
 // Verify device data response.

--- a/src/spm/services/skucfg.go
+++ b/src/spm/services/skucfg.go
@@ -35,16 +35,18 @@ const (
 )
 
 type Config struct {
-	Sku           string            `yaml:"sku"`
-	SlotID        int               `yaml:"slotId"`
-	NumSessions   int               `yaml:"numSessions"`
-	CertCountX509 int               `yaml:"certCountX509"`
-	CertCountCWT  int               `yaml:"certCountCWT"`
-	SymmetricKeys []SymmetricKey    `yaml:"symmetricKeys"`
-	PrivateKeys   []PrivateKey      `yaml:"privateKeys"`
-	PublicKeys    []PublicKey       `yaml:"publicKeys"`
-	Certs         []Certificate     `yaml:"certs"`
-	Attributes    map[string]string `yaml:"attributes"`
+	Sku                  string            `yaml:"sku"`
+	SlotID               int               `yaml:"slotId"`
+	NumSessions          int               `yaml:"numSessions"`
+	CertCountX509        int               `yaml:"certCountX509"`
+	CertCountCWT         int               `yaml:"certCountCWT"`
+	SymmetricKeys        []SymmetricKey    `yaml:"symmetricKeys"`
+	PrivateKeys          []PrivateKey      `yaml:"privateKeys"`
+	PublicKeys           []PublicKey       `yaml:"publicKeys"`
+	Certs                []Certificate     `yaml:"certs"`
+	Attributes           map[string]string `yaml:"attributes"`
+	DutCwtCertHashOrder  []string          `yaml:"cwtCertHashOrder"`
+	DutX509CertHashOrder []string          `yaml:"x509CertHashOrder"`
 }
 
 type SymmetricKey struct {


### PR DESCRIPTION
After writing all certificates to flash, the DUT reads out each certificate and computes a SHA256 hash over them. It then sends this hash to the host so the provisioning-infrastructure can validate the certificates were installed successfully into non-volatile storage on the DUT.

To validate this hash, we update the RegisterDevice API to validate the hash of all certs written to flash.