### PR TITLE
[ate] bump ATE DLL version to 2.0.0.0

### DIFF
--- a/src/ate/version.rc
+++ b/src/ate/version.rc
@@ -1,8 +1,8 @@
 #include "winver.h"
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 1,0,5,0
-PRODUCTVERSION 1,0,5,0
+FILEVERSION 2,0,0,0
+PRODUCTVERSION 2,0,0,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
 FILEFLAGS 0x1L
@@ -17,14 +17,14 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "CompanyName", "Nuvoton\0"
+            VALUE "CompanyName", "lowRISC\0"
             VALUE "FileDescription", "ATE DLL\0"
-            VALUE "FileVersion", "1.0.5.0\0"
+            VALUE "FileVersion", "2.0.0.0\0"
             VALUE "InternalName", "ate.dll\0"
-            VALUE "LegalCopyright", "Copyright (C) Nuvoton 2024\0"
+            VALUE "LegalCopyright", "Copyright lowRISC contributors (OpenTitan project)\0"
             VALUE "OriginalFilename", "ate.dll\0"
             VALUE "ProductName", "ATE DLL\0"
-            VALUE "ProductVersion", "1.0.5.0\0"
+            VALUE "ProductVersion", "2.0.0.0\0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
This bumps the ATE DLL release version to 2.0.0.0 to reflect the first release / deployment.