### PR TITLE
[device_id] fix device ID string formatting util

### DIFF
--- a/src/proto/device_id_utils.go
+++ b/src/proto/device_id_utils.go
@@ -15,7 +15,7 @@ const (
 
 // Converts a DeviceId proto object into a hex string.
 func DeviceIdToHexString(di *dpb.DeviceId) string {
-	return fmt.Sprintf("0x%x%08x%016x%08x%08x",
+	return fmt.Sprintf("0x%032x%08x%016x%04x%04x",
 		di.SkuSpecific,
 		ReservedDeviceIdField,
 		uint64(di.HardwareOrigin.DeviceIdentificationNumber),


### PR DESCRIPTION
There were several bugs in the device ID to hextstring util:
1. Si Creator ID should be 16 bits not 32.
2. Product ID should be 16 bits not 32.
3. SKU specific field should be 128 bits.