### PR TITLE
[ate] fixed the WAS TBS HMAC existence check

### DIFF
--- a/src/ate/ate_perso_blob.cc
+++ b/src/ate/ate_perso_blob.cc
@@ -445,10 +445,18 @@ DLLEXPORT int UnpackPersoBlob(
     remaining -= obj_size;
   }
 
-  if (signature->raw[0] == 0) {
+  bool all_zero = true;
+  for (size_t i = 0; i < sizeof(signature->raw); ++i) {
+    if (signature->raw[i] != 0) {
+      all_zero = false;
+      break;
+    }
+  }
+  if (all_zero) {
     LOG(ERROR) << "No WAS TBS HMAC found in the blob";
     return -1;
   }
+
   if (*tbs_cert_count == 0) {
     LOG(ERROR) << "No TBS certificates found in the blob";
     return -1;


### PR DESCRIPTION
The check of WAS TBS HMAC existence in a perso blob, is now done by scanning the entire signature bytes. An error is returned only if all the bytes are zeros.