### PR TITLE
[spm] Clear ephemeral keys from memory in GenerateTokens.

### DIFF
--- a/src/spm/services/se_pk11.go
+++ b/src/spm/services/se_pk11.go
@@ -281,6 +281,12 @@ func (h *HSM) GenerateTokens(params []*TokenParams) ([]TokenResult, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate random key: %v", err)
 			}
+			cleanup_seed := func() {
+				if err := seed.Destroy(); err != nil {
+					log.Printf("failed to destroy generated key: %v", err)
+				}
+			}
+			defer cleanup_seed()
 		default:
 			return nil, fmt.Errorf("unsupported key type: %v", p.Type)
 		}

--- a/src/spm/services/testutils/tbsgen.go
+++ b/src/spm/services/testutils/tbsgen.go
@@ -77,7 +77,7 @@ func buildTestTbsCert(session *pk11.Session, label string, intermediateCACert *x
 			CommonName:   label,
 		},
 		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(time.Hour),
+		NotAfter:              time.Now().Add(7 * 24 * time.Hour),
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,


### PR DESCRIPTION
The `TokenTypeKeyGen` in `GenerateTokens()` generates an emphemeral key which is exported in wrapped form. This change deletes the object from the HSM memory after it is no longer needed.