### PR TITLE
[ft] get CA certs from SPM during perso

### DIFF
--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -54,11 +54,13 @@ if [[ -n "${OT_PROV_ORCHESTRATOR_PATH}" ]]; then
 fi
 
 for OTSKU in "${FPGA_SKUS[@]}"; do
-  # Workaround for the ti01 SKU, which is actually a ti00 SKU in the
-  # orchestrator release.
+  # Workaround for the ti01 and pi01 SKUs, which are actually the ti00 and pi02
+  # SKUs in the orchestrator release.
   SKU_NAME="${OTSKU}"
   if [[ "${OTSKU}" == "ti01" ]]; then
     SKU_NAME="ti00"
+  elif [[ "${OTSKU}" == "pi01" ]]; then
+    SKU_NAME="pi02"
   fi
 
   echo "Running CP FPGA test flow SKU: ${OTSKU} ..."

--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -615,6 +615,22 @@ DLLEXPORT int GetCaSubjectKeys(ate_client_ptr client, const char* sku,
                                ca_subject_key_t* key_ids);
 
 /**
+ * Gets the CA certificates.
+ *
+ * This function retrieves the CA certificates from the PA/SPM. The caller
+ * should allocate enough memory to store the certificates.
+ *
+ * @param client A client instance.
+ * @param sku The SKU of the product to get the certificates for.
+ * @param count The number of certificates to retrieve.
+ * @param labels The lable strings of the certs to retrieve. Size `count`.
+ * @param[out] certs The certificates. Size `count`.
+ * @return The result of the operation.
+ */
+DLLEXPORT int GetCaCerts(ate_client_ptr client, const char* sku, size_t count,
+                         const char** labels, endorse_cert_response_t* certs);
+
+/**
  * Endorse certificates.
  *
  * The function endorses certificates based on the request parameters.
@@ -800,11 +816,15 @@ DLLEXPORT int UnpackPersoBlob(
  *
  * @param cert_count The number of certificates to pack.
  * @param certs The array of endorsed certificates to pack.
+ * @param ca_cert_count The number of CA certificates to pack.
+ * @param ca_certs The array of CA certificates to pack.
  * @param[out] blob The personalization blob to pack the certificates into.
  * @return The result of the operation.
  */
 DLLEXPORT int PackPersoBlob(size_t cert_count,
                             const endorse_cert_response_t* certs,
+                            size_t ca_cert_count,
+                            const endorse_cert_response_t* ca_certs,
                             perso_blob_t* blob);
 
 /**

--- a/src/ate/ate_client.cc
+++ b/src/ate/ate_client.cc
@@ -29,6 +29,8 @@ using pa::DeriveTokensRequest;
 using pa::DeriveTokensResponse;
 using pa::EndorseCertsRequest;
 using pa::EndorseCertsResponse;
+using pa::GetCaCertsRequest;
+using pa::GetCaCertsResponse;
 using pa::GetCaSubjectKeysRequest;
 using pa::GetCaSubjectKeysResponse;
 using pa::GetOwnerFwBootMessageRequest;
@@ -177,6 +179,19 @@ Status AteClient::GetCaSubjectKeys(GetCaSubjectKeysRequest& request,
 
   // The actual RPC - call the server's DeriveTokens method.
   return stub_->GetCaSubjectKeys(&context, request, reply);
+}
+
+Status AteClient::GetCaCerts(GetCaCertsRequest& request,
+                             GetCaCertsResponse* reply) {
+  LOG(INFO) << "AteClient::GetCaCerts";
+
+  // Context for the client (It could be used to convey extra information to
+  // the server and/or tweak certain RPC behaviors).
+  ClientContext context;
+  context.AddMetadata("authorization", sku_session_token_);
+
+  // The actual RPC - call the server's DeriveTokens method.
+  return stub_->GetCaCerts(&context, request, reply);
 }
 
 Status AteClient::GetOwnerFwBootMessage(GetOwnerFwBootMessageRequest& request,

--- a/src/ate/ate_client.h
+++ b/src/ate/ate_client.h
@@ -91,6 +91,10 @@ class AteClient {
   grpc::Status GetCaSubjectKeys(pa::GetCaSubjectKeysRequest& request,
                                 pa::GetCaSubjectKeysResponse* reply);
 
+  // Calls the server's GetCaCerts method and returns its reply.
+  grpc::Status GetCaCerts(pa::GetCaCertsRequest& request,
+                          pa::GetCaCertsResponse* reply);
+
   // Calls the server's GetOwnerFwBootMessage method and returns its reply.
   grpc::Status GetOwnerFwBootMessage(pa::GetOwnerFwBootMessageRequest& request,
                                      pa::GetOwnerFwBootMessageResponse* reply);

--- a/src/ate/ate_perso_blob.cc
+++ b/src/ate/ate_perso_blob.cc
@@ -475,6 +475,8 @@ DLLEXPORT int UnpackPersoBlob(
 
 DLLEXPORT int PackPersoBlob(size_t cert_count,
                             const endorse_cert_response_t* certs,
+                            size_t ca_cert_count,
+                            const endorse_cert_response_t* ca_certs,
                             perso_blob_t* blob) {
   if (blob == nullptr) {
     LOG(ERROR) << "Invalid personalization blob pointer";
@@ -498,6 +500,19 @@ DLLEXPORT int PackPersoBlob(size_t cert_count,
       return -1;
     }
   }
+
+  for (size_t i = 0; i < ca_cert_count; i++) {
+    const endorse_cert_response_t& cert = ca_certs[i];
+    if (cert.cert_size == 0) {
+      LOG(ERROR) << "Invalid CA certificate at index " << i;
+      return -1;
+    }
+    if (PackCertTlvObject(&cert, blob) != 0) {
+      LOG(ERROR) << "Unable to pack CA certificate into perso blob.";
+      return -1;
+    }
+  }
+
   return 0;
 }
 

--- a/src/ate/ate_perso_blob_test.cc
+++ b/src/ate/ate_perso_blob_test.cc
@@ -174,7 +174,7 @@ TEST_F(AtePersoBlobTest, UnpackPersoBlobNullInputs) {
 
 TEST_F(AtePersoBlobTest, PackPersoBlobSuccess) {
   perso_blob_t output_blob;
-  EXPECT_EQ(PackPersoBlob(1, &test_response_, &output_blob), 0);
+  EXPECT_EQ(PackPersoBlob(1, &test_response_, 0, nullptr, &output_blob), 0);
 
   // Verify the blob size is correct
   size_t expected_size =
@@ -187,13 +187,13 @@ TEST_F(AtePersoBlobTest, PackPersoBlobNullInputs) {
   perso_blob_t output_blob;
 
   // Test null blob
-  EXPECT_EQ(PackPersoBlob(1, &test_response_, nullptr), -1);
+  EXPECT_EQ(PackPersoBlob(1, &test_response_, 0, nullptr, nullptr), -1);
 
   // Test null certs
-  EXPECT_EQ(PackPersoBlob(1, nullptr, &output_blob), -1);
+  EXPECT_EQ(PackPersoBlob(1, nullptr, 0, nullptr, &output_blob), -1);
 
   // Test zero cert count
-  EXPECT_EQ(PackPersoBlob(0, &test_response_, &output_blob), -1);
+  EXPECT_EQ(PackPersoBlob(0, &test_response_, 0, nullptr, &output_blob), -1);
 }
 
 TEST_F(AtePersoBlobTest, PackPersoBlobOverflow) {
@@ -205,7 +205,7 @@ TEST_F(AtePersoBlobTest, PackPersoBlobOverflow) {
   large_cert.key_label_size = 8;
   memcpy(large_cert.key_label, "testkey1", 8);
 
-  EXPECT_EQ(PackPersoBlob(1, &large_cert, &output_blob), -1);
+  EXPECT_EQ(PackPersoBlob(1, &large_cert, 0, nullptr, &output_blob), -1);
 }
 
 }  // namespace

--- a/third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh
+++ b/third_party/lowrisc/ot_bitstreams/build-ot-bitstreams.sh
@@ -19,7 +19,7 @@ fi
 
 OT_REPO_TOP=$1
 
-_OT_REPO_BRANCH="Earlgrey-A2-Orchestrator-RC2"
+_OT_REPO_BRANCH="Earlgrey-A2-Orchestrator-RC3"
 _PROVISIONING_REPO_TOP=$(pwd)
 _FPGAS=("hyper310" "cw340")
 _CP_SKUS=("emulation")

--- a/third_party/lowrisc/ot_bitstreams/cp_hyper310.bit
+++ b/third_party/lowrisc/ot_bitstreams/cp_hyper310.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28d334cd26a2db68ba5187545b208e3a578534303dba54a7f343572288b69da0
+oid sha256:ea9f7f72440dc22cfe16523b5fe2a6cd9c53141ff9109af1f6fbb72a0513c2b0
 size 15878032

--- a/third_party/lowrisc/ot_bitstreams/cp_hyper340.bit
+++ b/third_party/lowrisc/ot_bitstreams/cp_hyper340.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf919e400708298d4e895bc6dc1cdc12ebde1a9ac986446097135010a8400e2a
+oid sha256:f37083334c82e9bb439eb566b3f96bedfe29aade94bbac5a169826a03da36c08
 size 35843488

--- a/third_party/lowrisc/ot_fw/build-orch-zip.sh
+++ b/third_party/lowrisc/ot_fw/build-orch-zip.sh
@@ -19,7 +19,7 @@ fi
 
 OT_REPO_TOP=$1
 
-_OT_REPO_BRANCH="Earlgrey-A2-Orchestrator-RC1"
+_OT_REPO_BRANCH="Earlgrey-A2-Orchestrator-RC3"
 _PROVISIONING_REPO_TOP=$(pwd)
 _ORCHESTRATOR_ZIP_PATH="bazel-bin/sw/host/provisioning/orchestrator/src/orchestrator.zip"
 

--- a/third_party/lowrisc/ot_fw/orchestrator.zip
+++ b/third_party/lowrisc/ot_fw/orchestrator.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5098ee556ecd5067cc03dd8a2da84d51caa1e460edf49bce63212040d2da6774
-size 112565360
+oid sha256:bd22b872608372a58fb4a5875ef5fc817f61e89d676f658eaad947bb06108f53
+size 117629028

--- a/util/integration_test_setup.sh
+++ b/util/integration_test_setup.sh
@@ -89,7 +89,7 @@ trap shutdown_callback EXIT
 
 
 DEPLOYMENT_BIN_DIR="${OPENTITAN_VAR_DIR}/bin"
-BUILD_BIN_DIR="bazel-bin/third_party/lowrisc/ot_fw/orchestrator/runfiles/lowrisc_opentitan"
+BUILD_BIN_DIR="bazel-bin/third_party/lowrisc/ot_fw/orchestrator/runfiles/_main"
 if [[ -z "${OT_PROV_ORCHESTRATOR_PATH}" ]]; then
   bazelisk build //third_party/lowrisc/ot_fw:orchestrator_unzip
 else
@@ -100,7 +100,7 @@ else
     exit 1
   fi
   ORCHESTRATOR_OUT="${OPENTITAN_VAR_DIR}/orchestrator"
-  BUILD_BIN_DIR="${ORCHESTRATOR_OUT}/runfiles/lowrisc_opentitan"
+  BUILD_BIN_DIR="${ORCHESTRATOR_OUT}/runfiles/_main"
   unzip -q "${OT_PROV_ORCHESTRATOR_PATH}" -d "${ORCHESTRATOR_OUT}"
 
   # If OT_PROV_ORCHESTRATOR_UNPACK is set, invoke it with the path to


### PR DESCRIPTION
This updates the reference FT test program to retrieve the CA certs from the SPM during perso to facilitate SKUs (i.e., pi01/2) that require passing the root and ICA certs to the DUT during perso.