### PR TITLE
Update buildver_test.go

### DIFF
--- a/src/version/buildver_test.go
+++ b/src/version/buildver_test.go
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package buildver_tests implements unit tests for the buildver package.
+// Package buildver_test implements unit tests for the buildver package.
 package buildver_test
 
 import (


### PR DESCRIPTION
This is to follow Go's test naming convention. From https://pkg.go.dev/testing:

> The test file can be in the same package as the one being tested, or in a corresponding package with the suffix "_test".