### PR TITLE
Add support for Windows x64 platforms

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -106,6 +106,7 @@ release(
         ":proxybuffer_containers_tar": "ProxyBuffer container",
         ":release_bundle": "Deployment scripts",
         ":softhsm_dev": "SoftHSM2 development binaries",
-        "//src/ate:windows": "ATE Win32 binaries",
+        "//src/ate:windows_win32": "ATE Win32 binaries",
+        "//src/ate:windows_x64": "ATE x64 binaries",
     },
 )

--- a/src/ate/BUILD.bazel
+++ b/src/ate/BUILD.bazel
@@ -115,13 +115,23 @@ cc_binary(
 )
 
 pkg_win(
-    name = "windows",
+    name = "windows_win32",
     srcs = [
         "ate_api.h",
         "ate_perso_blob.h",
         ":ate",
     ],
     platform = "@crt//platforms/x86_32:win32",
+)
+
+pkg_win(
+    name = "windows_x64",
+    srcs = [
+        "ate_api.h",
+        "ate_perso_blob.h",
+        ":ate",
+    ],
+    platform = "@crt//platforms/x86_64:win64",
 )
 
 go_library(

--- a/src/ate/ate_api.h
+++ b/src/ate/ate_api.h
@@ -13,14 +13,28 @@
 #define COMPILE_TIME_ASSERT(condition, msg) \
   typedef char COMPILE_TIME_ASSERT_##msg[(condition) ? 1 : -1]
 
-// types for TP
-typedef unsigned __int8 uint8_t;
-typedef unsigned __int16 uint16_t;
-typedef unsigned __int32 uint32_t;
-typedef unsigned __int64 uint64_t;
-typedef unsigned int size_t;
-#else  // not _WIN32
+// Check for standard definition of fixed-width integer types
+#ifndef UINT8_MAX
+/* Fallback for old compilers which do not provide a standart <stdint.h> header
+ * (pre-C99) */
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+#else
 #include <stdint.h>
+#endif  // UINT8_MAX
+
+// Check for standard definition of 'size_t' type
+#ifndef _SIZE_T_DEFINED
+/* Fallback for old compilers that do not provide a standard <stddef.h> header
+ * (pre-C99) */
+#if defined(_WIN64)
+typedef uint64_t size_t;  // 8 bytes size in 64-platform
+#else
+typedef uint32_t size_t;  // 4 bytes size in 32-platform
+#endif
+#endif  // _SIZE_T_DEFINED
 #endif  // _WIN32
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixed ate_api.h: updated macros to work correctly on both Win32 and x64 platforms.
Build.bazel: changed artifacts to windows_win32 and windows_x64.