### PR TITLE
build: Bump Go version to 1.26.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -117,16 +117,12 @@ register_toolchains("@llvm_toolchain_host//:all")
 # Go Toolchain & Dependencies
 # -------------------------------------------------------------------------
 
-bazel_dep(name = "rules_go", version = "0.52.0", repo_name = "io_bazel_rules_go")
-single_version_override(
-    module_name = "rules_go",
-    version = "0.52.0",
-)
+bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "io_bazel_rules_go")
 
-bazel_dep(name = "gazelle", version = "0.41.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "gazelle", version = "0.47.0", repo_name = "bazel_gazelle")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.24.0")
+go_sdk.download(version = "1.26.0")
 use_repo(go_sdk, "go_default_sdk")
 
 register_toolchains("@go_default_sdk//:all")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/lowRISC/opentitan-provisioning
 
-go 1.24.0
+go 1.26.0
 
 // This file is used to manage dependencies for the OpenTitan Provisioning
 // project. It is used by the Go toolchain to fetch dependencies and their

--- a/src/ate/proto/BUILD
+++ b/src/ate/proto/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/src/pa/proto/BUILD.bazel
+++ b/src/pa/proto/BUILD.bazel
@@ -4,7 +4,7 @@
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -6,7 +6,7 @@
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/proto/crypto/BUILD.bazel
+++ b/src/proto/crypto/BUILD.bazel
@@ -5,7 +5,7 @@
 # OT Provisioning Protobuf Definitions for Cryptographic Primitives
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
This bumps the Go toolchain to version 1.26.0 to leverage native crypto/hpke and crypto/mlkem support. Also upgrades rules_go to 0.54.0 to support the new Go version.