### PR TITLE
Fix rules_docker 403 errors by pulling mirrored binaries via mirror.b…

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -322,14 +322,14 @@ http_file(
     name = "go_puller_linux_amd64",
     executable = True,
     sha256 = "08b8963cce9234f57055bafc7cadd1624cdce3c5990048cea1df453d7d288bc6",
-    urls = ["https://storage.googleapis.com/rules_docker/aad94363e63d31d574cf701df484b3e8b868a96a/puller-linux-amd64"],
+    urls = ["https://mirror.bazel.build/storage.googleapis.com/rules_docker/aad94363e63d31d574cf701df484b3e8b868a96a/puller-linux-amd64"],
 )
 
 http_file(
     name = "loader_linux_amd64",
     executable = True,
     sha256 = "5e5ada66beff07f9188bdc1f99c3fa37c407fc0048cd78b9c2047e9c5516f20b",
-    urls = ["https://storage.googleapis.com/rules_docker/aad94363e63d31d574cf701df484b3e8b868a96a/loader-linux-amd64"],
+    urls = ["https://mirror.bazel.build/storage.googleapis.com/rules_docker/aad94363e63d31d574cf701df484b3e8b868a96a/loader-linux-amd64"],
 )
 
 http_archive(


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_docker/issues/2291 for details