### PR TITLE
build: Bump Go version to 1.27.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,9 +11,9 @@ http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "ht
 # -------------------------------------------------------------------------
 
 bazel_dep(name = "abseil-cpp", version = "20240722.0.bcr.1", repo_name = "com_google_absl")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
-bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")
 bazel_dep(name = "upb", version = "0.0.0-20230907-e7430e6")
 
@@ -27,7 +27,6 @@ bazel_dep(name = "rules_cc", version = "0.1.2")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "aspect_rules_lint", version = "1.0.8")
-
 bazel_dep(name = "rules_foreign_cc", version = "0.9.0")
 single_version_override(
     module_name = "rules_foreign_cc",
@@ -109,7 +108,7 @@ llvm.toolchain(
     name = "llvm_toolchain_lint",
     llvm_versions = {"": "14.0.0"},
 )
-use_repo(llvm, "llvm_toolchain_llvm", "llvm_toolchain_host", "llvm_toolchain_lint")
+use_repo(llvm, "llvm_toolchain_host", "llvm_toolchain_lint", "llvm_toolchain_llvm")
 
 register_toolchains("@llvm_toolchain_host//:all")
 
@@ -117,12 +116,11 @@ register_toolchains("@llvm_toolchain_host//:all")
 # Go Toolchain & Dependencies
 # -------------------------------------------------------------------------
 
-bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "io_bazel_rules_go")
-
-bazel_dep(name = "gazelle", version = "0.47.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", version = "0.63.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.51.3", repo_name = "bazel_gazelle")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.26.0")
+go_sdk.download(version = "1.27.1")
 use_repo(go_sdk, "go_default_sdk")
 
 register_toolchains("@go_default_sdk//:all")
@@ -397,6 +395,7 @@ http_archive(
     strip_prefix = "SoftHSMv2-6319797ff0d11578375965d3a5b2bba7a81e03f0",
     urls = ["https://github.com/opendnssec/SoftHSMv2/archive/6319797ff0d11578375965d3a5b2bba7a81e03f0.tar.gz"],
 )
+
 # Release Tools
 http_archive(
     name = "lowrisc_bazel_release",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -57,7 +57,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/6.1.2/MODULE.bazel": "2ef4962c8b0b6d8d21928a89190755619254459bc67f870dc0ccb9ba9952d444",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/6.4.0/MODULE.bazel": "37389c6b5a40c59410b4226d3bb54b08637f393d66e2fa57925c6fcf68e64bf4",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/6.4.0/source.json": "83eb01b197ed0b392f797860c9da5ed1bf95f4d0ded994d694a3d44731275916",
@@ -80,8 +81,8 @@
     "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
     "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
     "https://bcr.bazel.build/modules/gazelle/0.40.0/MODULE.bazel": "42ba5378ebe845fca43989a53186ab436d956db498acde790685fe0e8f9c6146",
-    "https://bcr.bazel.build/modules/gazelle/0.47.0/MODULE.bazel": "b61bb007c4efad134aa30ee7f4a8e2a39b22aa5685f005edaa022fbd1de43ebc",
-    "https://bcr.bazel.build/modules/gazelle/0.47.0/source.json": "aeb2e5df14b7fb298625d75d08b9c65bdb0b56014c5eb89da9e5dd0572280ae6",
+    "https://bcr.bazel.build/modules/gazelle/0.51.3/MODULE.bazel": "618a729142f66de1e2cb776d026413763be5b80d5e3d29ffb9d3d90c5defde90",
+    "https://bcr.bazel.build/modules/gazelle/0.51.3/source.json": "fbe5312a01fb4a2a58caff4a0d40dcf384b6f0bda75e85546663360da1d7538a",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.4/MODULE.bazel": "c6d54a11dcf64ee63545f42561eda3fd94c1b5f5ebe1357011de63ae33739d5e",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.5/MODULE.bazel": "9ba9b31b984022828a950e3300410977eda2e35df35584c6b0b2d0c2e52766b7",
@@ -124,6 +125,7 @@
     "https://bcr.bazel.build/modules/opentelemetry-proto/1.3.1/source.json": "4ea3f46eb63107e1f1164adc1897bd95bf0fe9673ea632f56cae2f0572eaecc7",
     "https://bcr.bazel.build/modules/opentracing-cpp/1.6.0/MODULE.bazel": "b3925269f63561b8b880ae7cf62ccf81f6ece55b62cd791eda9925147ae116ec",
     "https://bcr.bazel.build/modules/opentracing-cpp/1.6.0/source.json": "da1cb1add160f5e5074b7272e9db6fd8f1b3336c15032cd0a653af9d2f484aed",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.3/MODULE.bazel": "77890552ecea9e284b5424c9de827a58099348763a4359e975c359a83d4faa83",
     "https://bcr.bazel.build/modules/package_metadata/0.0.5/MODULE.bazel": "ef4f9439e3270fdd6b9fd4dbc3d2f29d13888e44c529a1b243f7a31dfbc2e8e4",
     "https://bcr.bazel.build/modules/package_metadata/0.0.5/source.json": "2326db2f6592578177751c3e1f74786b79382cd6008834c9d01ec865b9126a85",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
@@ -135,7 +137,8 @@
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
     "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
-    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
+    "https://bcr.bazel.build/modules/platforms/1.1.0/MODULE.bazel": "1c0c09f5bdcf4b3f924720d2478a3711cb39f4977019ca5988685e5b7e18b3d2",
+    "https://bcr.bazel.build/modules/platforms/1.1.0/source.json": "fcf351c47596c939140ab0d333dfdd08ed1ea6ce33c2fe70c12493a301cf1344",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.2.4/MODULE.bazel": "0fbe5dcff66311947a3f6b86ebc6a6d9328e31a28413ca864debc4a043f371e5",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0/MODULE.bazel": "ce82e086bbc0b60267e970f6a54b2ca6d0f22d3eb6633e00e2cc2899c700f3d8",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0/source.json": "8cb66b4e535afc718e9d104a3db96ccb71a42ee816a100e50fd0d5ac843c0606",
@@ -148,6 +151,7 @@
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
     "https://bcr.bazel.build/modules/protobuf/28.3/MODULE.bazel": "2b3764bbab2e46703412bd3b859efcf0322638ed015e88432df3bb740507a1e9",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2.bcr.1/MODULE.bazel": "52f4126f63a2f0bbf36b99c2a87648f08467a4eaf92ba726bc7d6a500bbf770c",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
     "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
@@ -201,9 +205,9 @@
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
     "https://bcr.bazel.build/modules/rules_go/0.48.0/MODULE.bazel": "d00ebcae0908ee3f5e6d53f68677a303d6d59a77beef879598700049c3980a03",
     "https://bcr.bazel.build/modules/rules_go/0.50.1/MODULE.bazel": "b91a308dc5782bb0a8021ad4330c81fea5bda77f96b9e4c117b9b9c8f6665ee0",
-    "https://bcr.bazel.build/modules/rules_go/0.53.0/MODULE.bazel": "a4ed760d3ac0dbc0d7b967631a9a3fd9100d28f7d9fcf214b4df87d4bfff5f9a",
-    "https://bcr.bazel.build/modules/rules_go/0.60.0/MODULE.bazel": "4a57ff2ffc2a3570e3c5646575c5a4b07287e91bcdac5d1f72383d51502b48cb",
-    "https://bcr.bazel.build/modules/rules_go/0.60.0/source.json": "1e21368c5e0c3013a110bd79a8fcff8ca46b5bcb2b561713a7273cbfcff7c464",
+    "https://bcr.bazel.build/modules/rules_go/0.59.0/MODULE.bazel": "b7e43e7414a3139a7547d1b4909b29085fbe5182b6c58cbe1ed4c6272815aeae",
+    "https://bcr.bazel.build/modules/rules_go/0.63.0/MODULE.bazel": "a2079e783a5d2715a90e6e2970ec8ffd717a487ff2aecb5f553e3975c5294a21",
+    "https://bcr.bazel.build/modules/rules_go/0.63.0/source.json": "5bf37b45c440ac03abad0cbfa8b8b8dd89cc4e82bc8305f468b8436fa58bae78",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.1.0/MODULE.bazel": "324b6478b0343a3ce7a9add8586ad75d24076d6d43d2f622990b9c1cfd8a1b15",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
@@ -297,6 +301,22 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "//rules:vendor.bzl%vendor_deps": {
+      "general": {
+        "bzlTransitiveDigest": "y8ZLAJk8ue+VB5O60QJmxmAk3ZuHPD27oJNpcwNf4ug=",
+        "usagesDigest": "nCjnircLxt69SkiPTrkuYvFJlMOg1zU2KUZt9zNODrk=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "vendor_repo": {
+            "repoRuleId": "@@//rules:vendor.bzl%vendor_repo",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "//third_party/docker:extensions.bzl%docker_extension": {
       "general": {
         "bzlTransitiveDigest": "65s8nCWiVdC8hL51zcW+UvRrSeBhbDCq7pJq5WVVSbo=",
@@ -7993,7 +8013,7 @@
     },
     "@@rules_rust+//crate_universe:extension.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "G1LF8CZyeom3UMkJpy8InWfbYgFdiQN8v8Ir1gyjQHA=",
+        "bzlTransitiveDigest": "ONhEU2e5wTMASEogwupFXyWkQ1YqEANiat/3CAabnL4=",
         "usagesDigest": "rSBMaWTSO0xjQGq63YDTbXuIxeEaHS9VHk6PtlwehAs=",
         "recordedFileInputs": {
           "@@+_repo_rules+lowrisc_opentitan_head//third_party/rust/Cargo.lock": "e6d3f308be12a5d2b3263ec1b3842752f3b61be381ea4cb9c71c140aff8389e1",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/lowRISC/opentitan-provisioning
 
-go 1.26.0
+go 1.27.1
 
 // This file is used to manage dependencies for the OpenTitan Provisioning
 // project. It is used by the Go toolchain to fetch dependencies and their

--- a/src/spm/services/spm.go
+++ b/src/spm/services/spm.go
@@ -576,6 +576,10 @@ func (s *server) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequ
 				},
 			})
 		case *pbc.SigningKeyParams_MldsaParams:
+			rootCertMldsa, ok := sku.Certs["RootCAMldsa"]
+			if !ok {
+				rootCertMldsa = rootCert
+			}
 			params := se.EndorseCertParams{
 				KeyLabel: keyLabel,
 				MldsaAlgorithm: &se.MldsaParams{
@@ -585,7 +589,7 @@ func (s *server) EndorseCerts(ctx context.Context, request *pbp.EndorseCertsRequ
 					caCert,
 				},
 				Roots: []*x509.Certificate{
-					rootCert,
+					rootCertMldsa,
 				},
 			}
 			cert, err := sku.SeHandle.EndorseCert(bundle.Tbs, params)
@@ -699,6 +703,9 @@ func (s *server) VerifyDeviceData(ctx context.Context, request *pbs.VerifyDevice
 	}
 	roots := x509.NewCertPool()
 	roots.AddCert(rootCert)
+	if rootMldsaCert, ok := sku.Certs["RootCAMldsa"]; ok {
+		roots.AddCert(rootMldsaCert)
+	}
 
 	udsICA, ok := sku.Certs["SigningKey/Dice/v0"]
 	if !ok {
@@ -716,6 +723,9 @@ func (s *server) VerifyDeviceData(ctx context.Context, request *pbs.VerifyDevice
 	extICA, ok := sku.Certs["SigningKey/Ext/v0"]
 	if ok {
 		extIntermediates.AddCert(extICA)
+	}
+	if extMldsaICA, ok := sku.Certs["SigningKey/Ext/Mldsa/v0"]; ok {
+		extIntermediates.AddCert(extMldsaICA)
 	}
 
 	certChainDiceLeaf, err := sku.Config.GetUnsafeAttribute(skucfg.AttrNameCertChainDiceLeaf)

--- a/src/spm/services/testutils/tbsgen/main.go
+++ b/src/spm/services/testutils/tbsgen/main.go
@@ -47,7 +47,7 @@ func generateTBS() {
 	caCertPath := f.String("ca-cert", "", "Path to the CA certificate (optional, PEM or DER)")
 	output := f.String("output", "", "Path to output the TBS DER file")
 	days := f.Int("days", 7300, "Number of days the certificate is valid for. Use -1 for no expiry.")
-	
+
 	f.Parse(os.Args[2:])
 
 	if *csrPath == "" || *output == "" {
@@ -87,15 +87,8 @@ func generateTBS() {
 	// We can detect it from the CSR public key OID or just always try to patch if it matches.
 	// The current tbsgen library only patches if isMldsa is true.
 	// Let's add a flag or detect it.
-	
-	// MLDSA-87 OID: 2.16.840.1.101.3.4.3.19
-	isMldsa := false
-	if csr.PublicKeyAlgorithm == x509.UnknownPublicKeyAlgorithm {
-		// x509.ParseCertificateRequest might set Unknown for OIDs it doesn't know.
-		// We should check the raw OID if possible, but for now let's just use a flag
-		// or check if the signer is MLDSA in the script.
-		isMldsa = true // Default to true if unknown, as this tool is mainly for MLDSA.
-	}
+
+	isMldsa := csr.PublicKeyAlgorithm == x509.MLDSA
 
 	tbsDER, err := tbsgen.GenerateTBS(csr, caCert, *days, isMldsa)
 	if err != nil {


### PR DESCRIPTION
Bump Go toolchain and go.mod to Go 1.27.1.
Upgrade rules_go to 0.63.0 and gazelle to 0.51.3 to natively support Go 1.27's response file format for cgo ldflags.